### PR TITLE
Fix Copilot LSP sign-in: handle server→client signIn request for device code

### DIFF
--- a/src-tauri/src/commands/copilot_lsp.rs
+++ b/src-tauri/src/commands/copilot_lsp.rs
@@ -337,10 +337,80 @@ async fn handle_server_request(
     id: &Value,
     params: Option<&Value>,
     writer: &Arc<Mutex<BufWriter<ChildStdin>>>,
-    _next_id: &Arc<AtomicU64>,
+    next_id: &Arc<AtomicU64>,
     app: &AppHandle,
 ) {
     let response_result = match method {
+        "signIn" => {
+            // Server→client request: OAuth device flow sign-in data.
+            // The Copilot LSP sends this after sign-in is initiated, containing
+            // the device code the user must enter on GitHub.
+            if let Some(params) = params {
+                let user_code = params
+                    .get("userCode")
+                    .and_then(|v| v.as_str())
+                    .or_else(|| params.get("user_code").and_then(|v| v.as_str()))
+                    .unwrap_or("")
+                    .to_string();
+                let verification_uri = params
+                    .get("verificationUri")
+                    .and_then(|v| v.as_str())
+                    .or_else(|| params.get("verification_uri").and_then(|v| v.as_str()))
+                    .unwrap_or("https://github.com/login/device")
+                    .to_string();
+
+                eprintln!(
+                    "[copilot-lsp] signIn server request: userCode={}, verificationUri={}",
+                    user_code, verification_uri
+                );
+
+                // Emit device code to frontend
+                if !user_code.is_empty() {
+                    let _ = app.emit(
+                        "copilot-auth-device-code",
+                        serde_json::json!({
+                            "userCode": user_code,
+                            "verificationUri": verification_uri,
+                        }),
+                    );
+                }
+
+                // Execute the embedded command to finish the device flow
+                // (tells the LSP to start polling GitHub for OAuth completion)
+                if let Some(command) = params.get("command") {
+                    let cmd_name = command
+                        .get("command")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("");
+                    let cmd_args = command
+                        .get("arguments")
+                        .cloned()
+                        .unwrap_or(Value::Array(vec![]));
+
+                    if !cmd_name.is_empty() {
+                        let exec_id = next_id.fetch_add(1, Ordering::SeqCst);
+                        let exec_req = serde_json::json!({
+                            "jsonrpc": "2.0",
+                            "id": exec_id,
+                            "method": "workspace/executeCommand",
+                            "params": {
+                                "command": cmd_name,
+                                "arguments": cmd_args,
+                            },
+                        });
+                        if let Ok(json) = serde_json::to_string(&exec_req) {
+                            let header = format!("Content-Length: {}\r\n\r\n", json.len());
+                            let mut w = writer.lock().await;
+                            let _ = w.write_all(header.as_bytes()).await;
+                            let _ = w.write_all(json.as_bytes()).await;
+                            let _ = w.flush().await;
+                        }
+                    }
+                }
+            }
+            serde_json::json!({})
+        }
+
         "window/showDocument" => {
             // LSP wants to open a URL (e.g., GitHub login page during auth)
             if let Some(params) = params {
@@ -854,9 +924,16 @@ pub async fn copilot_lsp_status(
 
 /// Sign in to GitHub Copilot via OAuth device flow.
 ///
-/// Sends the `signIn` request to the LSP, which returns a device code.
-/// The LSP then opens a browser via `window/showDocument` (handled by the
-/// reader loop). Auth completion is signalled asynchronously via
+/// Two-phase approach:
+/// 1. Try the direct `signIn` JSON-RPC method — works with older LSP versions
+///    that return `{ userCode, verificationUri, command }` directly.
+/// 2. If step 1 returns an empty device code, fall back to executing the
+///    `github.copilot.signInInitiate` workspace command. In this case the LSP
+///    sends the device code asynchronously via a server→client `signIn` request,
+///    which is handled in `handle_server_request` and emitted as the
+///    `copilot-auth-device-code` Tauri event.
+///
+/// Auth completion is signalled asynchronously via
 /// `didChangeStatus` → `copilot-status-changed` Tauri event.
 #[tauri::command]
 pub async fn copilot_lsp_sign_in(
@@ -868,7 +945,7 @@ pub async fn copilot_lsp_sign_in(
         .as_ref()
         .ok_or("Copilot LSP not running. Call copilot_lsp_start first.")?;
 
-    // Send signIn request — returns { userCode, command } or { user_code, verification_uri }
+    // --- Phase 1: Try direct signIn RPC ---
     let result = process
         .transport
         .send_request("signIn", Some(serde_json::json!({})))
@@ -899,59 +976,76 @@ pub async fn copilot_lsp_sign_in(
             eprintln!("[copilot-lsp] Extracted user_code from URI: {}", code);
             code
         } else {
-            eprintln!("[copilot-lsp] WARNING: Could not extract user_code from signIn response");
-            let _ = app.emit(
-                "copilot-sign-in-error",
-                serde_json::json!({
-                    "message": "Sign-in returned empty device code. The LSP response format may have changed.",
-                    "response": result.to_string(),
-                }),
-            );
             String::new()
         }
     } else {
         user_code
     };
 
-    // Extract the command to execute (triggers browser opening)
-    if let Some(command) = result.get("command") {
-        let cmd_name = command
-            .get("command")
-            .and_then(|v| v.as_str())
-            .unwrap_or("");
-        let cmd_args = command
-            .get("arguments")
-            .cloned()
-            .unwrap_or(Value::Array(vec![]));
+    if !user_code.is_empty() {
+        // Phase 1 succeeded — we have a device code from the direct response.
+        // Execute the embedded command to trigger the device flow.
+        if let Some(command) = result.get("command") {
+            let cmd_name = command
+                .get("command")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let cmd_args = command
+                .get("arguments")
+                .cloned()
+                .unwrap_or(Value::Array(vec![]));
 
-        if !cmd_name.is_empty() {
-            // Execute the command via workspace/executeCommand
-            // This tells the LSP to proceed with the device flow
-            let _ = process
-                .transport
-                .send_request(
-                    "workspace/executeCommand",
-                    Some(serde_json::json!({
-                        "command": cmd_name,
-                        "arguments": cmd_args,
-                    })),
-                )
-                .await;
+            if !cmd_name.is_empty() {
+                let _ = process
+                    .transport
+                    .send_request(
+                        "workspace/executeCommand",
+                        Some(serde_json::json!({
+                            "command": cmd_name,
+                            "arguments": cmd_args,
+                        })),
+                    )
+                    .await;
+            }
         }
+
+        let _ = app.emit(
+            "copilot-auth-device-code",
+            serde_json::json!({
+                "userCode": user_code,
+                "verificationUri": verification_uri,
+            }),
+        );
+
+        return Ok(SignInResponse {
+            user_code,
+            verification_uri,
+        });
     }
 
-    // Emit device code event for the frontend
-    let _ = app.emit(
-        "copilot-auth-device-code",
-        serde_json::json!({
-            "userCode": user_code,
-            "verificationUri": verification_uri,
-        }),
-    );
+    // --- Phase 2: Fallback — initiate sign-in via workspace command ---
+    // Newer Copilot LSP versions return the device code asynchronously via
+    // a server→client `signIn` request (handled in handle_server_request)
+    // rather than in the direct signIn response.
+    eprintln!("[copilot-lsp] signIn returned empty device code, falling back to signInInitiate command");
 
+    let _ = process
+        .transport
+        .send_request(
+            "workspace/executeCommand",
+            Some(serde_json::json!({
+                "command": "github.copilot.signInInitiate",
+                "arguments": [],
+            })),
+        )
+        .await;
+
+    // The device code will arrive asynchronously via the server→client
+    // `signIn` request → handle_server_request → copilot-auth-device-code event.
+    // Return empty response; frontend will use the event.
     Ok(SignInResponse {
-        user_code,
-        verification_uri,
+        user_code: String::new(),
+        verification_uri: "https://github.com/login/device".to_string(),
     })
 }
 

--- a/src/components/settings/ConnectionsSettings.tsx
+++ b/src/components/settings/ConnectionsSettings.tsx
@@ -433,7 +433,9 @@ function ConnectCopilotLsp({
   const [deviceCode, setDeviceCode] = useState<string | null>(null);
   const [retryCount, setRetryCount] = useState(0);
   const [retrying, setRetrying] = useState(false);
+  const [copied, setCopied] = useState(false);
   const isRetryRef = useRef(false);
+  const deviceCodeReceivedRef = useRef(false);
   const onConnectedRef = useRef(onConnected);
   onConnectedRef.current = onConnected;
 
@@ -476,9 +478,27 @@ function ConnectCopilotLsp({
       }
     );
 
+    // Listen for device code from server→client signIn request (fallback path).
+    // When the direct signIn RPC returns an empty code, the LSP sends the
+    // device code asynchronously via a server→client request handled in Rust.
+    deviceCodeReceivedRef.current = false;
+    const unlistenDeviceCode = listen<{ userCode: string; verificationUri: string }>(
+      'copilot-auth-device-code',
+      (event) => {
+        const { userCode } = event.payload;
+        console.log('[copilot-lsp-ui] device code received via event:', userCode);
+        if (userCode && !authCompleted.current) {
+          deviceCodeReceivedRef.current = true;
+          setDeviceCode(userCode);
+          setPhase('device_code');
+        }
+      }
+    );
+
     return () => {
       unlistenStatus.then((fn) => fn());
       unlistenError.then((fn) => fn());
+      unlistenDeviceCode.then((fn) => fn());
     };
   }, [completeAuth, retryCount]);
 
@@ -565,14 +585,20 @@ function ConnectCopilotLsp({
         if (!active) return;
 
         if (!result.user_code) {
-          // Empty user code may mean already authenticated
-          console.log('[copilot-lsp-ui] Empty user_code — may be already authenticated');
+          // Empty user code from direct signIn RPC — the fallback path
+          // (workspace/executeCommand with signInInitiate) was triggered.
+          // The device code will arrive via copilot-auth-device-code event
+          // from the server→client signIn request handler.
+          console.log('[copilot-lsp-ui] Empty user_code from signIn — waiting for device code event or auth completion');
           if (!authCompleted.current) {
-            // Give the status event a moment to arrive
-            await new Promise((r) => setTimeout(r, 1000));
-            if (authCompleted.current) return;
-            // Still not authenticated — show error
-            setError('Sign-in returned empty device code. You may already be authenticated — try removing and re-adding the connection.');
+            // Wait up to 10 seconds for either the device code event or auth completion
+            for (let i = 0; i < 20; i++) {
+              await new Promise((r) => setTimeout(r, 500));
+              if (!active || authCompleted.current || deviceCodeReceivedRef.current) return;
+            }
+            if (!active) return;
+            // Still nothing — show error
+            setError('Sign-in timed out waiting for device code. You may already be authenticated — try removing and re-adding the connection.');
             setPhase('error');
           }
           return;
@@ -606,7 +632,13 @@ function ConnectCopilotLsp({
 
   const handleCopyCode = useCallback(() => {
     if (deviceCode) {
-      navigator.clipboard.writeText(deviceCode).catch(() => {});
+      navigator.clipboard.writeText(deviceCode).then(
+        () => {
+          setCopied(true);
+          setTimeout(() => setCopied(false), 2000);
+        },
+        () => {}
+      );
     }
   }, [deviceCode]);
 
@@ -663,15 +695,24 @@ function ConnectCopilotLsp({
             <p className="text-xs text-muted-foreground mb-2">
               Enter this code on GitHub:
             </p>
-            <button
-              onClick={handleCopyCode}
-              className="text-2xl font-mono font-bold tracking-widest cursor-pointer hover:opacity-70 transition-opacity"
-              title="Click to copy"
-            >
-              {deviceCode}
-            </button>
+            <div className="flex items-center justify-center gap-2">
+              <span className="text-2xl font-mono font-bold tracking-widest">
+                {deviceCode}
+              </span>
+              <button
+                onClick={handleCopyCode}
+                className="p-1 rounded hover:bg-muted transition-colors"
+                title="Copy code"
+              >
+                {copied ? (
+                  <Check className="h-4 w-4 text-green-500" strokeWidth={2} />
+                ) : (
+                  <Copy className="h-4 w-4 text-muted-foreground" strokeWidth={1.5} />
+                )}
+              </button>
+            </div>
             <p className="text-xs text-muted-foreground mt-2">
-              Click code to copy
+              {copied ? 'Copied!' : 'Click icon to copy'}
             </p>
           </div>
           <div className="flex gap-2">

--- a/src/components/settings/ConnectionsSettings.tsx
+++ b/src/components/settings/ConnectionsSettings.tsx
@@ -468,16 +468,6 @@ function ConnectCopilotLsp({
       }
     );
 
-    // Listen for sign-in errors from the backend
-    const unlistenError = listen<{ message: string; response?: string }>(
-      'copilot-sign-in-error',
-      (event) => {
-        console.error('[copilot-lsp-ui] sign-in error:', event.payload);
-        setError(event.payload.message);
-        setPhase('error');
-      }
-    );
-
     // Listen for device code from server→client signIn request (fallback path).
     // When the direct signIn RPC returns an empty code, the LSP sends the
     // device code asynchronously via a server→client request handled in Rust.
@@ -497,7 +487,6 @@ function ConnectCopilotLsp({
 
     return () => {
       unlistenStatus.then((fn) => fn());
-      unlistenError.then((fn) => fn());
       unlistenDeviceCode.then((fn) => fn());
     };
   }, [completeAuth, retryCount]);
@@ -705,7 +694,7 @@ function ConnectCopilotLsp({
                 title="Copy code"
               >
                 {copied ? (
-                  <Check className="h-4 w-4 text-green-500" strokeWidth={2} />
+                  <Check className="h-4 w-4 text-foreground" strokeWidth={2} />
                 ) : (
                   <Copy className="h-4 w-4 text-muted-foreground" strokeWidth={1.5} />
                 )}


### PR DESCRIPTION
The Copilot LSP sign-in flow was broken because newer LSP versions send the
device code via a server→client `signIn` request rather than in the response
to the direct `signIn` RPC method. This request was falling through to the
unhandled default case in the reader loop, losing the 8-digit device code.

Changes:
- Add `signIn` handler in `handle_server_request` to catch the server→client
  request, extract the device code, emit it to the frontend, and execute the
  embedded command to finish the OAuth device flow
- Add fallback in `copilot_lsp_sign_in`: if direct `signIn` RPC returns an
  empty device code, initiate via `workspace/executeCommand` with
  `github.copilot.signInInitiate` (matching the approach used by other LSP
  clients like the copilot-lsp Neovim plugin)
- Add `copilot-auth-device-code` event listener in ConnectCopilotLsp so the
  frontend receives the device code from either the direct response or the
  async server→client request
- Improve copy-to-clipboard UX: show Copy icon that toggles to a checkmark
  after copying the device code

https://claude.ai/code/session_013PUQqkpSjiezhhTS5ELjiM