### PR TITLE
Add configurable debug logging and fix Copilot LSP issues

### DIFF
--- a/src-tauri/src/commands/copilot_lsp.rs
+++ b/src-tauri/src/commands/copilot_lsp.rs
@@ -346,7 +346,7 @@ async fn handle_server_request(
             // The Copilot LSP sends this after sign-in is initiated, containing
             // the device code the user must enter on GitHub.
             if let Some(params) = params {
-                eprintln!(
+                debug_log!(
                     "[copilot-lsp] signIn server→client request received, raw params: {}",
                     params
                 );
@@ -364,7 +364,7 @@ async fn handle_server_request(
                     .unwrap_or("https://github.com/login/device")
                     .to_string();
 
-                eprintln!(
+                debug_log!(
                     "[copilot-lsp] signIn server request: userCode={}, verificationUri={}",
                     user_code, verification_uri
                 );
@@ -436,7 +436,7 @@ async fn handle_server_request(
             // Log it and return null (no action selected).
             if let Some(params) = params {
                 if let Some(message) = params.get("message").and_then(|v| v.as_str()) {
-                    eprintln!("[copilot-lsp] showMessageRequest: {}", message);
+                    debug_log!("[copilot-lsp] showMessageRequest: {}", message);
                 }
             }
             Value::Null
@@ -469,7 +469,7 @@ async fn handle_server_request(
         }
 
         _ => {
-            eprintln!("[copilot-lsp] Unhandled server request: {}", method);
+            debug_log!("[copilot-lsp] Unhandled server request: {}", method);
             Value::Null
         }
     };
@@ -530,14 +530,14 @@ async fn handle_server_notification(method: &str, params: Option<&Value>, app: &
                     3 => "INFO",
                     _ => "LOG",
                 };
-                eprintln!("[copilot-lsp] [{}] {}", level, message);
+                debug_log!("[copilot-lsp] [{}] {}", level, message);
             }
         }
 
         "window/showMessage" => {
             if let Some(params) = params {
                 if let Some(message) = params.get("message").and_then(|v| v.as_str()) {
-                    eprintln!("[copilot-lsp] showMessage: {}", message);
+                    debug_log!("[copilot-lsp] showMessage: {}", message);
                 }
             }
         }
@@ -929,7 +929,7 @@ pub async fn copilot_lsp_status(
 
 /// Sign in to GitHub Copilot via OAuth device flow.
 ///
-/// Two-phase approach:
+/// Three-phase approach:
 /// 1. Try the direct `signIn` JSON-RPC method — works with older LSP versions
 ///    that return `{ userCode, verificationUri, command }` directly.
 /// 2. If step 1 fails or returns an empty device code, fall back to executing
@@ -957,20 +957,20 @@ pub async fn copilot_lsp_sign_in(
     // --- Phase 1: Try direct signIn RPC ---
     // Some older LSP versions support `signIn` as a client→server method.
     // Use `match` instead of `?` so we can fall through to Phase 2 on error.
-    eprintln!("[copilot-lsp] Phase 1: Sending signIn RPC...");
+    debug_log!("[copilot-lsp] Phase 1: Sending signIn RPC...");
     match process
         .transport
         .send_request("signIn", Some(serde_json::json!({})))
         .await
     {
         Ok(result) => {
-            eprintln!("[copilot-lsp] Phase 1 signIn response: {}", result);
+            debug_log!("[copilot-lsp] Phase 1 signIn response: {}", result);
 
             let user_code = extract_user_code_from_result(&result);
             let verification_uri = extract_verification_uri(&result);
 
             if !user_code.is_empty() {
-                eprintln!(
+                debug_log!(
                     "[copilot-lsp] Phase 1 succeeded — userCode={}, verificationUri={}",
                     user_code, verification_uri
                 );
@@ -992,11 +992,11 @@ pub async fn copilot_lsp_sign_in(
                 });
             }
 
-            eprintln!("[copilot-lsp] Phase 1: signIn returned no device code, falling to Phase 2");
+            debug_log!("[copilot-lsp] Phase 1: signIn returned no device code, falling to Phase 2");
         }
         Err(e) => {
             // signIn might not be supported — fall through to Phase 2
-            eprintln!(
+            debug_log!(
                 "[copilot-lsp] Phase 1: signIn RPC failed (non-fatal, falling to Phase 2): {}",
                 e
             );
@@ -1006,7 +1006,7 @@ pub async fn copilot_lsp_sign_in(
     // --- Phase 2: signInInitiate workspace command (official flow) ---
     // Per the Copilot LSP docs, `signInInitiate` returns `{ userCode, command }`
     // in the response. We must extract it and execute the embedded command.
-    eprintln!("[copilot-lsp] Phase 2: Sending workspace/executeCommand(signInInitiate)...");
+    debug_log!("[copilot-lsp] Phase 2: Sending workspace/executeCommand(signInInitiate)...");
 
     match process
         .transport
@@ -1020,13 +1020,13 @@ pub async fn copilot_lsp_sign_in(
         .await
     {
         Ok(result) => {
-            eprintln!("[copilot-lsp] Phase 2 signInInitiate response: {}", result);
+            debug_log!("[copilot-lsp] Phase 2 signInInitiate response: {}", result);
 
             let user_code = extract_user_code_from_result(&result);
             let verification_uri = extract_verification_uri(&result);
 
             if !user_code.is_empty() {
-                eprintln!(
+                debug_log!(
                     "[copilot-lsp] Phase 2 succeeded — userCode={}, verificationUri={}",
                     user_code, verification_uri
                 );
@@ -1049,12 +1049,12 @@ pub async fn copilot_lsp_sign_in(
                 });
             }
 
-            eprintln!(
+            debug_log!(
                 "[copilot-lsp] Phase 2: signInInitiate returned no device code in response"
             );
         }
         Err(e) => {
-            eprintln!("[copilot-lsp] Phase 2: signInInitiate command failed: {}", e);
+            debug_log!("[copilot-lsp] Phase 2: signInInitiate command failed: {}", e);
         }
     }
 
@@ -1062,7 +1062,7 @@ pub async fn copilot_lsp_sign_in(
     // Neither phase returned a device code in the response. The LSP may send
     // the code asynchronously via a server→client `signIn` request, which is
     // handled in `handle_server_request` and emitted as `copilot-auth-device-code`.
-    eprintln!(
+    debug_log!(
         "[copilot-lsp] Both phases returned no device code — waiting for server→client signIn request"
     );
 
@@ -1122,7 +1122,7 @@ fn extract_user_code_from_result(result: &Value) -> String {
         .or_else(|| result.get("verification_uri").and_then(|v| v.as_str()))
         .unwrap_or("");
     if let Some(code) = extract_code_from_uri(verification_uri) {
-        eprintln!("[copilot-lsp] Extracted user_code from URI: {}", code);
+        debug_log!("[copilot-lsp] Extracted user_code from URI: {}", code);
         return code;
     }
 
@@ -1154,11 +1154,11 @@ async fn execute_embedded_command(process: &CopilotLspProcess, result: &Value) {
             .unwrap_or(Value::Array(vec![]));
 
         if !cmd_name.is_empty() {
-            eprintln!(
+            debug_log!(
                 "[copilot-lsp] Executing embedded command: {} with args: {}",
                 cmd_name, cmd_args
             );
-            let _ = process
+            if let Err(e) = process
                 .transport
                 .send_request(
                     "workspace/executeCommand",
@@ -1167,7 +1167,10 @@ async fn execute_embedded_command(process: &CopilotLspProcess, result: &Value) {
                         "arguments": cmd_args,
                     })),
                 )
-                .await;
+                .await
+            {
+                eprintln!("[copilot-lsp] Failed to execute embedded command '{}': {}", cmd_name, e);
+            }
         }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,18 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
+pub static DEBUG_LOGGING: AtomicBool = AtomicBool::new(false);
+
+/// Conditional debug logging macro. Only prints when DEBUG_LOGGING is enabled.
+/// Use for diagnostic messages; keep genuine errors as `eprintln!`.
+#[macro_export]
+macro_rules! debug_log {
+    ($($arg:tt)*) => {
+        if $crate::DEBUG_LOGGING.load(std::sync::atomic::Ordering::Relaxed) {
+            eprintln!($($arg)*);
+        }
+    };
+}
+
 mod commands;
 mod export;
 
@@ -7,6 +22,11 @@ use tauri::{Manager, RunEvent};
 #[tauri::command]
 fn open_devtools(webview_window: tauri::WebviewWindow) {
     webview_window.open_devtools();
+}
+
+#[tauri::command]
+fn set_debug_logging(enabled: bool) {
+    DEBUG_LOGGING.store(enabled, Ordering::Relaxed);
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -24,6 +44,7 @@ pub fn run() {
         .manage(CopilotLspState::new())
         .invoke_handler(tauri::generate_handler![
             open_devtools,
+            set_debug_logging,
             read_file,
             read_binary_file,
             write_file,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -187,6 +187,14 @@ function App() {
     migrateV1AISettings();
   }, []);
 
+  // Sync debug logging setting to Rust backend on startup
+  useEffect(() => {
+    const { debugLogging } = useSettingsStore.getState();
+    if (debugLogging) {
+      tauriApi.setDebugLogging(true);
+    }
+  }, []);
+
   // Stop ACP agent processes on window close (supplementary to Rust exit hook)
   useEffect(() => {
     const handleBeforeUnload = () => {

--- a/src/components/settings/ConnectionsSettings.tsx
+++ b/src/components/settings/ConnectionsSettings.tsx
@@ -25,6 +25,7 @@ import { ProviderLogo } from '@/components/ProviderLogo';
 import type { Connection, ProviderOption } from '@/lib/ai/connections';
 import { PROVIDER_OPTIONS, CAPABILITY_LABELS } from '@/lib/ai/connections';
 import { invoke } from '@tauri-apps/api/core';
+import { debugLog } from '@/lib/debug';
 
 const COPILOT_PATH = "M7.998 15.035c-4.562 0-7.873-2.914-7.998-3.749V9.338c.085-.628.677-1.686 1.588-2.065.013-.07.024-.143.036-.218.029-.183.06-.384.126-.612-.201-.508-.254-1.084-.254-1.656 0-.87.128-1.769.693-2.484.579-.733 1.494-1.124 2.724-1.261 1.206-.134 2.262.034 2.944.765.05.053.096.108.139.165.044-.057.094-.112.143-.165.682-.731 1.738-.899 2.944-.765 1.23.137 2.145.528 2.724 1.261.566.715.693 1.614.693 2.484 0 .572-.053 1.148-.254 1.656.066.228.098.429.126.612.012.076.024.148.037.218.924.385 1.522 1.471 1.591 2.095v1.872c0 .766-3.351 3.795-8.002 3.795Zm0-1.485c2.28 0 4.584-1.11 5.002-1.433V7.862l-.023-.116c-.49.21-1.075.291-1.727.291-1.146 0-2.059-.327-2.71-.991A3.222 3.222 0 0 1 8 6.303a3.24 3.24 0 0 1-.544.743c-.65.664-1.563.991-2.71.991-.652 0-1.236-.081-1.727-.291l-.023.116v4.255c.419.323 2.722 1.433 5.002 1.433ZM6.762 2.83c-.193-.206-.637-.413-1.682-.297-1.019.113-1.479.404-1.713.7-.247.312-.369.789-.369 1.554 0 .793.129 1.171.308 1.371.162.181.519.379 1.442.379.853 0 1.339-.235 1.638-.54.315-.322.527-.827.617-1.553.117-.935-.037-1.395-.241-1.614Zm4.155-.297c-1.044-.116-1.488.091-1.681.297-.204.219-.359.679-.242 1.614.091.726.303 1.231.618 1.553.299.305.784.54 1.638.54.922 0 1.28-.198 1.442-.379.179-.2.308-.578.308-1.371 0-.765-.123-1.242-.37-1.554-.233-.296-.693-.587-1.713-.7Z";
 const COPILOT_EYES = "M6.25 9.037a.75.75 0 0 1 .75.75v1.501a.75.75 0 0 1-1.5 0V9.787a.75.75 0 0 1 .75-.75Zm4.25.75v1.501a.75.75 0 0 1-1.5 0V9.787a.75.75 0 0 1 1.5 0Z";
@@ -450,7 +451,7 @@ function ConnectCopilotLsp({
   const completeAuth = useCallback(() => {
     if (authCompleted.current) return; // already fired
     authCompleted.current = true;
-    console.log('[copilot-lsp-ui] Auth succeeded, completing connection (once)');
+    debugLog('[copilot-lsp-ui] Auth succeeded, completing connection (once)');
     setPhase('connected');
     // Don't stop the LSP here — useCopilotCompletion will restart it with
     // the correct working directory. Stopping here races with the hook's start.
@@ -464,7 +465,7 @@ function ConnectCopilotLsp({
       'copilot-status-changed',
       (event) => {
         const { message, kind } = event.payload;
-        console.log('[copilot-lsp-ui] status changed:', kind, message);
+        debugLog('[copilot-lsp-ui] status changed:', kind, message);
         if (kind === 'Normal') {
           completeAuth();
         }
@@ -479,7 +480,7 @@ function ConnectCopilotLsp({
       'copilot-auth-device-code',
       (event) => {
         const { userCode } = event.payload;
-        console.log('[copilot-lsp-ui] device code received via event:', userCode);
+        debugLog('[copilot-lsp-ui] device code received via event:', userCode);
         if (userCode && !authCompleted.current) {
           deviceCodeReceivedRef.current = true;
           setDeviceCode(userCode);
@@ -515,13 +516,13 @@ function ConnectCopilotLsp({
       setError(null);
 
       try {
-        console.log('[copilot-lsp-ui] Checking binary availability...');
+        debugLog('[copilot-lsp-ui] Checking binary availability...');
         const available = await withTimeout(
           invoke<boolean>('copilot_lsp_check_availability'),
           CONNECTION_TIMEOUT_MS,
           'Availability check',
         );
-        console.log('[copilot-lsp-ui] Binary available:', available);
+        debugLog('[copilot-lsp-ui] Binary available:', available);
         if (!active) return;
 
         await endRetry();
@@ -533,28 +534,28 @@ function ConnectCopilotLsp({
         // Binary found — start LSP and sign in
         setPhase('signing_in');
 
-        console.log('[copilot-lsp-ui] Starting LSP...');
+        debugLog('[copilot-lsp-ui] Starting LSP...');
         await withTimeout(
           invoke('copilot_lsp_start', { workingDirectory: '/tmp' }),
           CONNECTION_TIMEOUT_MS,
           'Starting Copilot',
         );
-        console.log('[copilot-lsp-ui] LSP started');
+        debugLog('[copilot-lsp-ui] LSP started');
         if (!active) return;
 
         // Check if already authenticated (status event arrived during init)
         if (authCompleted.current) {
-          console.log('[copilot-lsp-ui] Already authenticated during LSP init, skipping signIn');
+          debugLog('[copilot-lsp-ui] Already authenticated during LSP init, skipping signIn');
           return;
         }
 
         // Check status before attempting sign-in
-        console.log('[copilot-lsp-ui] Checking LSP status...');
+        debugLog('[copilot-lsp-ui] Checking LSP status...');
         try {
           const status = await invoke<{ authenticated: boolean; message: string; kind: string }>(
             'copilot_lsp_status'
           );
-          console.log('[copilot-lsp-ui] LSP status:', JSON.stringify(status));
+          debugLog('[copilot-lsp-ui] LSP status:', JSON.stringify(status));
           if (!active) return;
 
           if (status.authenticated) {
@@ -562,10 +563,10 @@ function ConnectCopilotLsp({
             return;
           }
         } catch (statusErr) {
-          console.log('[copilot-lsp-ui] Status check failed (non-fatal):', statusErr);
+          debugLog('[copilot-lsp-ui] Status check failed (non-fatal):', statusErr);
         }
 
-        console.log('[copilot-lsp-ui] Calling copilot_lsp_sign_in (timeout:', CONNECTION_TIMEOUT_MS, 'ms)...');
+        debugLog('[copilot-lsp-ui] Calling copilot_lsp_sign_in (timeout:', CONNECTION_TIMEOUT_MS, 'ms)...');
         const signInStart = Date.now();
         const result = await withTimeout(
           invoke<{ user_code: string; verification_uri: string }>(
@@ -574,12 +575,12 @@ function ConnectCopilotLsp({
           CONNECTION_TIMEOUT_MS,
           'Sign-in',
         );
-        console.log('[copilot-lsp-ui] signIn returned after', Date.now() - signInStart, 'ms — result:', JSON.stringify(result));
+        debugLog('[copilot-lsp-ui] signIn returned after', Date.now() - signInStart, 'ms — result:', JSON.stringify(result));
         if (!active) return;
 
         // Check if the device code was already received via event while signIn was running
         if (deviceCodeReceivedRef.current) {
-          console.log('[copilot-lsp-ui] Device code already received via event during signIn call — skipping result processing');
+          debugLog('[copilot-lsp-ui] Device code already received via event during signIn call — skipping result processing');
           return;
         }
 
@@ -587,13 +588,13 @@ function ConnectCopilotLsp({
           // Neither Phase 1 (signIn) nor Phase 2 (signInInitiate) returned a
           // device code. Wait for the LSP to send it asynchronously via a
           // server→client signIn request → copilot-auth-device-code event.
-          console.log('[copilot-lsp-ui] Empty user_code from signIn — waiting for device code event or auth completion');
+          debugLog('[copilot-lsp-ui] Empty user_code from signIn — waiting for device code event or auth completion');
           if (!authCompleted.current) {
             // Wait up to 10 seconds for either the device code event or auth completion
             for (let i = 0; i < 20; i++) {
               await new Promise((r) => setTimeout(r, 500));
               if (!active || authCompleted.current || deviceCodeReceivedRef.current) {
-                console.log('[copilot-lsp-ui] Wait resolved — authCompleted:', authCompleted.current, 'deviceCodeReceived:', deviceCodeReceivedRef.current);
+                debugLog('[copilot-lsp-ui] Wait resolved — authCompleted:', authCompleted.current, 'deviceCodeReceived:', deviceCodeReceivedRef.current);
                 return;
               }
             }
@@ -606,7 +607,7 @@ function ConnectCopilotLsp({
           return;
         }
 
-        console.log('[copilot-lsp-ui] Got device code from signIn result:', result.user_code);
+        debugLog('[copilot-lsp-ui] Got device code from signIn result:', result.user_code);
         setDeviceCode(result.user_code);
         setPhase('device_code');
       } catch (err) {

--- a/src/components/settings/SettingsDialog.tsx
+++ b/src/components/settings/SettingsDialog.tsx
@@ -120,6 +120,7 @@ export function SettingsDialog({ open, onOpenChange, initialTab, updateState, on
     marginRight, setMarginRight,
     gitEnabled, setGitEnabled,
     pageBreaks, setPageBreaks,
+    debugLogging, setDebugLogging,
     autoCheckUpdates, setAutoCheckUpdates,
     lastUpdateCheck,
   } = useSettingsStore();
@@ -635,6 +636,45 @@ export function SettingsDialog({ open, onOpenChange, initialTab, updateState, on
                         id="auto-check-updates"
                         checked={autoCheckUpdates}
                         onCheckedChange={setAutoCheckUpdates}
+                        className="ml-auto"
+                      />
+                    </div>
+                  </div>
+                </div>
+
+                <div className="h-px bg-border" />
+
+                {/* Developer */}
+                <div className="space-y-4">
+                  <div>
+                    <Label className="text-sm font-semibold">Developer</Label>
+                    <p className="text-xs text-muted-foreground mt-1">
+                      Troubleshooting and diagnostics
+                    </p>
+                  </div>
+
+                  <div className="space-y-2">
+                    <div
+                      className="flex flex-wrap items-center justify-between gap-3 px-4 py-3 rounded-lg border border-border hover:border-muted-foreground transition-colors duration-150"
+                    >
+                      <div>
+                        <Label
+                          htmlFor="debug-logging"
+                          className="text-sm font-medium cursor-pointer"
+                        >
+                          Debug Logging
+                        </Label>
+                        <p className="text-xs text-muted-foreground mt-0.5">
+                          Log diagnostic messages to the console and stderr for troubleshooting
+                        </p>
+                      </div>
+                      <Switch
+                        id="debug-logging"
+                        checked={debugLogging}
+                        onCheckedChange={(checked) => {
+                          setDebugLogging(checked);
+                          tauriApi.setDebugLogging(checked);
+                        }}
                         className="ml-auto"
                       />
                     </div>

--- a/src/lib/debug.ts
+++ b/src/lib/debug.ts
@@ -1,0 +1,7 @@
+import { useSettingsStore } from '@/stores/settings-store';
+
+export function debugLog(...args: unknown[]): void {
+  if (useSettingsStore.getState().debugLogging) {
+    console.log(...args);
+  }
+}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -262,6 +262,11 @@ export const tauriApi = {
     await invoke("acp_permission_respond", { instanceId, requestId, optionId });
   },
 
+  // Debug logging
+  async setDebugLogging(enabled: boolean): Promise<void> {
+    await invoke("set_debug_logging", { enabled });
+  },
+
   // Tag scanning
   async scanTagsInDirectories(paths: string[]): Promise<Record<string, string[]>> {
     return await invoke<Record<string, string[]>>("scan_tags_in_directories", { paths });

--- a/src/stores/settings-store.ts
+++ b/src/stores/settings-store.ts
@@ -29,6 +29,7 @@ interface SettingsStore {
   externalChangeDiffReview: boolean;
   sourceWordWrap: boolean;
   copilotMaxCompletionChars: number;
+  debugLogging: boolean;
   autoCheckUpdates: boolean;
   lastUpdateCheck: string | null;
   dismissedVersion: string | null;
@@ -59,6 +60,7 @@ interface SettingsStore {
   setExternalChangeDiffReview: (enabled: boolean) => void;
   setSourceWordWrap: (enabled: boolean) => void;
   setCopilotMaxCompletionChars: (chars: number) => void;
+  setDebugLogging: (enabled: boolean) => void;
   setAutoCheckUpdates: (enabled: boolean) => void;
   setLastUpdateCheck: (timestamp: string | null) => void;
   setDismissedVersion: (version: string | null) => void;
@@ -95,6 +97,7 @@ export const useSettingsStore = create<SettingsStore>()(
       externalChangeDiffReview: false,
       sourceWordWrap: true,
       copilotMaxCompletionChars: 80,
+      debugLogging: false,
       autoCheckUpdates: true,
       lastUpdateCheck: null,
       dismissedVersion: null,
@@ -181,6 +184,10 @@ export const useSettingsStore = create<SettingsStore>()(
 
       setCopilotMaxCompletionChars: (chars: number) => {
         set({ copilotMaxCompletionChars: chars });
+      },
+
+      setDebugLogging: (enabled: boolean) => {
+        set({ debugLogging: enabled });
       },
 
       setAutoCheckUpdates: (enabled: boolean) => {


### PR DESCRIPTION
## Summary
- Fixes doc comment in `copilot_lsp_sign_in` ("Two-phase" → "Three-phase") to match the actual implementation
- Fixes `execute_embedded_command()` silently swallowing errors (`let _ =` → proper error logging)
- Adds a configurable debug logging toggle (Settings > About > Developer) that controls both backend (`debug_log!` macro) and frontend (`debugLog()`) diagnostic output

## Changes

| File | Change |
|------|--------|
| `src-tauri/src/lib.rs` | `DEBUG_LOGGING` AtomicBool, `debug_log!` macro, `set_debug_logging` command |
| `src-tauri/src/commands/copilot_lsp.rs` | Fix doc comment, fix error swallowing, migrate `eprintln!` → `debug_log!` |
| `src/lib/debug.ts` | New `debugLog()` utility using Zustand `getState()` |
| `src/stores/settings-store.ts` | Add `debugLogging` boolean + setter |
| `src/lib/tauri.ts` | Add `setDebugLogging` wrapper |
| `src/components/settings/SettingsDialog.tsx` | Developer section with Debug Logging toggle |
| `src/components/settings/ConnectionsSettings.tsx` | Migrate `console.log` → `debugLog` |
| `src/App.tsx` | Sync debug setting to backend on startup |

## Test plan
- [ ] `cargo check` passes
- [ ] `tsc --noEmit` passes
- [ ] Toggle Debug Logging on in Settings > About > Developer → verify console/stderr output appears during Copilot sign-in
- [ ] Toggle off → verify diagnostic logs stop
- [ ] Enable, quit, reopen → verify setting persists and backend receives it on startup
- [ ] Genuine errors (e.g., LSP crash) still log unconditionally

🤖 Generated with [Claude Code](https://claude.com/claude-code)