### PR TITLE
Add Skills-to-Tools Glue Layer PRD and Research

### DIFF
--- a/docs/prds/2026-03-29-skills-to-tools-glue-layer.md
+++ b/docs/prds/2026-03-29-skills-to-tools-glue-layer.md
@@ -1,0 +1,399 @@
+# PRD: Skills-to-Tools Glue Layer
+
+|  |  |
+| --- | --- |
+| **Date** | 2026-03-29 |
+| **Status** | Draft |
+| **Priority** | High |
+| **Impact** | Any LLM with tool-calling support can discover and use skills — not just large frontier models |
+| **Research** | [skills-to-tools-glue-layer](../research/skills-to-tools-glue-layer.md) |
+
+## Problem
+
+Notesage skills are invisible to models that can't perform multi-step meta-reasoning. Today, using a skill requires:
+
+1. The model reads a text hint in the system prompt ("Available skills: **download-webpage**: ...")
+2. The model calls `read_skill_content` to load the full SKILL.md instructions
+3. The model parses the instructions and identifies the correct script + arguments
+4. The model calls `execute_skill_script` with the right parameters
+
+This 3-step chain works for Claude, GPT-4o, and large Qwen/Llama models. It fails for smaller local models (7B–14B parameter range) that can handle basic tool calling but not multi-step reasoning about a meta-protocol.
+
+Meanwhile, the same models handle built-in tools like `web_search({ query })` and `read_file({ path })` reliably — because these are presented as first-class tool definitions via the trained tool-calling pathway.
+
+**The gap:** Skills use a different, harder discovery mechanism than tools, even though the underlying capability (call a function with structured arguments) is identical.
+
+## Goals
+
+1. **Script-bearing skills automatically appear as tool definitions** alongside built-in tools — no SKILL.md changes required
+2. **Any model that can call `web_search({ query })` can also call `download_webpage({ url, output_dir })`** — same abstraction level, same discovery mechanism
+3. **Knowledge-only skills continue working as system prompt injections** — the glue layer only targets skills with scripts
+4. **Existing skill format is fully backward compatible** — no breaking changes to SKILL.md spec
+5. **Optional explicit schemas** supported for skill authors who want precise control
+
+## Non-Goals
+
+- Converting knowledge-only skills (no scripts) into tools — these are system prompt extensions and will remain so
+- Replacing MCP integration — MCP servers remain the path for complex external integrations
+- Auto-generating schemas from script source code analysis or AST parsing
+- Supporting tool calling for ACP agent connections (they handle skills natively)
+- Building a skill marketplace or registry
+
+## User Stories
+
+- As a user running a local 8B model, I want to say "download this webpage" and have the model call the download-webpage skill directly, so I get the same skill capabilities as users with frontier models
+- As a skill author, I want my existing skills to work with the glue layer without any changes, so I don't need to learn a new schema format
+- As a skill author, I want to optionally declare explicit parameter schemas in my SKILL.md, so I can provide more precise tool definitions for complex scripts
+- As a power user, I want to see which skills are exposed as tools and which remain instruction-only, so I understand what my model can access
+
+## Technical Approach
+
+### Skill Classification at Discovery Time
+
+When skills are scanned (via `discover_skills` in `skills.rs`), classify each skill:
+
+| Classification | Criteria | Handling |
+| --- | --- | --- |
+| **Tool-eligible** | `has_scripts: true` AND `disable_model_invocation != true` | Generate tool definitions from scripts |
+| **Instruction-only** | `has_scripts: false` OR no parseable script interface | Keep as system prompt injection (current behavior) |
+| **Explicitly schema'd** | Has `tools:` field in SKILL.md frontmatter | Use author-provided JSON Schema directly |
+
+### Parameter Schema Extraction
+
+For tool-eligible skills without explicit schemas, extract parameter information at discovery time. The extraction pipeline runs in the Rust backend during skill scanning, in priority order:
+
+**Priority 1 — Explicit frontmatter schema (new optional field):**
+
+```yaml
+---
+name: download-webpage
+description: Download a web page by URL and save as clean markdown
+tools:
+  - name: download
+    description: Download a web page and save as markdown with images
+    script: scripts/download.mjs
+    parameters:
+      type: object
+      properties:
+        url:
+          type: string
+          description: URL of the page to download
+        output_dir:
+          type: string
+          description: Directory to save the downloaded file
+        force:
+          type: boolean
+          description: Overwrite existing files
+      required: [url, output_dir]
+---
+```
+
+**Priority 2 — Script Usage comment parsing:**
+
+Parse the first 10 lines of each script file for `Usage:` patterns:
+
+```
+// Usage: node download.mjs <url> <output_dir> [--force]
+```
+
+Extraction rules:
+- `<name>` → required string parameter
+- `[name]` → optional string parameter
+- `[--flag]` → optional boolean parameter
+- `[--flag "value"]` → optional string parameter
+- `<name1> [name2...]` → first required, rest collected into array
+- Parameter descriptions derived from SKILL.md body invocation examples where possible
+
+**Priority 3 — Fallback generic schema:**
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "args": { "type": "array", "items": { "type": "string" }, "description": "Arguments for the script" }
+  },
+  "required": ["args"]
+}
+```
+
+This is still better than the current 3-step chain because the tool is named and described — the model sees `download_webpage__download` not the generic `execute_skill_script`.
+
+### Tool Definition Generation
+
+Each tool-eligible script produces one `ToolDefinition`:
+
+```typescript
+{
+  name: "skill__download_webpage__download",  // skill__{skill}__{script}
+  description: "Download a web page and save as markdown with images. Returns JSON: {title, url, file, wordCount, images, status}",
+  input_schema: { /* extracted or explicit JSON Schema */ }
+}
+```
+
+**Naming convention:** `skill__{skill_name}__{script_name}` where:
+- `skill__` prefix identifies skill-generated tools (for routing)
+- Skill name and script name are snake_cased from their original names
+- Script name derived from filename without extension (`download.mjs` → `download`)
+
+For skills with a single script, the script name portion can be omitted for brevity:
+- `skill__download_webpage` (single script)
+- `skill__create_skill__scaffold`, `skill__create_skill__validate` (multiple scripts)
+
+### Tool Execution Routing
+
+In `tool-executor.ts`, add a `skill__` prefix handler:
+
+```typescript
+if (name.startsWith('skill__')) {
+  // Parse: skill__{skill_name}__{script_name}
+  // Look up skill and script from skill store
+  // Map structured JSON args → string[] for execute_skill_script
+  // Call invoke('execute_skill_script', { skillPath, script, args, ... })
+}
+```
+
+**Argument mapping (JSON → string[]):**
+
+The executor converts the structured JSON arguments from the tool call into the `string[]` that `execute_skill_script` expects:
+
+1. Required positional params → added in order
+2. Optional params with values → added as `--flag value`
+3. Boolean flags that are `true` → added as `--flag`
+4. Array params → spread as multiple positional args
+
+Example: `{ url: "https://example.com", output_dir: "./articles", force: true }` → `["https://example.com", "./articles", "--force"]`
+
+The mapping rules are stored alongside the extracted schema so the executor knows the original parameter order and flag format.
+
+### Integration with getToolDefinitions()
+
+Update `skill-store.ts`:
+
+```typescript
+getToolDefinitions: (allowedTools?: string[]) => {
+  const builtIn = allowedTools
+    ? BUILT_IN_TOOLS.filter(t => allowedTools.includes(t.name))
+    : BUILT_IN_TOOLS;
+
+  const skillTools = getSkillToolDefinitions(allowedTools);
+
+  return [...builtIn, ...skillTools];
+}
+```
+
+Skill-generated tools respect the same `allowedTools` agent filtering as built-in tools. The agent's `allowed-tools` frontmatter can reference skill tool names (e.g., `skill__download_webpage`).
+
+### System Prompt Update
+
+When skill tools are generated, remove those skills from the system prompt text injection (they're now in the `tools` array). Knowledge-only skills remain in the system prompt.
+
+### Data Flow
+
+```
+Skill Discovery (Rust: skills.rs)
+  │
+  ├─ For each skill with has_scripts:
+  │    ├─ Check frontmatter for explicit `tools:` field → use as-is
+  │    ├─ Else: read first 10 lines of each script → parse Usage: comment
+  │    ├─ Else: fallback to generic { args: string[] }
+  │    └─ Return SkillToolEntry { name, description, script_path, parameters, arg_mapping }
+  │
+  └─ Frontend receives SkillEntry[] (existing) + SkillToolEntry[] (new)
+
+Tool Assembly (TS: skill-store.ts)
+  │
+  ├─ Convert SkillToolEntry[] → ToolDefinition[]
+  ├─ Merge with BUILT_IN_TOOLS
+  └─ Pass to ai_chat_stream as tools array
+
+Tool Execution (TS: tool-executor.ts)
+  │
+  ├─ Detect skill__ prefix
+  ├─ Look up skill + script from store
+  ├─ Convert JSON args → string[] via arg_mapping
+  └─ Call execute_skill_script Tauri command
+```
+
+## Data Model
+
+### New Rust Structs (skills.rs)
+
+```rust
+/// A tool definition extracted from a skill script.
+#[derive(Serialize, Deserialize, Clone)]
+pub struct SkillToolEntry {
+    /// Tool name: skill__{skill}__{script}
+    pub tool_name: String,
+    /// Human-readable description for the LLM
+    pub description: String,
+    /// Parent skill name (for routing)
+    pub skill_name: String,
+    /// Relative script path within the skill directory
+    pub script_path: String,
+    /// JSON Schema for tool parameters
+    pub parameters: serde_json::Value,
+    /// Mapping metadata: how to convert JSON args to string[]
+    pub arg_mapping: Vec<ArgMapping>,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct ArgMapping {
+    /// Parameter name in the JSON Schema
+    pub param_name: String,
+    /// How this parameter maps to CLI args
+    pub mapping_type: ArgMappingType,
+    /// Position in the args array (for positional params)
+    pub position: Option<usize>,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub enum ArgMappingType {
+    /// Positional argument: value added at position
+    Positional,
+    /// Flag: --name value
+    Flag { flag: String },
+    /// Boolean flag: --name (present if true)
+    BoolFlag { flag: String },
+    /// Spread: array values added as consecutive positional args
+    Spread,
+}
+```
+
+### New TypeScript Interface (lib/tauri.ts)
+
+```typescript
+export interface SkillToolEntry {
+  tool_name: string;
+  description: string;
+  skill_name: string;
+  script_path: string;
+  parameters: Record<string, unknown>;
+  arg_mapping: ArgMapping[];
+}
+
+export interface ArgMapping {
+  param_name: string;
+  mapping_type: 'positional' | 'flag' | 'bool_flag' | 'spread';
+  position?: number;
+  flag?: string;
+}
+```
+
+### Extended SKILL.md Frontmatter (Optional)
+
+```yaml
+---
+name: my-skill
+description: My skill description
+tools:                              # NEW optional field
+  - name: my-action                 # Tool name suffix
+    description: What this does     # LLM-facing description
+    script: scripts/my-script.sh    # Script path
+    parameters:                     # JSON Schema
+      type: object
+      properties:
+        input: { type: string, description: Input value }
+      required: [input]
+---
+```
+
+### Skill Store Changes (skill-store.ts)
+
+Add to the store interface:
+
+```typescript
+interface SkillStore {
+  // ... existing fields ...
+
+  /** Tool definitions extracted from script-bearing skills. */
+  skillTools: SkillToolEntry[];
+
+  /** Update skill tools (called after skill scan). */
+  setSkillTools: (tools: SkillToolEntry[]) => void;
+}
+```
+
+### Updated Tauri Command
+
+Extend `discover_skills` return type or add a new command:
+
+```rust
+#[tauri::command]
+pub async fn extract_skill_tools(
+    skill_entries: Vec<SkillEntry>,
+) -> Result<Vec<SkillToolEntry>, String>
+```
+
+This runs the extraction pipeline on the provided skill entries and returns tool definitions. Called after `discover_skills` completes.
+
+## UI/UX
+
+### Settings > Skills & Agents
+
+- Skill cards that have generated tools show a "Tools" badge with count (e.g., "2 tools")
+- Expanding a skill card shows the generated tool names and their extracted parameters
+- Skills with explicit `tools:` frontmatter show a checkmark indicating author-provided schemas
+- Skills with auto-extracted schemas show an "auto" indicator
+
+### Chat Footer Tools Indicator
+
+The existing tools count badge in the chat footer already shows the number of available tools. This number will increase to include skill-generated tools. Clicking the badge shows the tools popover — skill tools should be visually grouped under a "Skills" section, separate from built-in tools.
+
+### No Changes Required
+
+- Chat input behavior unchanged
+- Tool call permission cards work identically (skill scripts already require approval via `execute_skill_script`)
+- Activity panel shows tool calls the same way
+
+## Dependencies
+
+- No new libraries required
+- Uses existing `execute_skill_script` Tauri command for execution
+- Uses existing `ToolDefinition` type for tool definitions
+- Uses existing tool-calling infrastructure in `useDirectApiChat.ts`
+
+## Quality Gates
+
+### Functional
+
+- [ ] Skills with scripts are automatically exposed as tool definitions
+- [ ] A local model (e.g., Qwen3 8B via Ollama) can discover and call `skill__download_webpage` without ever seeing the SKILL.md body
+- [ ] The same skill works via both paths: tool call (small model) and read_skill_content chain (large model)
+- [ ] Skills without scripts remain as system prompt injections only
+- [ ] Explicit `tools:` frontmatter schemas are used when present
+- [ ] Usage comment parsing extracts correct parameters for all bundled skills
+- [ ] Fallback generic schema works for skills with no parseable interface
+- [ ] Agent `allowed-tools` filtering applies to skill-generated tools
+- [ ] Tool execution correctly maps JSON arguments to string[] for execute_skill_script
+- [ ] Boolean flags, positional args, and optional flags all map correctly
+
+### Backward Compatibility
+
+- [ ] Existing skills with no changes continue to work identically
+- [ ] `read_skill_content` and `execute_skill_script` built-in tools remain available
+- [ ] Skills with `disable_model_invocation: true` are not converted to tools
+- [ ] No changes to SKILL.md spec are required (new fields are optional)
+
+### Testing
+
+- [ ] Unit tests for Usage comment parser (various formats: positional, flags, optional, spread)
+- [ ] Unit tests for JSON → string[] argument mapping
+- [ ] Unit tests for tool name generation (snake_case, dedup, prefix)
+- [ ] Integration test: skill scan → tool extraction → tool definition assembly
+- [ ] Rust tests for `extract_skill_tools` command
+- [ ] All existing skill tests continue to pass
+
+### Performance
+
+- [ ] Skill tool extraction adds < 50ms to skill discovery time
+- [ ] Tool definitions for skills don't significantly increase token usage (< 500 tokens per skill tool)
+
+## Out of Scope
+
+- **Knowledge skill conversion** — Pure instruction skills cannot become tools; this is a fundamental limitation, not a bug to fix
+- **Script source code parsing** — Analyzing Python/Node/Bash ASTs to infer parameter types is fragile and not worth the complexity
+- **MCP migration path** — Converting skills to MCP servers is a separate initiative; both coexist
+- **Tool calling for ACP agents** — ACP agents handle skills natively via their subprocess; the glue layer targets direct API providers only
+- **Deferred/lazy tool loading** — For apps with 30+ skills, sending all tool schemas per request becomes expensive. Anthropic's `defer_loading` and OpenAI's `tool_search` solve this, but it's a future optimization
+- **Strict mode output validation** — Enforcing exact schema compliance on model output (OpenAI `strict: true`) is provider-specific and out of scope for v1
+- **Custom tool icons or categories** — Visual grouping in the tools popover is cosmetic and can be added later

--- a/docs/research/skills-to-tools-glue-layer.md
+++ b/docs/research/skills-to-tools-glue-layer.md
@@ -1,0 +1,261 @@
+# Skills-to-Tools Glue Layer Research
+
+**Date:** 2026-03-29 **Status:** Research complete
+
+| Stage | Link | Status |
+| --- | --- | --- |
+| PRD | [skills-to-tools-glue-layer](../prds/2026-03-29-skills-to-tools-glue-layer.md) | Draft |
+| Tasks | — | Not planned |
+
+**Context:** Notesage supports AI skills (SKILL.md files with optional scripts) and tool calling (6 hardcoded built-in tools). Currently, skills are injected as text descriptions in the system prompt — the model must reason through a multi-step chain (read system prompt, call `read_skill_content`, parse instructions, call `execute_skill_script`) to use them. This works for large models (Claude, GPT-4o) but fails for smaller local models that can handle basic tool calling but not multi-step meta-reasoning.
+
+**Goal:** Research how to bridge skills into first-class tool definitions so any model with tool-calling support can discover and use them deterministically.
+
+---
+
+## 1. The Problem
+
+### Current Architecture
+
+Skills are presented to the LLM via two mechanisms:
+
+1. **System prompt injection** — Skill names and descriptions appended to the system message:
+   ```
+   Available skills:
+   - **download-webpage**: Download a web page by URL and save it as clean markdown (has scripts)
+   ```
+
+2. **Two generic meta-tools** — The model must chain these to actually use a skill:
+   - `read_skill_content({ skill_name })` — loads the full SKILL.md body
+   - `execute_skill_script({ skill_name, script, args[] })` — runs a script
+
+### The Multi-Step Reasoning Chain
+
+To use a skill, the model must:
+1. Read the system prompt and notice a relevant skill exists
+2. Call `read_skill_content` to load the skill's full instructions
+3. Parse the instructions to identify which script to call and with what arguments
+4. Call `execute_skill_script` with the correct skill name, script path, and args
+
+This 3-step chain requires meta-reasoning that smaller models (Qwen 7B, Llama 8B, SmolLM2) cannot reliably perform, even though they can handle basic tool calling.
+
+### How Tool Calling Actually Works
+
+Tools are NOT in the system message. They're sent as a **separate `tools` array** in the API request:
+
+```json
+{
+  "system": "You are a helpful assistant...",
+  "messages": [...],
+  "tools": [
+    { "name": "web_search", "description": "...", "input_schema": { ... } }
+  ]
+}
+```
+
+The LLM provider injects tools into the model's context in a way the model was specifically fine-tuned to recognize. Tool calling is **never fully deterministic** — the model always decides *whether* to call a tool and *what values* to pass. But it IS:
+- **Discoverable** — the model sees all tools in the `tools` array
+- **Structured** — JSON Schema defines what params exist and their types
+- **Trained behavior** — models are fine-tuned on tool-calling patterns
+
+The gap: skills are discoverable only via system prompt text (not the trained tool-calling pathway), and their invocation requires multi-step reasoning (not a single structured call).
+
+---
+
+## 2. Industry Research
+
+### Universal Convergence: JSON Schema
+
+Every major platform uses JSON Schema for tool parameter definitions. The only variation is the envelope:
+
+| Platform | Tool Format |
+| --- | --- |
+| OpenAI | `{ type: "function", function: { name, description, parameters: JSONSchema } }` |
+| Anthropic | `{ name, description, input_schema: JSONSchema }` |
+| MCP | `{ name, description, inputSchema: JSONSchema }` (via `tools/list` JSON-RPC) |
+| LangChain | Pydantic BaseModel -> JSON Schema -> provider format |
+| Semantic Kernel | Code annotations -> JSON Schema -> provider format |
+| CrewAI | Pydantic `args_schema` -> JSON Schema |
+| Composio | Raw schema -> provider-specific `wrap_tool` adapters |
+
+### Schema Authoring Approaches
+
+| Approach | Schema Source | Requires Author Work? | Used By |
+| --- | --- | --- | --- |
+| Manual JSON Schema | Hand-written | Yes | MCP, raw OpenAI/Anthropic |
+| OpenAPI spec | Parsed from REST API description | Yes | GPT Actions, Semantic Kernel, Google ADK |
+| Type hint inference | Auto-generated from function signatures | No (if typed) | LangChain `@tool`, Semantic Kernel `@kernel_function` |
+| Pydantic model | Explicit `BaseModel` subclass | Yes | CrewAI `BaseTool`, LangChain `StructuredTool` |
+
+### Key Insight: Determinism
+
+No platform makes tool *selection* deterministic — the model always chooses heuristically. What they make deterministic is:
+- **Discoverability** — the model sees proper tool definitions via the trained pathway
+- **Output compliance** — `strict: true` constrains generated arguments to match the schema
+- **Single-step invocation** — one tool call, not a multi-step reasoning chain
+
+Sources:
+- [OpenAI Function Calling](https://platform.openai.com/docs/guides/function-calling)
+- [Anthropic Tool Use](https://docs.anthropic.com/en/docs/build-with-claude/tool-use)
+- [MCP Specification](https://modelcontextprotocol.io/specification/2025-11-25/basic)
+- [MCP Tool Schema](https://modelcontextprotocol.io/specification/2025-11-25/server/tools)
+- [LangChain Tools](https://docs.langchain.com/oss/python/langchain/tools)
+- [Semantic Kernel Plugins](https://learn.microsoft.com/en-us/semantic-kernel/concepts/plugins/)
+- [CrewAI Custom Tools](https://docs.crewai.com/en/learn/create-custom-tools)
+- [Composio Tool Calling](https://docs.composio.dev/tool-calling/introduction)
+- [OpenAI Cookbook: Function Calling with OpenAPI](https://cookbook.openai.com/examples/function_calling_with_an_openapi_spec)
+- [Google ADK OpenAPI Tools](https://google.github.io/adk-docs/tools-custom/openapi-tools/)
+
+---
+
+## 3. Skill Ecosystem Analysis
+
+### Sample of 20 Skills Analyzed
+
+Skills were sampled from three sources:
+- [anthropics/skills](https://github.com/anthropics/skills/tree/main/skills) (official Anthropic skills)
+- [ComposioHQ/awesome-claude-skills](https://github.com/ComposioHQ/awesome-claude-skills) (community skills)
+- Notesage bundled skills (`bundled-skills/`)
+
+### Two Distinct Skill Types
+
+**Type A: Knowledge Skills (no scripts, ~75% of ecosystem)**
+
+Pure instruction sets that teach the LLM how to use existing capabilities (Bash, read_file, write_file, Python/Node code). Examples:
+
+| Skill | What It Teaches | Scripts? |
+| --- | --- | --- |
+| pdf | pypdf, pdfplumber, reportlab, qpdf, OCR | No |
+| frontend-design | UI design principles, typography, color | No |
+| claude-api | Claude API usage, SDK patterns | No |
+| changelog-generator | git log parsing, changelog formatting | No |
+| invoice-organizer | File scanning, renaming, CSV generation | No |
+| lead-research-assistant | Web research, lead scoring | No |
+| meeting-insights-analyzer | Transcript parsing, pattern recognition | No |
+| content-research-writer | Research, outlining, citation management | No |
+| slack-gif-creator | PIL animation, GIF optimization | No |
+| brand-guidelines | Style rules, voice consistency | No |
+| mcp-builder | MCP server development patterns | No |
+
+**These cannot become tools** — there's nothing to execute. They work by enriching the LLM's context. A tool wrapper around them would just be `{ request: string }` which adds no structure over the current system prompt injection.
+
+**Type B: Script Skills (have executable scripts, ~25% of ecosystem)**
+
+Have scripts that perform concrete operations with defined inputs and outputs. Examples:
+
+| Skill | Scripts | Input → Output |
+| --- | --- | --- |
+| download-webpage | `download.mjs`, `setup.sh` | URL, output_dir → JSON {title, file, status} |
+| search-research | `search.mjs` | query, dirs, --tag, --limit → JSON array |
+| save-research | `save.mjs` | content, output_dir, --title, --tags → JSON {file, status} |
+| create-skill | `scaffold.sh`, `validate.sh` | name, target_dir → directory structure |
+| docx | `unpack.py`, `pack.py`, `validate.py` | file paths → processed files |
+| xlsx | `recalc.py` | file path → recalculated file |
+| pptx | `thumbnail.py`, `soffice.py` | file path → images |
+| webapp-testing | `with_server.py` | server config → managed process |
+| web-artifacts-builder | init script, bundle script | project config → HTML artifact |
+
+Within Type B, there's a further subdivision:
+
+- **Script-primary** (scripts ARE the capability): `download-webpage`, `search-research`, `save-research`, `create-skill` — the script does the real work, arguments are well-defined
+- **Script-helper** (scripts assist the LLM's work): `docx`, `xlsx`, `pptx` — scripts handle mechanical steps (unpack XML, recalculate formulas) but the LLM still needs instructions for the creative/analytical work
+
+### Script Parameter Discovery
+
+Existing scripts already contain parseable parameter information:
+
+**In script headers (Usage comments):**
+```
+// Usage: node download.mjs <url> <output_dir> [--force]
+// Usage: node search.mjs <query> <dir1> [dir2...] [--tag "tagname"] [--limit 20]
+// Usage: node save.mjs <content_or_path> <output_dir> [--title "..."] [--tags "..."]
+```
+
+**In SKILL.md invocation examples:**
+```
+execute_skill_script("download-webpage", "scripts/download.mjs", [url, output_dir])
+execute_skill_script("search-research", "scripts/search.mjs", [query, ...search_dirs, "--tag", "ai"])
+```
+
+**In SKILL.md output documentation:**
+```json
+{ "title": "Article Title", "file": "/path/to/saved/article.md", "status": "created" }
+```
+
+---
+
+## 4. Approach Evaluation
+
+### Option 1: Inline JSON Schema in SKILL.md Frontmatter
+
+Each script declares parameters in YAML frontmatter. The app parses these and generates tool definitions.
+
+| Pros | Cons |
+| --- | --- |
+| Explicit, unambiguous schemas | Requires skill authors to add schemas |
+| Matches MCP/OpenAI/Anthropic format | Breaks "no author changes" requirement |
+| Backward compatible (optional field) | YAML + JSON Schema is verbose |
+
+### Option 2: OpenAPI Spec Per Skill
+
+Each skill ships an `openapi.yaml`. Operations become tools.
+
+| Pros | Cons |
+| --- | --- |
+| Industry standard, massive ecosystem | Overkill for local scripts |
+| Rich tooling (validation, codegen) | Requires skill authors to learn OpenAPI |
+| Schema validation built in | Conceptual mismatch (scripts aren't REST APIs) |
+
+### Option 3: MCP Server Per Skill
+
+Each skill becomes an MCP server with `tools/list` discovery.
+
+| Pros | Cons |
+| --- | --- |
+| Emerging industry standard | Skills must be rewritten as MCP servers |
+| Already integrated in Notesage | Each skill is a running process |
+| Works across all AI tools | Heavy for simple scripts |
+
+### Option 4: Type-Hint Inference (@tool Decorator Pattern)
+
+Skills rewritten as typed Python/TypeScript functions. Runtime infers JSON Schema.
+
+| Pros | Cons |
+| --- | --- |
+| Zero-schema authoring | Requires specific language runtime |
+| Extremely ergonomic | Breaks polyglot model (bash, python, node) |
+| Battle-tested (LangChain, CrewAI) | Can't support shell scripts |
+
+### Option 5 (Recommended): Automatic Extraction + Optional Schema Override
+
+The glue layer **auto-extracts** parameter information from existing SKILL.md content and script headers at discovery time. No author changes needed. Authors CAN optionally provide explicit schemas for precision.
+
+**Auto-extraction sources (in priority order):**
+1. `scripts[].parameters` frontmatter (if author provides explicit schema — highest fidelity)
+2. Script `Usage:` header comments (parseable with regex)
+3. `execute_skill_script()` invocation examples in SKILL.md body
+4. Fallback: single `{ args: string[] }` generic schema
+
+| Pros | Cons |
+| --- | --- |
+| Zero changes to existing skills | Auto-extraction is heuristic, not perfect |
+| Backward compatible | Complex extraction logic |
+| Gradual improvement (authors can add schemas later) | Different quality levels per skill |
+| Works with any language (bash, python, node) | |
+| Matches existing ecosystem | |
+
+---
+
+## 5. Conclusions
+
+1. **~75% of skills are knowledge-only** and cannot become tools. They should remain as system prompt injections. The glue layer should only target script-bearing skills.
+
+2. **Script-primary skills map cleanly to tools.** Our bundled skills (`download-webpage`, `search-research`, `save-research`, `create-skill`) have well-defined interfaces extractable from existing metadata.
+
+3. **The industry standard is JSON Schema** for tool parameters. Every platform converges on this. The tool definition format is already implemented in Notesage (`ToolDefinition` with `input_schema`).
+
+4. **Auto-extraction from existing content is feasible** for well-structured skills. Script `Usage:` comments and SKILL.md invocation examples provide enough information to generate useful schemas for the most common patterns.
+
+5. **MCP is the long-term standard** for complex integrations, but the lightweight frontmatter approach is the right fit for simple script skills. Both paths should coexist (MCP already works in Notesage).
+
+6. **The key architectural insight:** the glue layer should treat each skill script as an independent tool, not wrap the entire skill in a single tool. A skill with 3 scripts produces 3 tools.


### PR DESCRIPTION
## Summary

This PR introduces comprehensive product requirements and research documentation for a new "Skills-to-Tools Glue Layer" feature that bridges Notesage skills into first-class tool definitions, enabling smaller language models to discover and invoke skills deterministically without multi-step meta-reasoning.

## Changes

- **Added PRD document** (`docs/prds/2026-03-29-skills-to-tools-glue-layer.md`): Complete product specification including:
  - Problem statement: skills currently require 3-step reasoning chain that fails for smaller models
  - Goals: automatic tool definition generation from script-bearing skills with backward compatibility
  - Technical approach: skill classification, parameter schema extraction (explicit frontmatter → Usage comment parsing → fallback), tool definition generation with `skill__` prefix naming convention
  - Data model: new Rust structs (`SkillToolEntry`, `ArgMapping`) and TypeScript interfaces for tool metadata
  - Integration points: updates to `skill-store.ts`, `tool-executor.ts`, and Tauri commands
  - UI/UX: skill cards showing tool badges, tools popover grouping
  - Quality gates and testing requirements

- **Added research document** (`docs/research/skills-to-tools-glue-layer.md`): Supporting research including:
  - Problem analysis: current multi-step skill invocation vs. trained tool-calling pathway
  - Industry research: JSON Schema convergence across OpenAI, Anthropic, MCP, LangChain, CrewAI, Composio
  - Skill ecosystem analysis: categorization of 20+ skills into knowledge-only (~75%) vs. script-bearing (~25%)
  - Approach evaluation: comparison of 5 implementation options (inline schemas, OpenAPI, MCP, type hints, auto-extraction)
  - Recommendation: automatic extraction with optional schema override (Option 5)

## Implementation Details

The proposed solution:
- **Classifies skills at discovery time** into tool-eligible (has scripts, not disabled) vs. instruction-only
- **Extracts parameters** from explicit SKILL.md `tools:` frontmatter, script `Usage:` comments, or invocation examples
- **Generates tool definitions** with naming convention `skill__{skill_name}__{script_name}` and JSON Schema input parameters
- **Routes tool execution** via `skill__` prefix detection in tool executor, mapping JSON arguments back to string arrays for `execute_skill_script`
- **Maintains backward compatibility**: existing skills work unchanged, knowledge-only skills remain as system prompt injections, `read_skill_content` and `execute_skill_script` remain available

No source code changes are included in this PR—this is documentation and specification only. Implementation will follow in subsequent PRs.

https://claude.ai/code/session_0162gj8qHp5rbTuVtYsTCZwB