### PR TITLE
Add research document for image attachment support across AI providers

### DIFF
--- a/docs/prds/2026-04-04-image-attachments.md
+++ b/docs/prds/2026-04-04-image-attachments.md
@@ -1,0 +1,314 @@
+# PRD: Image Attachments for Multi-Modal AI Chat
+
+|  |  |
+| --- | --- |
+| **Date** | 2026-04-04 |
+| **Status** | Draft |
+| **Priority** | High |
+| **Impact** | Users can include images in AI chat across all providers, enabling visual context for code review, UI feedback, document analysis, and drawing-to-code workflows |
+| **Research** | [docs/research/2026-04-03-image-attachments.md](../research/2026-04-03-image-attachments.md) |
+
+## Problem
+
+Notesage supports multi-modal AI providers (Anthropic Claude, OpenAI GPT-4o, Ollama vision models, local bundled vision models, and all four ACP agents) but has no way to include images in chat messages. Users cannot paste screenshots, attach files, or reference document images when conversing with AI. This is table-stakes functionality — every competing tool (Cursor, Cline, Continue.dev, Windsurf, Claude Desktop, ChatGPT Desktop) supports image attachments.
+
+Additionally, Notesage has a unique opportunity: images and Excalidraw drawings already exist inline in documents. No competing tool offers a "send this document image to AI" flow — all require manual copy-paste. Notesage can be the first.
+
+## Goals
+
+1. Users can attach images to chat messages via paste, drag-drop, and file picker across all vision-capable providers
+2. Images are automatically compressed client-side to prevent API limit errors (no tool does this today — a differentiator)
+3. The attachment UI is vision-capability-gated: hidden/disabled when the active model does not support images
+4. Images in the editor (Image nodes, Drawing SVGs) can be sent to AI via right-click context menu
+5. Image attachments work across all four AI paths: Direct API, ACP, local bundled, and Ollama
+
+## Non-Goals
+
+- **Audio attachments** — ACP supports `AudioContent` but this is a separate feature
+- **PDF/document attachments** — different from image vision; requires file upload APIs
+- **Anthropic Files API** — upload-once optimization deferred to a future phase
+- **Multi-turn image carry-forward** — images attach to a single turn only; not re-sent in subsequent turns
+- **Screenshot capture tool** — only ChatGPT has this; low priority for a desktop editor
+- **Image generation** — this PRD is about sending images to AI, not generating them
+
+## User Stories
+
+1. **As a user**, I want to paste a screenshot into the chat input and ask AI about it, so that I can get feedback on UI designs or error messages without describing them in text.
+
+2. **As a user**, I want to drag an image file from Finder into the chat panel, so that I can share reference images with the AI.
+
+3. **As a user**, I want to click an attachment button to browse for image files, so that I have a reliable fallback when paste/drag-drop isn't convenient.
+
+4. **As a user**, I want to right-click an image or drawing in my document and select "Send to AI", so that I can ask the AI about content already in my notes without manually copying it.
+
+5. **As a user**, I want my images automatically resized and compressed before sending, so that I never hit API size limit errors.
+
+6. **As a user**, I want the attachment button to be hidden when my selected AI model doesn't support images, so that I don't waste time attaching images that can't be sent.
+
+7. **As a user**, I want to see thumbnail previews of attached images before sending, so that I can verify the right images are included and remove any I don't want.
+
+## Technical Approach
+
+### Architecture Overview
+
+Images flow through three layers:
+
+1. **Input layer** (ChatInput) — captures images from paste/drop/picker/editor, compresses them, stores as `ImageAttachment[]` in component state
+2. **Storage layer** (chat-store) — persists `attachments` on `ChatMessage` via Zustand persist
+3. **Serialization layer** (Rust backend) — converts the internal format to provider-specific wire formats at send time
+
+### Image Compression Pipeline (Frontend)
+
+All images are processed before base64 encoding:
+
+1. Load into `HTMLCanvasElement`
+2. Resize so longest edge <= 1568px (Anthropic's optimal; server-side resize threshold)
+3. If image has no transparency, convert to JPEG at 80% quality; otherwise keep PNG
+4. Validate base64 size < 5 MB (Anthropic's limit — most restrictive provider)
+5. If still too large, retry at 60% quality
+6. Store as `ImageAttachment` with base64 data, MIME type, and display dimensions
+
+Utility: `src/lib/image-compress.ts`
+
+### Vision Capability Detection
+
+Each AI path reports vision support differently. A unified `supportsVision()` function resolves this:
+
+| Path | Detection method |
+|------|------------------|
+| Direct API (Anthropic) | Always `true` (Claude 3+ all support vision) |
+| Direct API (OpenAI) | Always `true` (GPT-4o+ all support vision) |
+| Direct API (Ollama) | Query `/api/show` for `"multimodal"` capability (extend existing `detect_thinking_support()` pattern) |
+| ACP | Check `promptCapabilities.image` from agent init response (store on `AcpState`) |
+| Local bundled | Check `supports_vision` in `model-catalog.json` (field already exists) |
+| OpenAI-compatible | Assume `true` (user-configured endpoints; can't reliably detect) |
+
+### Provider Serialization (Rust)
+
+The `ai_chat_stream` command receives images as an optional field on `ChatMessage`. Each provider's request builder serializes them differently:
+
+| Provider | Serialization |
+|----------|---------------|
+| Anthropic | `content[]` array: `{ type: "image", source: { type: "base64", media_type, data } }` before text blocks |
+| OpenAI | `content[]` array: `{ type: "image_url", image_url: { url: "data:{mime};base64,{data}" } }` |
+| Ollama (native) | `images: [base64_data]` on the message JSON object |
+| Ollama (OAI compat) | Same as OpenAI via `/v1/chat/completions` |
+| llama-server | Same as OpenAI via `/v1/chat/completions` |
+
+### ACP Path
+
+The `acp_session_prompt` command currently sends `vec![ContentBlock::Text(...)]`. To include images:
+
+1. Store `promptCapabilities` from the ACP `initialize` response on `AcpState`
+2. Add `images: Option<Vec<ImageData>>` parameter to `acp_session_prompt`
+3. Build `Vec<ContentBlock>` with `ContentBlock::Image(ImageContent::new(data, mime))` blocks preceding `ContentBlock::Text`
+4. The `agent-client-protocol` crate (0.10.4) already has `ImageContent` — no dependency changes
+
+### Editor-to-Chat Flow
+
+When a user right-clicks an image or drawing in the editor:
+
+1. Context menu shows "Send to AI" option (only when chat panel is open and model supports vision)
+2. For **Image nodes**: read the image source (local file path or URL), load via Tauri `read_file` or fetch, compress
+3. For **Drawing nodes**: read the `.svg` sidecar file, rasterize to PNG via canvas, compress
+4. Open chat panel if closed, populate `ChatInput` pending attachments
+5. User types their question and sends — image is attached to that message
+
+## UI/UX
+
+### Chat Input Attachments
+
+**Attachment button:** A small image icon (lucide `ImagePlus`, strokeWidth 1.5) appears to the left of the send button in `ChatInput`. Hidden when the active provider/model does not support vision. Tooltip: "Attach image".
+
+**Attachment strip:** When images are pending, a horizontal strip of thumbnails appears above the textarea, below any context items. Each thumbnail is 48x48px with rounded corners (6px), object-fit cover. Hover shows an X button (top-right corner) to remove. Maximum 5 images per message.
+
+**Paste handling:** Intercept `paste` event on the textarea. If `clipboardData.files` contains images, compress and add to pending attachments. If text and images are pasted simultaneously, handle both.
+
+**Drag-drop:** The chat input area accepts drag-drop of image files. A subtle dashed border highlight (using `--border` color) appears on dragover. Drop adds images to pending attachments.
+
+**File picker:** Clicking the attachment button opens a native file dialog (via Tauri `dialog.open()`) filtered to image types (JPEG, PNG, GIF, WebP).
+
+**States:**
+- **No attachments:** Button visible (if vision-capable), strip hidden
+- **With attachments:** Strip visible with thumbnails, badge count on button
+- **Sending:** Thumbnails show a subtle opacity reduction during upload
+- **Non-vision model:** Button hidden, paste handler rejects images with toast: "Current model doesn't support images"
+
+### Sent Message Display
+
+After sending, user messages with attachments show inline thumbnail previews above the message text. Thumbnails are 120px max-width, rounded corners, clickable to open full-size in a modal or native preview.
+
+### Editor Context Menu
+
+Image and Drawing nodes gain a context menu item: "Send to AI" (with a `MessageSquare` icon). Disabled if no vision-capable provider is active. Clicking opens/focuses the chat panel and adds the image to pending attachments.
+
+### Design System Compliance
+
+- All colors from CSS variables (no hardcoded values)
+- Thumbnails use `border-radius: var(--radius)` (6px)
+- Remove button: `text-muted-foreground` on hover, 150ms transition
+- Drag-drop highlight: `border: 1px dashed var(--border)` with `bg-muted/50` overlay
+- Dark mode: thumbnails on `bg-muted` background, no bright borders
+- Attachment button: same style as existing chat footer controls (muted, 16px icon)
+
+## Data Model
+
+### TypeScript (Frontend)
+
+```typescript
+// src/lib/ai/types.ts — new type
+export interface ImageAttachment {
+  /** Unique ID for React keys and removal */
+  id: string;
+  /** Base64-encoded image data (after compression) */
+  data: string;
+  /** MIME type: "image/jpeg" | "image/png" | "image/gif" | "image/webp" */
+  mimeType: string;
+  /** Display width in pixels (post-compression) */
+  width: number;
+  /** Display height in pixels (post-compression) */
+  height: number;
+  /** Original filename if from file picker/drop, undefined if from paste */
+  name?: string;
+  /** Base64 byte size (for UI display, e.g. "340 KB") */
+  size: number;
+}
+
+// src/lib/ai/types.ts — extend existing ChatMessage
+export interface ChatMessage {
+  // ... all existing fields unchanged ...
+  /** Image attachments on this message */
+  attachments?: ImageAttachment[];
+}
+```
+
+### Rust (Backend)
+
+```rust
+// src-tauri/src/commands/ai.rs — new struct
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct ImageData {
+    pub data: String,       // base64-encoded
+    pub mime_type: String,  // "image/jpeg", "image/png", etc.
+}
+
+// src-tauri/src/commands/ai.rs — extend existing ChatMessage
+pub struct ChatMessage {
+    pub role: String,
+    pub content: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_calls: Option<Vec<ToolCall>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub images: Option<Vec<ImageData>>,  // NEW
+}
+```
+
+### ACP State Extension
+
+```rust
+// src-tauri/src/commands/acp.rs — extend AcpInstance or AcpState
+pub struct AcpInstance {
+    // ... existing fields ...
+    pub supports_images: bool,  // NEW — from promptCapabilities.image
+}
+```
+
+### Tauri Command Changes
+
+```rust
+// acp_session_prompt — add images parameter
+pub async fn acp_session_prompt(
+    state: State<'_, AcpState>,
+    instance_id: String,
+    session_id: String,
+    content: String,
+    images: Option<Vec<ImageData>>,  // NEW
+) -> Result<(), String>
+```
+
+### New Utility
+
+```typescript
+// src/lib/image-compress.ts
+export async function compressImage(
+  source: File | Blob | string,  // File, Blob, or base64 string
+  options?: { maxDimension?: number; quality?: number; maxBytes?: number }
+): Promise<ImageAttachment>
+
+export function supportsVision(connection: Connection, localModel?: ModelCatalogEntry): boolean
+```
+
+### Store Changes
+
+The `chat-store` `ChatMessage` type gains the `attachments` field. Zustand persist handles this via optional field — old conversations without `attachments` continue to work. No migration needed.
+
+`ChatInput.onSend` signature changes from `(message: string) => void` to `(message: string, attachments?: ImageAttachment[]) => void`.
+
+## Dependencies
+
+**No new npm or Cargo dependencies required.**
+
+- Image compression uses native `HTMLCanvasElement` / `canvas.toBlob()` — no library needed
+- ACP image support uses existing `agent-client-protocol` crate's `ImageContent` type
+- File picker uses existing Tauri `dialog` plugin
+- All provider APIs already support images — this is a client-side feature
+
+## Quality Gates
+
+### Functional
+
+- [ ] Paste image from clipboard into chat input shows thumbnail preview
+- [ ] Drag image file onto chat input shows thumbnail preview
+- [ ] Click attachment button opens native file dialog filtered to images
+- [ ] Removing a thumbnail from the strip works (X button)
+- [ ] Sending a message with image(s) works with Anthropic provider
+- [ ] Sending a message with image(s) works with OpenAI provider
+- [ ] Sending a message with image(s) works with Ollama (vision model)
+- [ ] Sending a message with image(s) works with local bundled (vision model)
+- [ ] Sending a message with image(s) works via ACP (any agent)
+- [ ] Images > 1568px longest edge are resized before sending
+- [ ] Images > 5 MB after compression are re-compressed at lower quality
+- [ ] Attachment button is hidden when active model doesn't support vision
+- [ ] Pasting an image with a non-vision model shows "doesn't support images" toast
+- [ ] Switching from vision to non-vision model with pending attachments clears them with toast
+- [ ] Right-click image in editor shows "Send to AI" context menu item
+- [ ] Right-click drawing in editor shows "Send to AI" context menu item
+- [ ] Sent messages display inline image thumbnails
+- [ ] Image attachments persist in chat history (Zustand persist)
+- [ ] Old conversations without attachments render correctly (backward compat)
+- [ ] Maximum 5 images per message enforced
+
+### Design
+
+- [ ] Attachment strip thumbnails are 48x48px rounded, consistent spacing
+- [ ] Thumbnail remove button only visible on hover with 150ms transition
+- [ ] Drag-drop highlight uses dashed border, no chromatic colors
+- [ ] All colors from CSS variables, works in light and dark mode
+- [ ] Attachment button matches existing chat footer control styling
+- [ ] Sent message thumbnails are max 120px wide, rounded, clickable
+- [ ] No layout shift when attaching/removing images
+
+### Testing
+
+- [ ] Unit test: `compressImage` resizes to max dimension
+- [ ] Unit test: `compressImage` converts PNG without transparency to JPEG
+- [ ] Unit test: `compressImage` preserves PNG with transparency
+- [ ] Unit test: `supportsVision` returns correct value for each provider type
+- [ ] Unit test: Provider serializers produce correct wire format (Anthropic, OpenAI, Ollama, ACP)
+- [ ] Unit test: ChatMessage with attachments round-trips through Zustand persist
+- [ ] Rust test: `ChatMessage` with images serializes correctly for each provider
+- [ ] Rust test: `acp_session_prompt` builds correct `ContentBlock::Image` blocks
+
+## Out of Scope
+
+- **Audio attachments** — ACP supports it but requires separate UX (record button, playback)
+- **Anthropic Files API** — upload-once optimization for multi-turn cost reduction; Phase 2
+- **Multi-turn image carry-forward** — images only on the turn they're attached; no auto re-send
+- **Image generation** — generating images from AI responses
+- **Screenshot capture tool** — built-in screen capture like ChatGPT Desktop
+- **Image editing** — crop, annotate, or markup before sending
+- **Video attachments** — not supported by any provider API
+- **Inline image output from AI** — AI-generated images displayed in chat
+- **Comment delegation with images** — attaching images when delegating comments to agents

--- a/docs/research/2026-04-03-image-attachments.md
+++ b/docs/research/2026-04-03-image-attachments.md
@@ -132,22 +132,80 @@ OpenAI-compatible `image_url` format via `/v1/chat/completions`:
 
 ### ACP (Agent Client Protocol)
 
-First-class `ImageContent` content block:
+The ACP spec defines a `ContentBlock` enum with five variants (reuses MCP's structure):
+
+```
+ContentBlock::Text(TextContent)          -- always supported (baseline)
+ContentBlock::Image(ImageContent)        -- requires `image` prompt capability
+ContentBlock::Audio(AudioContent)        -- requires `audio` prompt capability
+ContentBlock::Resource(EmbeddedResource) -- requires `embeddedContext` prompt capability
+ContentBlock::ResourceLink(ResourceLink) -- always supported (baseline)
+```
+
+`ImageContent` uses base64 inline (not file references or URLs):
+
+```rust
+pub struct ImageContent {
+    pub annotations: Option<Annotations>,
+    pub data: Base64Bytes,       // base64-encoded image data
+    pub mime_type: String,       // e.g. "image/png", "image/jpeg"
+    pub type_: String,           // discriminator, always "image"
+}
+```
+
+JSON wire format:
 
 ```json
 {
   "type": "image",
-  "data": "<base64-encoded-string>",
   "mimeType": "image/png",
-  "uri": "optional-reference-uri",
-  "annotations": {}
+  "data": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB..."
 }
 ```
 
-**Key details:**
-- Agents advertise image support via `promptCapabilities.image: true` during initialization
-- Also supports `AudioContent` (`type: "audio"`) and `ResourceLink` / `EmbeddedResource`
-- Content blocks are ordered — images can be interleaved with text
+**Capability negotiation:** During `initialize`, agents declare supported content types:
+
+```json
+{
+  "promptCapabilities": {
+    "image": true,
+    "audio": true,
+    "embeddedContext": true
+  }
+}
+```
+
+Clients MUST check these before including non-text content blocks.
+
+**Per-agent support status:**
+
+| Agent | Image support? | Notes |
+|---|---|---|
+| `claude-agent-acp` | Yes | Claude models are vision-capable; changelog mentions "fix for image output from tool calls" |
+| `codex-acp` | Yes | Codex CLI supports `--image` flag; uses vision-enabled models |
+| `copilot --acp` | Yes | ACP server explicitly supports "prompts with text, images, and context resources" |
+| `gemini --acp` | Yes | Initialize response confirms `promptCapabilities: { image: true, audio: true, embeddedContext: true }` |
+
+**Current gap in Notesage:** `acp_session_prompt` in `src-tauri/src/commands/acp.rs` only sends `ContentBlock::Text`:
+
+```rust
+// line ~637
+vec![ContentBlock::Text(TextContent::new(content))],
+```
+
+The command takes a plain `content: String`. The `promptCapabilities` from the initialize response are not inspected or stored. The Rust crate already in use (`agent-client-protocol = 0.10.4`, `agent-client-protocol-schema = 0.11.4`) includes `ImageContent` and the full `ContentBlock` enum — no dependency changes needed.
+
+**To send images via ACP:**
+
+```rust
+let blocks = vec![
+    ContentBlock::Text(TextContent::new(text)),
+    ContentBlock::Image(ImageContent::new(base64_data, "image/png")),
+];
+let req = PromptRequest::new(SessionId::new(sid), blocks);
+```
+
+Sources: [ACP Content Docs](https://agentclientprotocol.com/protocol/content), [ACP Initialization](https://agentclientprotocol.com/protocol/initialization), [ContentBlock enum on docs.rs](https://docs.rs/agent-client-protocol/latest/agent_client_protocol/enum.ContentBlock.html), [Copilot CLI ACP docs](https://docs.github.com/en/copilot/reference/copilot-cli-reference/acp-server), [Gemini CLI ACP mode](https://geminicli.com/docs/cli/acp-mode/)
 
 ### Format Summary Table
 

--- a/docs/research/2026-04-03-image-attachments.md
+++ b/docs/research/2026-04-03-image-attachments.md
@@ -1,0 +1,380 @@
+# Research: Image Attachments for Multi-Modal AI Chat
+
+**Date:** 2026-04-03
+**Status:** Research complete
+**Purpose:** Understand how image attachments should work across Notesage's four AI paths (Direct API, ACP, Copilot LSP, Local Bundled) by surveying API formats, competitor UX, and implementation patterns.
+
+---
+
+## 1. API Message Formats by Provider
+
+Each provider uses a different wire format for images in chat messages. Notesage must serialize images differently per provider.
+
+### Anthropic (Claude)
+
+Content array with `type: "image"` blocks. Three source types:
+
+```json
+// Base64 (most common for desktop apps)
+{
+  "type": "image",
+  "source": {
+    "type": "base64",
+    "media_type": "image/jpeg",
+    "data": "<base64-encoded-string>"
+  }
+}
+
+// URL (for publicly accessible images)
+{
+  "type": "image",
+  "source": {
+    "type": "url",
+    "url": "https://example.com/image.jpg"
+  }
+}
+
+// Files API (upload once, reference by ID — avoids re-sending on every turn)
+{
+  "type": "image",
+  "source": {
+    "type": "file",
+    "file_id": "file_abc123"
+  }
+}
+```
+
+**Constraints:**
+- Formats: JPEG, PNG, GIF, WebP
+- Max 5 MB per image (API), 10 MB (claude.ai)
+- Max 8000x8000 px (single), 2000x2000 px (when >20 images)
+- Up to 600 images per request (100 for 200k-token models)
+- 32 MB total request size limit
+- Server-side resize if long edge >1568 px
+- Token cost: `(width * height) / 750`
+- Images should be placed **before** text in the content array for best results
+- Base64 images re-sent every turn in multi-turn conversations (Files API avoids this)
+
+### OpenAI (GPT-4o)
+
+Content array with `type: "image_url"` blocks. Base64 encoded as data URIs:
+
+```json
+// URL
+{
+  "type": "image_url",
+  "image_url": {
+    "url": "https://example.com/image.jpg",
+    "detail": "high"
+  }
+}
+
+// Base64 (embedded as data URI)
+{
+  "type": "image_url",
+  "image_url": {
+    "url": "data:image/jpeg;base64,<base64-encoded-string>",
+    "detail": "auto"
+  }
+}
+```
+
+**Constraints:**
+- Formats: JPEG, PNG, GIF, WebP
+- `detail` parameter: `"low"` (fixed 85 tokens), `"high"` (variable by tile count), `"auto"` (model decides)
+- Low detail: resized to 512x512
+- High detail: scaled so shortest side = 768px, split into 512x512 tiles; cost = 85 + (170 * tiles) tokens
+- Max 20 MB per image
+
+### Ollama
+
+**Native `/api/chat`** — `images` array on the message itself (not in a content array):
+
+```json
+{
+  "role": "user",
+  "content": "Describe this image",
+  "images": ["<base64-encoded-string>"]
+}
+```
+
+**OpenAI-compatible `/v1/chat/completions`** — also accepts the OpenAI `image_url` format with data URIs.
+
+**Constraints:**
+- Base64-only (no URL support in native REST API)
+- Formats: JPEG, PNG, WebP
+- Requires multimodal model (llava, SmolVLM, etc.)
+
+### llama-server (Local Bundled)
+
+OpenAI-compatible `image_url` format via `/v1/chat/completions`:
+
+```json
+{
+  "role": "user",
+  "content": [
+    {"type": "text", "text": "describe what you see"},
+    {
+      "type": "image_url",
+      "image_url": {
+        "url": "data:image/png;base64,<base64>"
+      }
+    }
+  ]
+}
+```
+
+**Constraints:**
+- Supports base64 data URIs and remote URLs
+- Multimodal is "experimental" — requires vision projector (`--mmproj` or auto-detected via `-hf`)
+- Supported families: Gemma 3, Qwen 2/2.5 VL, SmolVLM, Pixtral, InternVL, Llama 4 Scout, Moondream2
+- Same wire format as OpenAI — serialization code can be shared
+
+### ACP (Agent Client Protocol)
+
+First-class `ImageContent` content block:
+
+```json
+{
+  "type": "image",
+  "data": "<base64-encoded-string>",
+  "mimeType": "image/png",
+  "uri": "optional-reference-uri",
+  "annotations": {}
+}
+```
+
+**Key details:**
+- Agents advertise image support via `promptCapabilities.image: true` during initialization
+- Also supports `AudioContent` (`type: "audio"`) and `ResourceLink` / `EmbeddedResource`
+- Content blocks are ordered — images can be interleaved with text
+
+### Format Summary Table
+
+| Provider | Content Type | Base64 Format | URL Support | Image Location |
+|---|---|---|---|---|
+| Anthropic | `"type": "image"` | `source.data` | `source.url` | `content[]` array |
+| OpenAI | `"type": "image_url"` | data URI in `image_url.url` | direct URL | `content[]` array |
+| Ollama (native) | N/A | `images: [base64]` | No | Message object |
+| Ollama (OAI compat) | `"type": "image_url"` | Same as OpenAI | Same as OpenAI | `content[]` array |
+| llama-server | `"type": "image_url"` | Same as OpenAI | Same as OpenAI | `content[]` array |
+| ACP | `"type": "image"` | `data` + `mimeType` | `uri` optional | Prompt content blocks |
+
+---
+
+## 2. Chat UI Patterns from Competitor Tools
+
+### Input Methods
+
+| Method | Tools |
+|--------|-------|
+| **Clipboard paste** (Cmd/Ctrl+V) | Claude desktop, ChatGPT, Copilot Chat, Cline, Cursor, Windsurf |
+| **Drag and drop** from OS | Claude desktop, ChatGPT, Copilot Chat, Cursor, Windsurf |
+| **File picker button** (paperclip icon) | Claude desktop, ChatGPT, all IDE tools |
+| **Screenshot capture** (built-in) | Copilot Chat in VS Code ("Attach > Screenshot Window") |
+
+**Clipboard paste is the most common interaction** — every tool supports it. Drag-and-drop is second. File picker is always available as a fallback. Screenshot capture is rare (only VS Code Copilot).
+
+### Display Patterns
+
+- **Before sending:** Small thumbnail appears in/near the chat input area. Click to enlarge or remove (X button on thumbnail).
+- **After sending:** Image displays inline within the user message bubble at a readable preview size.
+- **Non-image files:** Shown as a filename chip/badge rather than a preview (Cursor pattern).
+
+### Provider Incompatibility Handling
+
+This is a critical UX question — what happens when the selected model doesn't support images?
+
+| Tool | Approach |
+|------|----------|
+| **Cline** | Only shows image option for multimodal models (GPT-4o, Claude, Gemini). Silently hidden otherwise. |
+| **Continue.dev** | Model capabilities in config with `image_input` flag. Non-vision models don't get attachment UI. |
+| **Copilot Chat** | Image attachment gated behind GPT-4o model selection. |
+| **Common pattern** | **Conditionally show/hide the attachment button** based on active model's vision capability. |
+
+**Consensus:** Hide/disable the attachment UI for non-vision models. Don't let users attach images they can't send.
+
+### Size Limits & Compression
+
+| Aspect | Common Practice |
+|--------|----------------|
+| **Client-side compression** | `canvas.toDataURL('image/jpeg', 0.8)` — JPEG at 80% quality |
+| **Resolution downsizing** | Max 1568px on longest edge (Anthropic's optimal) or 2048px |
+| **Provider limits** | Anthropic: 5 MB; OpenAI: 20 MB |
+| **Image count** | VS Code Copilot limits to 3 images per prompt |
+| **Auto-compress** | Claude Code auto-compresses images over 5 MB |
+
+**Recommendation:** Resize to 1568px longest edge + JPEG 80% quality before base64 encoding. This satisfies Anthropic's 5 MB limit (the most restrictive) while preserving visual quality.
+
+---
+
+## 3. Editor-to-Chat Image Flow
+
+**No tool currently has a "click image in document, send to AI" flow.** The universal pattern is always:
+
+1. User manually copies/screenshots/drags the image
+2. Pastes/drops into chat input
+3. Thumbnail preview shown
+4. On send, base64-encoded in API request
+
+### Existing approaches
+
+- **Windsurf:** Users paste screenshots of their website/UI into Cascade chat for code generation. Always manual.
+- **Copilot Chat "Screenshot Window":** Captures the VS Code window contents as an attachment. Closest to editor-to-chat.
+- **Cursor:** Drag files from explorer into chat. No "send image from document" action.
+- **Claude Code Desktop:** Attachment button, drag-and-drop, clipboard paste.
+
+### Differentiation opportunity for Notesage
+
+Notesage already has images and drawings embedded in documents (Image extension, Excalidraw Drawing extension). A unique feature would be:
+
+- Right-click image in editor -> "Send to AI" / "Ask AI about this image"
+- Bubble menu on image selection with AI actions
+- Auto-include document images as context when user references them in chat
+
+---
+
+## 4. Key Architecture Decisions
+
+### A. Capability Detection Layer
+
+Each AI path needs vision capability checking:
+
+| Path | How to detect vision support |
+|------|------------------------------|
+| **Direct API (Anthropic/OpenAI)** | Always supported (Claude 3+, GPT-4o+). Could be model-gated. |
+| **Direct API (Ollama)** | Query `/api/show` for multimodal tag (similar to existing thinking detection) |
+| **ACP** | Check `promptCapabilities.image` from agent initialization |
+| **Local bundled** | Check `supports_vision` flag in `model-catalog.json` |
+| **Copilot LSP** | Not applicable (completions only, no chat) |
+
+### B. Internal Image Representation
+
+Store images internally in a provider-agnostic format, then serialize per-provider at send time:
+
+```typescript
+interface ImageAttachment {
+  data: string;       // base64-encoded
+  mimeType: string;   // "image/jpeg" | "image/png" | "image/gif" | "image/webp"
+  width?: number;     // original width (for display)
+  height?: number;    // original height (for display)
+  name?: string;      // optional filename
+}
+```
+
+Provider serializers convert this to the appropriate wire format:
+- **Anthropic** -> `{ type: "image", source: { type: "base64", media_type, data } }`
+- **OpenAI** -> `{ type: "image_url", image_url: { url: "data:${mime};base64,${data}" } }`
+- **Ollama native** -> `images: [data]` on the message object
+- **ACP** -> `{ type: "image", data, mimeType }`
+
+### C. ChatMessage Model Change
+
+Currently `ChatMessage.content` is a `string`. Options:
+
+1. **New `attachments` field** (recommended — simpler, backward compatible):
+   ```typescript
+   interface ChatMessage {
+     role: string;
+     content: string;
+     attachments?: ImageAttachment[];  // NEW
+     // ... existing fields
+   }
+   ```
+   Provider serializers merge `content` + `attachments` into the provider-specific content array format at send time. Zustand persist handles it naturally. Old messages without `attachments` work unchanged.
+
+2. **Change `content` to union type** (matches API shape but invasive):
+   ```typescript
+   content: string | ContentBlock[];
+   ```
+   Requires updating every place that reads `content` as a string. High risk, low reward.
+
+**Pattern from Cline/Continue:** They use a separate `images` or `attachments` array alongside text content, and the provider serializer merges them. This is the recommended approach.
+
+### D. Image Compression Pipeline
+
+Before base64 encoding, process images client-side:
+
+1. Load into an `HTMLCanvasElement` or `OffscreenCanvas`
+2. If PNG with no transparency needed, convert to JPEG
+3. Resize so longest edge <= 1568px (Anthropic's optimal; anything larger is resized server-side anyway)
+4. Export as JPEG at 80% quality (or keep PNG if transparency is needed)
+5. Validate resulting base64 is < 5 MB (Anthropic's limit, the most restrictive)
+6. If still too large, reduce quality to 60% and retry
+
+This can be done entirely in the frontend with `canvas.toBlob()` / `canvas.toDataURL()`.
+
+### E. Rust Backend Changes
+
+The `ai_chat_stream` Tauri command currently takes `messages: Vec<ChatMessage>` where `ChatMessage.content` is a `String`. To support images:
+
+- Add `images: Option<Vec<ImageData>>` field to `ChatMessage` struct in `ai.rs`
+- Each provider's request builder merges text + images into the correct format
+- For ACP: images passed as `ImageContent` blocks in the prompt
+- For Ollama native: images placed in the `images` array on the JSON message
+
+```rust
+#[derive(Serialize, Deserialize)]
+pub struct ImageData {
+    pub data: String,      // base64
+    pub mime_type: String,  // "image/jpeg", etc.
+}
+```
+
+### F. Recommended Input Methods (priority order)
+
+1. **Clipboard paste** into chat input (Cmd+V) — highest ROI, most used pattern
+2. **Drag and drop** onto chat input area
+3. **Paperclip/attachment button** with native file picker dialog
+4. **Right-click image in editor -> "Ask AI"** — Notesage differentiator
+5. **Screenshot capture** — future enhancement
+
+### G. UI When Model Doesn't Support Images
+
+- **Hide/disable** the attachment button and paste handler when active model lacks vision
+- If user switches from a vision model to non-vision with pending attachments, show toast: "Images removed — current model doesn't support images"
+- Attachment button tooltip: "Attach image (requires vision model)"
+
+---
+
+## 5. Multi-Turn Image Handling
+
+A critical cost consideration: **base64 images are re-sent on every API turn** in multi-turn conversations.
+
+### The problem
+
+A 1568x1568 JPEG at 80% quality is ~200-400 KB base64. In a 10-turn conversation with 2 images, that's 4-8 MB re-sent per turn. This is:
+- Expensive (token cost: ~3,280 tokens per 1568x1568 image on Anthropic)
+- Slow (large request payloads)
+
+### How others handle it
+
+- **Anthropic Files API:** Upload once, reference by `file_id`. Avoids re-sending. Not yet widely adopted by third-party tools.
+- **Claude Code:** Currently re-sends images every turn (known pain point, issue #20738).
+- **ChatGPT:** Re-sends images every turn (standard behavior).
+- **Most tools:** Accept the cost and re-send.
+
+### Recommendation for Notesage
+
+- **Phase 1:** Re-send images on every turn (matches industry standard, simpler to implement)
+- **Phase 2:** Consider Anthropic Files API for heavy image use cases
+- **Optimization:** Only include images from the turn they were attached (don't carry forward to subsequent turns unless the user explicitly re-attaches)
+
+---
+
+## 6. Sources
+
+- [Anthropic Vision API](https://docs.anthropic.com/en/docs/build-with-claude/vision)
+- [OpenAI Vision API](https://platform.openai.com/docs/guides/vision)
+- [Ollama API Reference](https://github.com/ollama/ollama/blob/main/docs/api.md)
+- [llama.cpp Multimodal Docs](https://github.com/ggml-org/llama.cpp/blob/master/docs/multimodal.md)
+- [llama.cpp Server README](https://github.com/ggml-org/llama.cpp/blob/master/tools/server/README.md)
+- [Agent Client Protocol GitHub](https://github.com/agentclientprotocol/agent-client-protocol)
+- [ACP Intro (Goose)](https://block.github.io/goose/blog/2025/10/24/intro-to-agent-client-protocol-acp/)
+- [ACP Docs (Kiro)](https://kiro.dev/docs/cli/acp/)
+- [Copilot Chat Vision (VS Code)](https://github.blog/changelog/2025-03-05-copilot-chat-users-can-now-use-the-vision-input-in-vs-code-and-visual-studio-public-preview/)
+- [Cline Image Support](https://github.com/cline/cline/issues/7743)
+- [Continue.dev Model Capabilities](https://docs.continue.dev/customize/deep-dives/model-capabilities)
+- [Claude Code Image Guide](https://smartscope.blog/en/generative-ai/claude/claude-code-image-guide/)
+- [llama.cpp Vision (Simon Willison)](https://simonwillison.net/2025/May/10/llama-cpp-vision/)
+- [Windsurf vs Cursor](https://www.builder.io/blog/windsurf-vs-cursor)

--- a/docs/research/2026-04-03-image-attachments.md
+++ b/docs/research/2026-04-03-image-attachments.md
@@ -1,7 +1,12 @@
 # Research: Image Attachments for Multi-Modal AI Chat
 
-**Date:** 2026-04-03
-**Status:** Research complete
+**Date:** 2026-04-03 **Status:** Research complete
+
+| Stage | Link | Status |
+| --- | --- | --- |
+| PRD | [image-attachments](../prds/2026-04-04-image-attachments.md) | Draft |
+| Tasks | --- | Not planned |
+
 **Purpose:** Understand how image attachments should work across Notesage's four AI paths (Direct API, ACP, Copilot LSP, Local Bundled) by surveying API formats, competitor UX, and implementation patterns.
 
 ---

--- a/docs/research/2026-04-03-image-attachments.md
+++ b/docs/research/2026-04-03-image-attachments.md
@@ -222,47 +222,69 @@ Sources: [ACP Content Docs](https://agentclientprotocol.com/protocol/content), [
 
 ## 2. Chat UI Patterns from Competitor Tools
 
-### Input Methods
+### Per-Tool Breakdown
 
-| Method | Tools |
-|--------|-------|
-| **Clipboard paste** (Cmd/Ctrl+V) | Claude desktop, ChatGPT, Copilot Chat, Cline, Cursor, Windsurf |
-| **Drag and drop** from OS | Claude desktop, ChatGPT, Copilot Chat, Cursor, Windsurf |
-| **File picker button** (paperclip icon) | Claude desktop, ChatGPT, all IDE tools |
-| **Screenshot capture** (built-in) | Copilot Chat in VS Code ("Attach > Screenshot Window") |
+**Cursor IDE:**
+- Input: Drag-drop (since v0.17.0), Ctrl+V paste in chat (not in Composer), file picker (inconsistent — [issue #2776](https://github.com/cursor/cursor/issues/2776))
+- Display: Originally inline thumbnails, switched to compact file tag chips in v0.40+
+- Non-vision: Explicit error "Trying to submit images without a vision-enabled model selected" — blocks send. Error persists in session even after switching models; must start new chat.
+- No client-side resize — users hit "Image base64 size exceeds API limit (5.0 MB)" and must manually resize
+- Images can get "stuck" in session state and re-sent with every subsequent API call
 
-**Clipboard paste is the most common interaction** — every tool supports it. Drag-and-drop is second. File picker is always available as a fallback. Screenshot capture is rare (only VS Code Copilot).
+**Continue.dev:**
+- Input: Cmd/Ctrl+V paste, Shift+drag-drop ([PR #7408](https://github.com/continuedev/continue/pull/7408) fixed overlay bug)
+- Display: Inline thumbnails in chat input
+- Non-vision: `image_input` capability auto-detected per provider/model in `core/llm/autodetect.ts` (`PROVIDER_SUPPORTS_IMAGES` array). UI disables attachment for non-vision models. Users can manually override in `config.yaml`.
+- No client-side compression
 
-### Display Patterns
+**Cline (Claude Dev):**
+- Input: Cmd/Ctrl+V paste, Shift+drag-drop, "Add Files & Images" button. Known issues on Linux Wayland ([#5016](https://github.com/cline/cline/issues/5016)) and SSH remotes ([#7606](https://github.com/cline/cline/issues/7606)). File dialog filter missing image extensions in v3.38.3 ([#7743](https://github.com/cline/cline/issues/7743)).
+- Display: Inline thumbnails before and after sending
+- Non-vision: `supportsImages` flag on model config gates UI. PRs [#8684](https://github.com/cline/cline/pull/8684) and [#9780](https://github.com/cline/cline/pull/9780) fixed bugs where paste/drag-drop bypassed the toggle.
+- No client-side resize; [issue #675](https://github.com/cline/cline/issues/675) requested 2000px dimension cap
 
-- **Before sending:** Small thumbnail appears in/near the chat input area. Click to enlarge or remove (X button on thumbnail).
-- **After sending:** Image displays inline within the user message bubble at a readable preview size.
-- **Non-image files:** Shown as a filename chip/badge rather than a preview (Cursor pattern).
+**Windsurf (Codeium):**
+- Input: Drag-drop from OS (not from Windsurf's own explorer), clipboard paste, "Add image" button
+- Display: Inline previews; positioned for "Image-to-Code" workflows (Figma screenshot → HTML/CSS)
+- Non-vision: Only available for GPT-4o and Claude 3.5 Sonnet. API error breaks session history with non-vision models.
+- Originally 1 MB limit (now lifted)
 
-### Provider Incompatibility Handling
+**Claude Desktop & Claude Code:**
+- Input: Paperclip button, drag-drop, Cmd+V paste. Claude Code uses Ctrl+V (not Cmd+V on macOS — known UX issue)
+- Display: Inline thumbnail previews, expandable
+- Size: 5 MB API limit / 30 MB on claude.ai. Server-side downscale if >1568px longest edge. Claude Code does NOT auto-resize ([feature request #20738](https://github.com/anthropics/claude-code/issues/20738))
+- Token cost: `(width * height) / 750` — ~1,600 tokens for typical image
 
-This is a critical UX question — what happens when the selected model doesn't support images?
+**ChatGPT Desktop:**
+- Input: + button menu → "Upload file", drag-drop (broken on Windows 11), Cmd/Ctrl+V paste, **built-in screenshot tool** (unique — shows open windows, searchable), webcam capture
+- Display: Inline thumbnails, clickable to expand
+- Size: 20 MB per image. Free tier: 2 images/day; Plus: 50/day
+- Server-side `detail` processing: `low` = 512x512 at 85 tokens, `high` = 768px shortest side then 512x512 tiles
 
-| Tool | Approach |
-|------|----------|
-| **Cline** | Only shows image option for multimodal models (GPT-4o, Claude, Gemini). Silently hidden otherwise. |
-| **Continue.dev** | Model capabilities in config with `image_input` flag. Non-vision models don't get attachment UI. |
-| **Copilot Chat** | Image attachment gated behind GPT-4o model selection. |
-| **Common pattern** | **Conditionally show/hide the attachment button** based on active model's vision capability. |
+### Summary Comparison Table
 
-**Consensus:** Hide/disable the attachment UI for non-vision models. Don't let users attach images they can't send.
+| Feature | Cursor | Continue.dev | Cline | Windsurf | Claude Desktop | ChatGPT Desktop |
+|---|---|---|---|---|---|---|
+| **Paste** | Ctrl+V in chat only | Cmd/Ctrl+V | Cmd/Ctrl+V | Yes | Yes | Yes |
+| **Drag-drop** | Yes | Shift+drag | Shift+drag | OS only | Yes | Yes (broken Win11) |
+| **File picker** | Inconsistent | Not prominent | "Add Files & Images" | "Add image" button | Paperclip | + button menu |
+| **Screenshot** | No (3rd-party ext) | No | No | No | No | **Built-in tool** |
+| **Preview display** | File tag chip (v0.40+) | Inline thumbnail | Inline thumbnail | Inline preview | Inline thumbnail | Inline thumbnail |
+| **Non-vision handling** | Error, blocks send | UI disables attach | `supportsImages` gates UI | API error, breaks session | N/A (all support) | Model-gated |
+| **Client-side resize** | No | No | No | No | No | No |
+| **Size limit** | Provider-dependent | Provider-dependent | Provider-dependent | Was 1MB, now lifted | 5MB API / 30MB web | 20MB |
 
-### Size Limits & Compression
+### Key Patterns
 
-| Aspect | Common Practice |
-|--------|----------------|
-| **Client-side compression** | `canvas.toDataURL('image/jpeg', 0.8)` — JPEG at 80% quality |
-| **Resolution downsizing** | Max 1568px on longest edge (Anthropic's optimal) or 2048px |
-| **Provider limits** | Anthropic: 5 MB; OpenAI: 20 MB |
-| **Image count** | VS Code Copilot limits to 3 images per prompt |
-| **Auto-compress** | Claude Code auto-compresses images over 5 MB |
+**Input methods:** Clipboard paste is universal and highest priority. Drag-drop second. File picker as fallback.
 
-**Recommendation:** Resize to 1568px longest edge + JPEG 80% quality before base64 encoding. This satisfies Anthropic's 5 MB limit (the most restrictive) while preserving visual quality.
+**Display:** Inline thumbnails (before and after sending) is the standard. Cursor's v0.40 switch to compact file chips is the outlier.
+
+**Non-vision models:** The consensus is to **gate the attachment UI on model vision capability**. Tools that allow attaching images to non-vision models create broken session state. Best practice: hide/disable the button and reject pastes with a toast.
+
+**Client-side compression:** **No tool does it today** — but it's the #1 requested feature across Cursor, Cline, and Claude Code. This is a clear opportunity: pre-resize to 1568px longest edge + JPEG 80% would prevent the most common user error (5 MB API limit).
+
+**Recommendation:** Resize to 1568px longest edge + JPEG 80% quality before base64 encoding. This satisfies Anthropic's 5 MB limit (the most restrictive) while preserving visual quality. Notesage would be the first tool to do client-side compression automatically.
 
 ---
 

--- a/docs/research/2026-04-03-image-attachments.md
+++ b/docs/research/2026-04-03-image-attachments.md
@@ -5,7 +5,7 @@
 | Stage | Link | Status |
 | --- | --- | --- |
 | PRD | [image-attachments](../prds/2026-04-04-image-attachments.md) | Draft |
-| Tasks | --- | Not planned |
+| Tasks | [image-attachments-tasks](../tasks/2026-04-04-image-attachments-tasks.md) | Not started |
 
 **Purpose:** Understand how image attachments should work across Notesage's four AI paths (Direct API, ACP, Copilot LSP, Local Bundled) by surveying API formats, competitor UX, and implementation patterns.
 

--- a/docs/tasks/2026-04-04-image-attachments-tasks.md
+++ b/docs/tasks/2026-04-04-image-attachments-tasks.md
@@ -1,0 +1,346 @@
+# Tasks: Image Attachments for Multi-Modal AI Chat
+
+|  |  |
+| --- | --- |
+| **Date** | 2026-04-04 |
+| **Status** | Not started |
+| **PRD** | [image-attachments](../prds/2026-04-04-image-attachments.md) |
+| **Total** | 14 tasks: 4S, 6M, 4L |
+| **Suggested order** | Types (#1) -> Compression (#2) -> Vision detection (#3) -> Backend (#4-#7) -> Frontend state (#8) -> UI (#9-#12) -> Editor flow (#13) -> Tests (#14) |
+
+**Risks:**
+- Ollama vision detection depends on `/api/show` response shape — test with real multimodal models (llava, SmolVLM)
+- ACP `promptCapabilities` may not be exposed by all agent versions — graceful fallback to `false` needed
+- Canvas-based compression in Tauri's WKWebView may behave differently than Chromium — test JPEG quality output
+
+---
+
+## Task 1: Add ImageAttachment type and extend ChatMessage
+
+**Complexity:** S | **Category:** frontend | **Dependencies:** None
+
+**Description:** Add the `ImageAttachment` interface and the `attachments` optional field to `ChatMessage`. This is the foundation every other task depends on.
+
+**Files:**
+- `src/lib/ai/types.ts` — Add `ImageAttachment` interface (id, data, mimeType, width, height, name?, size). Add `attachments?: ImageAttachment[]` to `ChatMessage` (line ~131).
+
+**Acceptance criteria:**
+- `ImageAttachment` interface exported from `types.ts`
+- `ChatMessage.attachments` is optional — existing code unaffected
+- TypeScript compiles cleanly (`pnpm typecheck`)
+
+---
+
+## Task 2: Create image compression utility
+
+**Complexity:** M | **Category:** frontend | **Dependencies:** #1
+
+**Description:** Build `src/lib/image-compress.ts` with a `compressImage()` function that loads an image source (File, Blob, or base64 string), resizes to max 1568px longest edge, converts to JPEG 80% (or keeps PNG if transparent), validates <5 MB, and retries at 60% if too large. Returns an `ImageAttachment`.
+
+Also add a `hasTransparency()` helper that draws the image to a small canvas and checks for alpha < 255 pixels.
+
+**Files:**
+- `src/lib/image-compress.ts` — New file
+
+**Acceptance criteria:**
+- `compressImage(source, options?)` returns `Promise<ImageAttachment>`
+- Large images (>1568px) are resized proportionally
+- PNGs without transparency become JPEG
+- PNGs with transparency stay PNG
+- Result is always < 5 MB (retries at lower quality)
+- Works with File, Blob, and base64 string inputs
+
+---
+
+## Task 3: Create vision capability detection utility
+
+**Complexity:** S | **Category:** frontend | **Dependencies:** #1
+
+**Description:** Build a `supportsVision()` function that determines whether the active connection supports image input. This is used to show/hide the attachment UI.
+
+**Files:**
+- `src/lib/ai/vision.ts` — New file with `supportsVision(connection, ollamaModelInfo?, localModel?)` function
+
+**Logic:**
+- `anthropic` → always `true`
+- `openai` → always `true`
+- `openai_compatible` → always `true` (can't reliably detect; assume capable)
+- `ollama` → check for multimodal capability from `/api/show` response (extend existing pattern in `ai_streaming.rs` — but this is a frontend utility, so check a stored model info object, not a live API call)
+- `local_bundled` → check `supports_vision` from model catalog entry (field already exists)
+- `agent_managed` (ACP) → check `supports_images` flag from stored ACP instance info (depends on #6)
+
+**Acceptance criteria:**
+- Returns `boolean`
+- Each provider path covered
+- Defaults to `false` for unknown providers
+
+---
+
+## Task 4: Add ImageData struct to Rust ChatMessage
+
+**Complexity:** S | **Category:** backend | **Dependencies:** None
+
+**Description:** Add the `ImageData` struct and an optional `images` field to the Rust `ChatMessage` in `ai.rs`. This lets the frontend pass image data through IPC.
+
+**Files:**
+- `src-tauri/src/commands/ai.rs` — Add `ImageData` struct after `ChatMessage` (line ~76). Add `images: Option<Vec<ImageData>>` field to `ChatMessage` with `#[serde(skip_serializing_if = "Option::is_none")]`.
+
+**Acceptance criteria:**
+- `ImageData { data: String, mime_type: String }` with Serialize, Deserialize, Clone, Debug
+- `ChatMessage.images` is `Option<Vec<ImageData>>`, skipped when None
+- Existing `ai_chat_stream` callers unaffected (None default)
+- `cargo test` passes
+
+---
+
+## Task 5: Implement provider-specific image serialization in Rust
+
+**Complexity:** L | **Category:** backend | **Dependencies:** #4
+
+**Description:** Modify each provider's streaming function to include images in the request body when `ChatMessage.images` is `Some`. Each provider has a different wire format.
+
+**Files:**
+- `src-tauri/src/commands/ai.rs` — Modify `anthropic_chat_stream`, `openai_chat_stream`, `ollama_chat_stream`, `openai_compatible_chat_stream`, `local_bundled_chat_stream`
+
+**Per-provider changes:**
+
+**Anthropic** (`anthropic_chat_stream`):
+- When building the message JSON, if `images` is present, convert `content` from a plain string to a `content[]` array with image blocks before text:
+  ```json
+  "content": [
+    { "type": "image", "source": { "type": "base64", "media_type": "image/jpeg", "data": "..." } },
+    { "type": "text", "text": "user message" }
+  ]
+  ```
+
+**OpenAI / OpenAI-compatible / Local bundled** (`openai_chat_stream`, `openai_compatible_chat_stream`, `local_bundled_chat_stream`):
+- When building the message JSON, if `images` is present, convert `content` from a plain string to a `content[]` array:
+  ```json
+  "content": [
+    { "type": "image_url", "image_url": { "url": "data:image/jpeg;base64,..." } },
+    { "type": "text", "text": "user message" }
+  ]
+  ```
+
+**Ollama native** (`ollama_chat_stream`):
+- Add `"images": ["<base64>", ...]` to the message JSON object alongside `content`.
+
+**Acceptance criteria:**
+- Images are serialized correctly per provider
+- Messages without images produce the same JSON as before (backward compat)
+- Text-only messages are unchanged (no content array wrapping when no images)
+
+---
+
+## Task 6: Store ACP promptCapabilities and send images via ACP
+
+**Complexity:** M | **Category:** backend | **Dependencies:** #4
+
+**Description:** Capture `promptCapabilities.image` from the ACP `initialize` response and store it on the agent instance. Extend `acp_session_prompt` to accept and forward images as `ContentBlock::Image`.
+
+**Files:**
+- `src-tauri/src/commands/acp.rs` — Modify `AgentHandle` or managed state to store `supports_images: bool`. Extract from initialize response (line ~428). Modify `acp_session_prompt` (line ~1153) to accept `images: Option<Vec<ImageData>>` parameter. Build `ContentBlock::Image(ImageContent::new(data, mime))` blocks when images are provided.
+- `src-tauri/src/commands/acp_client.rs` — If `promptCapabilities` is available on the init response type, extract it. If not in the current crate version, default to `false`.
+
+**Acceptance criteria:**
+- `supports_images` stored per ACP agent instance after `initialize`
+- `acp_session_prompt` accepts optional images parameter
+- Images are sent as `ContentBlock::Image` before `ContentBlock::Text`
+- Agents without image support still work (text-only fallback)
+- New Tauri command `acp_supports_images(instance_id)` → `bool` so frontend can query
+
+---
+
+## Task 7: Expose ACP vision capability to frontend
+
+**Complexity:** S | **Category:** both | **Dependencies:** #6
+
+**Description:** Add a Tauri command to query whether an ACP agent supports images, and wire it into the frontend vision detection.
+
+**Files:**
+- `src-tauri/src/commands/acp.rs` — Add `acp_supports_images(instance_id: String) -> Result<bool, String>` command
+- `src-tauri/src/lib.rs` — Register the new command in `generate_handler![]`
+- `src/lib/tauri.ts` — Add `acpSupportsImages(instanceId: string): Promise<boolean>` wrapper
+- `src/lib/ai/vision.ts` — Wire `agent_managed` path to call the new command (or accept a pre-fetched boolean)
+
+**Acceptance criteria:**
+- Frontend can check `supportsVision()` for ACP connections
+- Returns `false` if agent not initialized or capability not declared
+
+---
+
+## Task 8: Thread attachments through chat flow
+
+**Complexity:** M | **Category:** frontend | **Dependencies:** #1, #4, #5, #6
+
+**Description:** Update the frontend chat flow so that `ImageAttachment[]` from `ChatInput` flows through to the Rust backend. This touches the `onSend` callback chain, message creation, store persistence, and the `invoke` calls.
+
+**Files:**
+- `src/components/chat/ChatInput.tsx` — Change `onSend` prop from `(message: string) => void` to `(message: string, attachments?: ImageAttachment[]) => void`
+- `src/components/chat/ChatPanel.tsx` — Update `onSend` handler to pass attachments through
+- `src/hooks/useDirectApiChat.ts` — Accept attachments in `sendChatMessage`, include on the user message object (line ~103), and pass `images` data in the `invoke('ai_chat_stream', ...)` call (line ~459). Map `ImageAttachment[]` to the `images` field format expected by Rust (`{ data, mime_type }`).
+- `src/hooks/useAcpLifecycle.ts` — Update the three `invoke('acp_session_prompt', ...)` call sites (lines ~244, ~400, ~559) to pass images when attachments are present
+- `src/lib/tauri.ts` — Update `acpSessionPrompt` wrapper to accept images parameter
+- `src/stores/chat-store.ts` — Verify `attachments` persists via Zustand (optional field, no migration needed)
+
+**Acceptance criteria:**
+- Attachments flow from ChatInput → ChatPanel → useDirectApiChat/useAcpLifecycle → Rust backend
+- Attachments stored on ChatMessage in chat-store (persisted)
+- Old messages without attachments continue to work
+- TypeScript compiles cleanly
+
+---
+
+## Task 9: Build attachment strip UI in ChatInput
+
+**Complexity:** L | **Category:** frontend | **Dependencies:** #1, #2, #3
+
+**Description:** Add the image attachment UI to `ChatInput`: attachment button, thumbnail strip, paste handler, drag-drop handler, and file picker integration.
+
+**Files:**
+- `src/components/chat/ChatInput.tsx` — Major changes:
+  - Add `pendingAttachments` state (`useState<ImageAttachment[]>([])`)
+  - Add attachment button (lucide `ImagePlus`, 16px, strokeWidth 1.5) next to send button, conditionally rendered via `supportsVision()`
+  - Add `AttachmentStrip` component (horizontal flex row of 48x48 thumbnails with remove buttons)
+  - Add `onPaste` handler on textarea: check `clipboardData.files` for images, compress via `compressImage()`, add to pending
+  - Add `onDragOver` / `onDrop` handlers on the input container: accept image files, compress, add to pending
+  - File picker on attachment button click: use Tauri `dialog.open()` with image file filters
+  - Max 5 images enforced with toast on overflow
+  - Clear pending attachments after send
+  - Pass attachments to `onSend(message, attachments)`
+- `src/components/chat/AttachmentStrip.tsx` — New component: horizontal strip of thumbnails with hover-reveal X buttons. Props: `attachments: ImageAttachment[]`, `onRemove: (id: string) => void`.
+
+**Acceptance criteria:**
+- Paste image from clipboard → thumbnail appears in strip
+- Drag image file → thumbnail appears in strip
+- Click attachment button → file dialog opens, selected image compressed and shown
+- X button on thumbnail removes it
+- Max 5 images with toast
+- Attachment button hidden when vision not supported
+- Paste rejected with toast when vision not supported
+- Strip clears after sending
+- All styling per design system (CSS variables, dark mode, 150ms transitions)
+
+---
+
+## Task 10: Display image attachments in sent messages
+
+**Complexity:** M | **Category:** frontend | **Dependencies:** #1, #8
+
+**Description:** Render inline image thumbnails on user messages that have attachments.
+
+**Files:**
+- `src/components/chat/ChatMessage.tsx` — In the `UserContent` function (line ~155), check `message.attachments`. If present, render a row of thumbnail images above the text content. Max-width 120px, rounded corners, clickable to expand.
+- `src/styles/editor.css` or inline Tailwind — Thumbnail styles
+
+**Acceptance criteria:**
+- User messages with attachments show thumbnails above text
+- Thumbnails are max 120px wide, rounded corners (`var(--radius)`)
+- Clicking a thumbnail opens full-size view (modal or new window)
+- Messages without attachments render unchanged
+- Works in both light and dark mode
+
+---
+
+## Task 11: Ollama multimodal detection in Rust backend
+
+**Complexity:** M | **Category:** backend | **Dependencies:** None
+
+**Description:** Extend the existing `detect_thinking_support()` pattern in `ai_streaming.rs` to also detect multimodal/vision capability from the Ollama `/api/show` response. Return this information alongside thinking support so the frontend can use it for vision gating.
+
+**Files:**
+- `src-tauri/src/commands/ai_streaming.rs` — Extend `ThinkingSupport` struct (or create a sibling `ModelCapabilities` struct) to include `is_multimodal: bool`. In `detect_thinking_support()` (line ~93), check the `/api/show` response for multimodal indicators (e.g., `"multimodal"` in model details/capabilities array, or vision-related model family names).
+- `src-tauri/src/commands/ai.rs` — Add a new Tauri command `ollama_model_supports_vision(ollama_url: String, model: String) -> Result<bool, String>` that calls the detection logic. Register in `lib.rs`.
+- `src/lib/tauri.ts` — Add wrapper `ollamaModelSupportsVision(ollamaUrl: string, model: string): Promise<boolean>`
+
+**Acceptance criteria:**
+- `/api/show` response parsed for multimodal capability
+- New command returns `true` for known vision models (llava, SmolVLM, etc.)
+- Returns `false` for text-only models
+- Follows existing `detect_thinking_support` pattern (graceful fallback on error)
+
+---
+
+## Task 12: Handle vision model switching edge cases
+
+**Complexity:** S | **Category:** frontend | **Dependencies:** #3, #9
+
+**Description:** Handle the edge case where a user has pending image attachments and switches to a non-vision provider/model.
+
+**Files:**
+- `src/components/chat/ChatInput.tsx` — Add an effect that watches the active connection/model. If `supportsVision()` becomes `false` while `pendingAttachments.length > 0`, clear attachments and show toast: "Images removed — current model doesn't support images".
+
+**Acceptance criteria:**
+- Switching from vision to non-vision model clears pending attachments
+- Toast notification shown
+- No crash or stale state
+- Switching back to vision model allows new attachments
+
+---
+
+## Task 13: Editor "Send to AI" context menu for images and drawings
+
+**Complexity:** L | **Category:** frontend | **Dependencies:** #2, #3, #9
+
+**Description:** Add a "Send to AI" context menu item on Image and Drawing nodes in the editor. Clicking it extracts the image, compresses it, opens the chat panel, and populates the pending attachments.
+
+**Files:**
+- `src/components/editor/EditorContent.tsx` or wherever the editor context menu is defined — Add "Send to AI" item for Image and Drawing node types. Guard with `supportsVision()` check.
+- `src/components/chat/ChatInput.tsx` — Expose a way to externally add pending attachments (e.g., a ref callback, or a Zustand store for pending attachments, or a custom event)
+- `src/lib/image-compress.ts` — Ensure it handles image URLs (local `asset://` protocol) and SVG strings (for drawings)
+
+**For Image nodes:**
+1. Get the `src` attribute (could be a local file path via Tauri asset protocol or a URL)
+2. Fetch the image data (via Tauri `read_file` for local, or `fetch` for URLs)
+3. Compress via `compressImage()`
+
+**For Drawing nodes:**
+1. Get the `data-drawing-id` attribute (path to `.excalidraw` file)
+2. Resolve the `.svg` sidecar path (same path with `.svg` extension)
+3. Load SVG content, render to canvas via `new Image()` with `src = 'data:image/svg+xml;...'`
+4. Compress the rasterized PNG
+
+**Acceptance criteria:**
+- Right-click image → "Send to AI" visible (only when vision model active)
+- Right-click drawing → "Send to AI" visible
+- Clicking opens/focuses chat panel with image in attachment strip
+- Image is compressed before attaching
+- Drawings are rasterized from SVG and compressed
+- Disabled/hidden when no vision-capable model is active
+
+---
+
+## Task 14: Write tests
+
+**Complexity:** L | **Category:** both | **Dependencies:** #1-#13
+
+**Description:** Write unit and integration tests for the image attachment pipeline.
+
+**Files:**
+- `src/lib/__tests__/image-compress.test.ts` — New file:
+  - Test: resizes image to max 1568px
+  - Test: converts opaque PNG to JPEG
+  - Test: preserves transparent PNG
+  - Test: retries at lower quality when >5 MB
+  - Test: handles File, Blob, and base64 inputs
+- `src/lib/ai/__tests__/vision.test.ts` — New file:
+  - Test: `supportsVision` returns `true` for Anthropic
+  - Test: `supportsVision` returns `true` for OpenAI
+  - Test: `supportsVision` returns `false` for Ollama text model
+  - Test: `supportsVision` returns `true` for local model with `supports_vision: true`
+  - Test: `supportsVision` returns `false` for unknown provider
+- `src-tauri/src/commands/ai.rs` — Add Rust tests:
+  - Test: `ChatMessage` with images serializes correctly (serde round-trip)
+  - Test: Anthropic message body includes image content blocks
+  - Test: OpenAI message body includes image_url content blocks
+  - Test: Ollama message body includes images array
+- `src/stores/__tests__/chat-store.test.ts` — Add test case:
+  - Test: Message with attachments round-trips through store (add → retrieve → verify attachments present)
+  - Test: Old messages without attachments continue to work
+
+**Acceptance criteria:**
+- All new tests pass (`pnpm test`, `cargo test`)
+- Compression pipeline has coverage for core paths
+- Vision detection has coverage for each provider type
+- Rust serialization tested per provider
+- No regressions in existing tests


### PR DESCRIPTION
Surveys API formats (Anthropic, OpenAI, Ollama, llama-server, ACP),
competitor UX patterns (Cursor, Cline, Continue.dev, Copilot Chat),
and recommends architecture decisions for Notesage implementation.

https://claude.ai/code/session_01RZNtrS5xQnd2umnxFrFcry