### PR TITLE
Add insert-chart bundled skill for AI agent chart generation

### DIFF
--- a/bundled-agents/agents.md
+++ b/bundled-agents/agents.md
@@ -35,3 +35,7 @@ Let me explain what I want
 ```
 
 NEVER write a numbered or bulleted list of options AND quick-replies tags — use ONLY the tags.
+
+## Rich Content Blocks
+
+Notesage supports inline charts and drawings that render natively in the editor. When a user asks you to create a chart, visualize data, or add a graph to their document, read the `insert-chart` skill for the exact sidecar JSON format and examples. Charts are inserted as `![chart](/.notesage/charts/{uuid}.json)` in markdown, with the chart data stored in a sidecar JSON file under the project's `.notesage/charts/` directory.

--- a/bundled-skills/insert-chart/SKILL.md
+++ b/bundled-skills/insert-chart/SKILL.md
@@ -48,12 +48,19 @@ When the editor sees this markdown pattern, it renders an interactive chart. The
 
 ## Tips
 
+- **Start with minimal data** — verify rendering with a simple 3-point single-series chart before building the full dataset. This catches format issues early.
 - Keep data arrays reasonable (5–30 points for readability)
 - Use `"line"` or `"area"` for time series data
 - Use `"pie"` or `"donut"` only when showing parts of a whole (typically 3–8 slices)
-- Multi-series charts need the `series` array — see the schema and examples
+- Multi-series charts need the `series` array — see the schema and examples. Set `showLegend: true` so series are distinguishable.
 - The `colorScheme` options are `"neutral"`, `"monochrome"`, `"warm"`, and `"cool"`
 - If you need to look at existing charts in the project for reference, check `.notesage/charts/*.json`
+
+## Troubleshooting
+
+- **Chart renders empty (axes only, no bars/lines):** Check that the `dataKey` values match. For single-series, each data point needs a `value` field. For multi-series, each data point must contain all series keys as numeric properties, and the `series` array must list them.
+- **Chart disappears after switching tabs:** If the chart markdown reference (`![chart](...)`) was removed from the document (e.g., by an undo or failed edit), the editor deletes the orphaned sidecar file after 5 seconds. Re-insert the markdown line and re-create the JSON file.
+- **Chart shows placeholder instead of rendering:** The sidecar JSON file may be missing or contain invalid JSON. Check that `.notesage/charts/{id}.json` exists and is valid JSON matching the schema.
 
 ## References
 

--- a/bundled-skills/insert-chart/SKILL.md
+++ b/bundled-skills/insert-chart/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: insert-chart
+description: Insert inline Recharts-based charts into Notesage documents
+user-invocable: true
+---
+
+# Insert Chart
+
+Insert an inline chart into a Notesage markdown document. Charts render natively in the editor using Recharts and export to PDF, DOCX, and HTML.
+
+## How It Works
+
+Notesage charts are stored as two pieces:
+1. A **sidecar JSON file** in `.notesage/charts/{id}.json` containing the chart data and configuration
+2. A **markdown image reference** `![chart](/.notesage/charts/{id}.json)` in the document
+
+When the editor sees this markdown pattern, it renders an interactive chart. The file watcher automatically picks up changes, so the chart appears as soon as both files are written.
+
+## Workflow
+
+1. **Generate a unique ID** for the chart. Use `uuidgen` (available on macOS and most Linux), or any unique string — the only requirement is no collisions within the project's `.notesage/charts/` directory.
+
+2. **Create the charts directory** if it doesn't exist:
+   ```
+   mkdir -p <project_root>/.notesage/charts
+   ```
+
+3. **Write the chart JSON** to `.notesage/charts/{id}.json`. See `references/CHART-SCHEMA.md` for the full data format and `references/EXAMPLES.md` for complete working examples.
+
+4. **Insert the markdown reference** into the document at the desired location:
+   ```markdown
+   ![chart](/.notesage/charts/{id}.json)
+   ```
+   This line must be on its own paragraph (blank lines above and below).
+
+5. **Save the document.** The editor detects the file change and renders the chart inline.
+
+## Supported Chart Types
+
+| Type | Description | Best For |
+|------|-------------|----------|
+| `bar` | Vertical bar chart | Comparing categories |
+| `horizontal_bar` | Horizontal bar chart | Long category labels |
+| `line` | Line chart | Trends over time |
+| `area` | Filled area chart | Volume over time |
+| `pie` | Pie chart | Proportions of a whole |
+| `donut` | Donut chart | Proportions with center space |
+
+## Tips
+
+- Keep data arrays reasonable (5–30 points for readability)
+- Use `"line"` or `"area"` for time series data
+- Use `"pie"` or `"donut"` only when showing parts of a whole (typically 3–8 slices)
+- Multi-series charts need the `series` array — see the schema and examples
+- The `colorScheme` options are `"neutral"`, `"monochrome"`, `"warm"`, and `"cool"`
+- If you need to look at existing charts in the project for reference, check `.notesage/charts/*.json`
+
+## References
+
+- `references/CHART-SCHEMA.md` — Full JSON schema for the chart sidecar file
+- `references/EXAMPLES.md` — Complete working examples for each chart type

--- a/bundled-skills/insert-chart/references/CHART-SCHEMA.md
+++ b/bundled-skills/insert-chart/references/CHART-SCHEMA.md
@@ -1,0 +1,114 @@
+# Chart Sidecar JSON Schema
+
+The chart sidecar file (`.notesage/charts/{id}.json`) must conform to the following structure. Notesage renders charts using [Recharts](https://recharts.org/), so the data format maps directly to Recharts component props.
+
+## Top-Level Object: ChartData
+
+```json
+{
+  "type": "<ChartType>",
+  "title": "<string>",
+  "data": [<ChartDataPoint>, ...],
+  "series": [<ChartSeries>, ...],
+  "config": <ChartConfig>
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | ChartType | Yes | Chart type (see below) |
+| `title` | string | Yes | Chart title displayed above the chart. Can be empty string. |
+| `data` | ChartDataPoint[] | Yes | Array of data points |
+| `series` | ChartSeries[] | No | Required only for multi-series charts |
+| `config` | ChartConfig | Yes | Display configuration |
+
+## ChartType
+
+One of: `"bar"`, `"line"`, `"area"`, `"pie"`, `"donut"`, `"horizontal_bar"`
+
+**Recharts mapping:**
+
+| ChartType | Recharts Component | Data Shape |
+|-----------|-------------------|------------|
+| `bar` | `<BarChart>` with vertical `<Bar>` | cartesian |
+| `horizontal_bar` | `<BarChart layout="vertical">` | cartesian |
+| `line` | `<LineChart>` with `<Line>` | cartesian |
+| `area` | `<AreaChart>` with `<Area>` | cartesian |
+| `pie` | `<PieChart>` with `<Pie>` | radial |
+| `donut` | `<PieChart>` with `<Pie innerRadius>` | radial |
+
+## ChartDataPoint
+
+Each data point is an object in the `data` array:
+
+```json
+{ "category": "<string>", "value": <number> }
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `category` | string | Yes | Label for this data point. Used as the X-axis label (cartesian) or slice label (radial). This is the Recharts `dataKey` for the `<XAxis>`. |
+| `value` | number | Yes | Numeric value. This is the Recharts `dataKey` for the default series. |
+
+**For multi-series charts**, each data point must also include additional numeric properties matching each series key:
+
+```json
+{ "category": "Q1", "revenue": 100, "expenses": 80 }
+```
+
+When using multi-series, the `value` field is not used — the series keys replace it.
+
+## ChartSeries
+
+Only needed for multi-series charts (2+ data lines/bars). Omit entirely for single-series charts.
+
+```json
+{ "key": "<string>", "label": "<string>" }
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `key` | string | Yes | Property name on each data point (e.g., `"revenue"`). Must match a key in every ChartDataPoint object. |
+| `label` | string | Yes | Human-readable label shown in legend and tooltips |
+
+## ChartConfig
+
+```json
+{
+  "xLabel": "<string>",
+  "yLabel": "<string>",
+  "showGrid": <boolean>,
+  "showLegend": <boolean>,
+  "colorScheme": "<ColorScheme>"
+}
+```
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `xLabel` | string | Yes | `""` | X-axis label. Empty string for no label. |
+| `yLabel` | string | Yes | `""` | Y-axis label. Empty string for no label. |
+| `showGrid` | boolean | Yes | `true` | Show background grid lines |
+| `showLegend` | boolean | Yes | `false` | Show chart legend. Recommended for multi-series. |
+| `colorScheme` | ColorScheme | Yes | `"neutral"` | Color palette for the chart |
+
+## ColorScheme
+
+One of: `"neutral"`, `"monochrome"`, `"warm"`, `"cool"`
+
+| Scheme | Description |
+|--------|-------------|
+| `neutral` | Low-chroma grey-blue tones (default, matches Notesage design) |
+| `monochrome` | Pure greyscale |
+| `warm` | Orange and red tones |
+| `cool` | Blue and purple tones |
+
+Each scheme provides 5 distinct colors for multi-series differentiation, with separate light and dark mode variants that the editor applies automatically.
+
+## Validation Rules
+
+- `data` must have at least 1 entry
+- `category` must be a string (even for numeric years — use `"2020"`, not `2020`)
+- `value` must be a number (not a string)
+- For multi-series: every data point must contain all series keys as numeric properties
+- `type` must be one of the 6 valid chart types
+- `colorScheme` must be one of the 4 valid schemes

--- a/bundled-skills/insert-chart/references/EXAMPLES.md
+++ b/bundled-skills/insert-chart/references/EXAMPLES.md
@@ -103,7 +103,40 @@ Note: For pie and donut charts, `xLabel`, `yLabel`, and `showGrid` are ignored b
 
 ---
 
-## Example 4: Multi-Series Line Chart — Revenue vs Expenses
+## Example 4: Horizontal Bar Chart — Programming Languages
+
+**Markdown to insert:**
+```markdown
+![chart](/.notesage/charts/languages-example.json)
+```
+
+**Sidecar JSON** (`.notesage/charts/languages-example.json`):
+```json
+{
+  "type": "horizontal_bar",
+  "title": "Top Programming Languages (2025)",
+  "data": [
+    { "category": "Python", "value": 28 },
+    { "category": "JavaScript", "value": 22 },
+    { "category": "TypeScript", "value": 15 },
+    { "category": "Java", "value": 12 },
+    { "category": "Rust", "value": 8 }
+  ],
+  "config": {
+    "xLabel": "Usage (%)",
+    "yLabel": "",
+    "showGrid": true,
+    "showLegend": false,
+    "colorScheme": "cool"
+  }
+}
+```
+
+Note: Horizontal bar charts work like vertical bar charts but with `"type": "horizontal_bar"`. Category labels appear on the Y-axis, values on the X-axis. Good for long category names.
+
+---
+
+## Example 5: Multi-Series Line Chart — Revenue vs Expenses
 
 **Markdown to insert:**
 ```markdown

--- a/bundled-skills/insert-chart/references/EXAMPLES.md
+++ b/bundled-skills/insert-chart/references/EXAMPLES.md
@@ -1,0 +1,140 @@
+# Chart Examples
+
+Complete sidecar JSON examples ready to use. Each example includes the JSON file content and the markdown line to insert.
+
+---
+
+## Example 1: Line Chart — S&P 500 Performance
+
+**Markdown to insert:**
+```markdown
+![chart](/.notesage/charts/sp500-example.json)
+```
+
+**Sidecar JSON** (`.notesage/charts/sp500-example.json`):
+```json
+{
+  "type": "line",
+  "title": "S&P 500 Annual Close",
+  "data": [
+    { "category": "2016", "value": 2239 },
+    { "category": "2017", "value": 2674 },
+    { "category": "2018", "value": 2507 },
+    { "category": "2019", "value": 3231 },
+    { "category": "2020", "value": 3756 },
+    { "category": "2021", "value": 4766 },
+    { "category": "2022", "value": 3840 },
+    { "category": "2023", "value": 4770 },
+    { "category": "2024", "value": 5881 },
+    { "category": "2025", "value": 5693 }
+  ],
+  "config": {
+    "xLabel": "Year",
+    "yLabel": "Close Price (USD)",
+    "showGrid": true,
+    "showLegend": false,
+    "colorScheme": "neutral"
+  }
+}
+```
+
+---
+
+## Example 2: Bar Chart — Quarterly Revenue
+
+**Markdown to insert:**
+```markdown
+![chart](/.notesage/charts/revenue-example.json)
+```
+
+**Sidecar JSON** (`.notesage/charts/revenue-example.json`):
+```json
+{
+  "type": "bar",
+  "title": "2025 Quarterly Revenue",
+  "data": [
+    { "category": "Q1", "value": 142 },
+    { "category": "Q2", "value": 168 },
+    { "category": "Q3", "value": 155 },
+    { "category": "Q4", "value": 193 }
+  ],
+  "config": {
+    "xLabel": "Quarter",
+    "yLabel": "Revenue ($M)",
+    "showGrid": true,
+    "showLegend": false,
+    "colorScheme": "cool"
+  }
+}
+```
+
+---
+
+## Example 3: Pie Chart — Market Share
+
+**Markdown to insert:**
+```markdown
+![chart](/.notesage/charts/market-share-example.json)
+```
+
+**Sidecar JSON** (`.notesage/charts/market-share-example.json`):
+```json
+{
+  "type": "pie",
+  "title": "Browser Market Share (2025)",
+  "data": [
+    { "category": "Chrome", "value": 65 },
+    { "category": "Safari", "value": 18 },
+    { "category": "Firefox", "value": 6 },
+    { "category": "Edge", "value": 5 },
+    { "category": "Other", "value": 6 }
+  ],
+  "config": {
+    "xLabel": "",
+    "yLabel": "",
+    "showGrid": false,
+    "showLegend": true,
+    "colorScheme": "neutral"
+  }
+}
+```
+
+Note: For pie and donut charts, `xLabel`, `yLabel`, and `showGrid` are ignored but must still be present in the config object. Set `showLegend` to `true` so slice labels are visible.
+
+---
+
+## Example 4: Multi-Series Line Chart — Revenue vs Expenses
+
+**Markdown to insert:**
+```markdown
+![chart](/.notesage/charts/rev-vs-exp-example.json)
+```
+
+**Sidecar JSON** (`.notesage/charts/rev-vs-exp-example.json`):
+```json
+{
+  "type": "line",
+  "title": "Revenue vs Expenses",
+  "data": [
+    { "category": "Jan", "revenue": 120, "expenses": 95 },
+    { "category": "Feb", "revenue": 135, "expenses": 100 },
+    { "category": "Mar", "revenue": 148, "expenses": 105 },
+    { "category": "Apr", "revenue": 142, "expenses": 110 },
+    { "category": "May", "revenue": 165, "expenses": 108 },
+    { "category": "Jun", "revenue": 178, "expenses": 115 }
+  ],
+  "series": [
+    { "key": "revenue", "label": "Revenue ($K)" },
+    { "key": "expenses", "label": "Expenses ($K)" }
+  ],
+  "config": {
+    "xLabel": "Month",
+    "yLabel": "Amount ($K)",
+    "showGrid": true,
+    "showLegend": true,
+    "colorScheme": "neutral"
+  }
+}
+```
+
+Note: Multi-series charts use `series` to define each data line. Each series `key` must exist as a property on every data point. The `value` field is not needed when using explicit series keys. Set `showLegend` to `true` so series are distinguishable.

--- a/src-tauri/src/commands/skills.rs
+++ b/src-tauri/src/commands/skills.rs
@@ -814,6 +814,22 @@ pub async fn extract_bundled_skills() -> Result<String, String> {
             content: include_str!("../../../bundled-skills/create-agent/references/EXAMPLES.md"),
             executable: false,
         },
+        // insert-chart
+        BundledFile {
+            relative_path: "insert-chart/SKILL.md",
+            content: include_str!("../../../bundled-skills/insert-chart/SKILL.md"),
+            executable: false,
+        },
+        BundledFile {
+            relative_path: "insert-chart/references/CHART-SCHEMA.md",
+            content: include_str!("../../../bundled-skills/insert-chart/references/CHART-SCHEMA.md"),
+            executable: false,
+        },
+        BundledFile {
+            relative_path: "insert-chart/references/EXAMPLES.md",
+            content: include_str!("../../../bundled-skills/insert-chart/references/EXAMPLES.md"),
+            executable: false,
+        },
     ];
 
     info!("Extracting {} bundled skill files to {}", bundled_files.len(), bundled_dir.display());

--- a/src/components/editor/charts/BarChartRenderer.tsx
+++ b/src/components/editor/charts/BarChartRenderer.tsx
@@ -119,11 +119,22 @@ export function BarChartRenderer({
         {chartData.config.showLegend && (
           <ChartLegend content={<ChartLegendContent />} />
         )}
-        <Bar
-          dataKey="value"
-          fill="var(--color-value)"
-          radius={[4, 4, 0, 0]}
-        />
+        {chartData.series && chartData.series.length > 0 ? (
+          chartData.series.map((s) => (
+            <Bar
+              key={s.key}
+              dataKey={s.key}
+              fill={`var(--color-${CSS.escape(s.key)})`}
+              radius={[4, 4, 0, 0]}
+            />
+          ))
+        ) : (
+          <Bar
+            dataKey="value"
+            fill="var(--color-value)"
+            radius={[4, 4, 0, 0]}
+          />
+        )}
       </BarChart>
     </ChartContainer>
   );

--- a/src/components/editor/charts/LineChartRenderer.tsx
+++ b/src/components/editor/charts/LineChartRenderer.tsx
@@ -86,14 +86,28 @@ export function LineChartRenderer({
           margin={{ top: 8, right: 16, bottom: 8, left: 8 }}
         >
           {axisElements}
-          <Area
-            type="monotone"
-            dataKey="value"
-            stroke="var(--color-value)"
-            fill="var(--color-value)"
-            fillOpacity={0.2}
-            strokeWidth={2}
-          />
+          {chartData.series && chartData.series.length > 0 ? (
+            chartData.series.map((s) => (
+              <Area
+                key={s.key}
+                type="monotone"
+                dataKey={s.key}
+                stroke={`var(--color-${CSS.escape(s.key)})`}
+                fill={`var(--color-${CSS.escape(s.key)})`}
+                fillOpacity={0.2}
+                strokeWidth={2}
+              />
+            ))
+          ) : (
+            <Area
+              type="monotone"
+              dataKey="value"
+              stroke="var(--color-value)"
+              fill="var(--color-value)"
+              fillOpacity={0.2}
+              strokeWidth={2}
+            />
+          )}
         </AreaChart>
       </ChartContainer>
     );
@@ -106,14 +120,28 @@ export function LineChartRenderer({
         margin={{ top: 8, right: 16, bottom: 8, left: 8 }}
       >
         {axisElements}
-        <Line
-          type="monotone"
-          dataKey="value"
-          stroke="var(--color-value)"
-          strokeWidth={2}
-          dot={{ r: 3, fill: "var(--color-value)" }}
-          activeDot={{ r: 5 }}
-        />
+        {chartData.series && chartData.series.length > 0 ? (
+          chartData.series.map((s) => (
+            <Line
+              key={s.key}
+              type="monotone"
+              dataKey={s.key}
+              stroke={`var(--color-${CSS.escape(s.key)})`}
+              strokeWidth={2}
+              dot={{ r: 3, fill: `var(--color-${CSS.escape(s.key)})` }}
+              activeDot={{ r: 5 }}
+            />
+          ))
+        ) : (
+          <Line
+            type="monotone"
+            dataKey="value"
+            stroke="var(--color-value)"
+            strokeWidth={2}
+            dot={{ r: 3, fill: "var(--color-value)" }}
+            activeDot={{ r: 5 }}
+          />
+        )}
       </LineChart>
     </ChartContainer>
   );


### PR DESCRIPTION
Teach agents (both direct API and ACP) how to insert inline Recharts-based
charts into documents. Agents already operate on markdown files via read_file
and write_file — they just need to know the chart sidecar JSON format.

- New bundled skill: insert-chart with SKILL.md workflow instructions
- Reference docs: CHART-SCHEMA.md (Recharts data format) and EXAMPLES.md
  (4 complete examples: line, bar, pie, multi-series)
- Brief hint in agents.md so the capability is discoverable from system prompt
- Registered in extract_bundled_skills for automatic extraction

https://claude.ai/code/session_01FCy7cZKAbeKSZ3Z5J3f5gh