### PR TITLE
skills: add liteparse skill for PDF/Office/image extraction

### DIFF
--- a/bundled-skills/liteparse/SKILL.md
+++ b/bundled-skills/liteparse/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: liteparse
+description: Parse PDFs, Office documents, and images into markdown text or page screenshots using LlamaIndex liteparse
+user-invocable: true
+---
+
+# Liteparse
+
+Extract text and screenshots from PDFs, Office documents (Word, PowerPoint, Excel), and images using the `lit` CLI from [LlamaIndex liteparse](https://github.com/run-llama/liteparse). Output is written to a file the user chooses — stdout stays small so large documents do not flood the AI context window.
+
+Use this skill when the user asks to:
+
+- Read, summarize, or ask questions about a PDF, DOCX, PPTX, XLSX, or image file
+- Convert a non-markdown document into a markdown file they can edit
+- Run OCR on a scanned PDF or photo of text
+- Produce page screenshots of a PDF for visual inspection (pass them back through the chat attachment flow)
+
+## Prerequisites
+
+`lit` must be on the user's `PATH`. Non-PDF formats also require LibreOffice (Office formats) and ImageMagick (image formats).
+
+Always run `setup.sh` first. It is idempotent — it only prints install instructions when something is missing.
+
+```
+execute_skill_script("liteparse", "scripts/setup.sh", [])
+```
+
+If the script exits non-zero, show the user the missing-dependency message verbatim and stop. Do **not** attempt to install anything on their behalf.
+
+## Workflow — Parse a document
+
+1. **Get the input path.** Ask the user for the absolute path to the document if you do not already have it from the conversation (e.g., a file they opened, a research attachment, or a paste).
+
+2. **Ask where to save the extracted text.** Default to a sibling `.md` file (e.g., `report.pdf` → `report.md`), but confirm before writing. For research ingestion, default to `.notesage/research/` in the current project.
+
+3. **Run the parse script:**
+   ```
+   execute_skill_script("liteparse", "scripts/parse.sh", [input_path, output_path])
+   ```
+
+   Optional flags:
+   - `--format "markdown"` — output format. Defaults to `markdown`. Other values: `text`, `json`.
+   - `--no-ocr` — disable OCR entirely. Use this for digital-native PDFs where OCR is wasteful.
+   - `--ocr-language "eng"` — Tesseract language code. Default `eng`. Use e.g. `swe` for Swedish, `fra+eng` for multi-language.
+   - `--password "secret"` — password for encrypted PDFs.
+
+   Output JSON on stdout:
+   ```json
+   {
+     "file": "/path/to/output.md",
+     "format": "markdown",
+     "bytes": 48213,
+     "ocrUsed": false,
+     "status": "created"
+   }
+   ```
+
+   **status values:**
+   - `"created"` — new file saved
+   - `"exists"` — file already exists, nothing was written
+   - `"overwritten"` — existing file was replaced (when `--force` was used)
+
+4. **Handle existing files.** If `status` is `"exists"`, present exactly these three options as a numbered list:
+   1. **Overwrite** — re-run with `--force` added to the flags
+   2. **Keep both** — append `-1` (or `-2`, etc.) to the output filename and re-run
+   3. **Skip** — do nothing
+
+5. **Report the result.** Tell the user the page count, whether OCR ran, and the output path. Offer to open the file as a new tab.
+
+## Workflow — Screenshot PDF pages
+
+Use this when the user wants to *see* specific pages (e.g., "show me page 3 of this PDF") or when you need to feed a vision model a page that liteparse cannot faithfully text-extract (complex tables, diagrams, handwriting where OCR quality is low).
+
+1. **Get the input path and page range.** Page range syntax matches liteparse: `"1-5"`, `"1,3,7"`, `"all"`.
+
+2. **Decide the output directory.** Use a temp directory under the project (e.g., `.notesage/tmp/screenshots/<doc-name>/`) unless the user specifies otherwise.
+
+3. **Run the screenshot script:**
+   ```
+   execute_skill_script("liteparse", "scripts/screenshot.sh", [input_path, output_dir, "--target-pages", "1-5"])
+   ```
+
+   Optional flags:
+   - `--dpi "150"` — render resolution. Default 150. Use 72 for drafts, 300 for print fidelity.
+   - `--format "png"` — image format (`png` or `jpg`). Default `png`.
+
+   Output JSON on stdout:
+   ```json
+   {
+     "dir": "/path/to/screenshots",
+     "pages": [
+       { "page": 1, "file": "/path/to/screenshots/page-001.png" },
+       { "page": 2, "file": "/path/to/screenshots/page-002.png" }
+     ],
+     "status": "created"
+   }
+   ```
+
+4. **Follow-up.** After generating screenshots, suggest the user right-click "Add to chat" on any of the PNGs to attach them to the conversation for vision-based reasoning. Do not attempt to attach images yourself — the attachment event bus is user-driven.
+
+## Error handling
+
+- If `lit` is missing, `setup.sh` exits with a clear install snippet. Relay it verbatim.
+- If LibreOffice is missing and the input is `.docx` / `.pptx` / `.xlsx`, the CLI errors out. Tell the user which dependency is missing and the install command.
+- If OCR fails on a specific page, liteparse continues with a blank; report that the output may be incomplete.
+- For encrypted PDFs without `--password`, surface the CLI error and ask the user for the password.
+
+## When not to use this skill
+
+- **Already a markdown file** — just read it directly with `read_file`.
+- **User wants to *render* a PDF interactively** — open it as a tab instead; the built-in PDF viewer supports search and navigation.
+- **User wants to *edit* an Office document** — converting to markdown is lossy; suggest they edit the original in its native app.
+
+## Notes for AI
+
+- The parse output can be large. Always write to a file and only read back the subset you need via `read_file` with line ranges.
+- When summarizing a long PDF, parse once, then use structured slicing (e.g., read the first 200 lines, then the last 200) before synthesizing.
+- For research ingestion, chain with `save-research` to add tags and frontmatter after parsing.

--- a/bundled-skills/liteparse/scripts/parse.sh
+++ b/bundled-skills/liteparse/scripts/parse.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# parse.sh - Parse a document into markdown/text/JSON via `lit parse`.
+# Usage: parse.sh <input_path> <output_path> [--format "markdown"] [--no-ocr] [--ocr-language "eng"] [--password "secret"] [--force]
+#
+# Outputs JSON to stdout: { file, format, pages, bytes, ocrUsed, status }
+# status: "created", "exists", or "overwritten"
+# Errors go to stderr with non-zero exit code.
+
+set -euo pipefail
+
+if [ $# -lt 2 ]; then
+  echo "Usage: parse.sh <input_path> <output_path> [--format FMT] [--no-ocr] [--ocr-language LANG] [--password PW] [--force]" >&2
+  exit 64
+fi
+
+input="$1"
+output="$2"
+shift 2
+
+format="markdown"
+ocr=true
+ocr_language=""
+password=""
+force=false
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --format)         format="${2:?--format requires a value}"; shift 2 ;;
+    --no-ocr)         ocr=false; shift ;;
+    --ocr-language)   ocr_language="${2:?--ocr-language requires a value}"; shift 2 ;;
+    --password)       password="${2:?--password requires a value}"; shift 2 ;;
+    --force)          force=true; shift ;;
+    *)                echo "Unknown flag: $1" >&2; exit 64 ;;
+  esac
+done
+
+if [ ! -f "$input" ]; then
+  echo "Error: input file does not exist: $input" >&2
+  exit 66
+fi
+
+if ! command -v lit >/dev/null 2>&1; then
+  echo "Error: lit CLI not found. Run setup.sh first." >&2
+  exit 127
+fi
+
+if [ -e "$output" ] && [ "$force" = false ]; then
+  size=$(wc -c <"$output" | tr -d ' ')
+  printf '{"file":"%s","format":"%s","pages":0,"bytes":%s,"ocrUsed":false,"status":"exists"}\n' \
+    "$output" "$format" "$size"
+  exit 0
+fi
+
+existed=false
+[ -e "$output" ] && existed=true
+
+mkdir -p "$(dirname "$output")"
+
+args=(parse "$input" --format "$format" -o "$output")
+if [ "$ocr" = false ]; then
+  args+=(--no-ocr)
+fi
+if [ -n "$ocr_language" ]; then
+  args+=(--ocr-language "$ocr_language")
+fi
+if [ -n "$password" ]; then
+  args+=(--password "$password")
+fi
+
+if ! lit "${args[@]}" >/dev/null 2>&1; then
+  lit "${args[@]}" >&2 || true
+  echo "Error: lit parse failed for $input" >&2
+  exit 1
+fi
+
+if [ ! -f "$output" ]; then
+  echo "Error: lit reported success but output file is missing: $output" >&2
+  exit 1
+fi
+
+bytes=$(wc -c <"$output" | tr -d ' ')
+
+ocr_used="false"
+if [ "$ocr" = true ]; then
+  ocr_used="true"
+fi
+
+status="created"
+[ "$existed" = true ] && status="overwritten"
+
+printf '{"file":"%s","format":"%s","bytes":%s,"ocrUsed":%s,"status":"%s"}\n' \
+  "$output" "$format" "$bytes" "$ocr_used" "$status"

--- a/bundled-skills/liteparse/scripts/screenshot.sh
+++ b/bundled-skills/liteparse/scripts/screenshot.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# screenshot.sh - Render PDF pages as images via `lit screenshot`.
+# Usage: screenshot.sh <input_path> <output_dir> [--target-pages "1-5"] [--dpi "150"] [--format "png"]
+#
+# Outputs JSON to stdout: { dir, pages: [{ page, file }], status }
+# Errors go to stderr with non-zero exit code.
+
+set -euo pipefail
+
+if [ $# -lt 2 ]; then
+  echo "Usage: screenshot.sh <input_path> <output_dir> [--target-pages RANGE] [--dpi N] [--format png|jpg]" >&2
+  exit 64
+fi
+
+input="$1"
+output_dir="$2"
+shift 2
+
+target_pages="all"
+dpi="150"
+format="png"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --target-pages)   target_pages="${2:?--target-pages requires a value}"; shift 2 ;;
+    --dpi)            dpi="${2:?--dpi requires a value}"; shift 2 ;;
+    --format)         format="${2:?--format requires a value}"; shift 2 ;;
+    *)                echo "Unknown flag: $1" >&2; exit 64 ;;
+  esac
+done
+
+if [ ! -f "$input" ]; then
+  echo "Error: input file does not exist: $input" >&2
+  exit 66
+fi
+
+if ! command -v lit >/dev/null 2>&1; then
+  echo "Error: lit CLI not found. Run setup.sh first." >&2
+  exit 127
+fi
+
+mkdir -p "$output_dir"
+
+args=(screenshot "$input" --target-pages "$target_pages" --dpi "$dpi" --format "$format" -o "$output_dir")
+
+if ! lit "${args[@]}" >/dev/null 2>&1; then
+  lit "${args[@]}" >&2 || true
+  echo "Error: lit screenshot failed for $input" >&2
+  exit 1
+fi
+
+python3 - "$output_dir" "$format" <<'PY'
+import json
+import os
+import re
+import sys
+
+out_dir, fmt = sys.argv[1], sys.argv[2]
+entries = []
+pat = re.compile(r"(\d+)")
+for name in sorted(os.listdir(out_dir)):
+    if not name.lower().endswith("." + fmt.lower()):
+        continue
+    m = pat.search(name)
+    if not m:
+        continue
+    entries.append({"page": int(m.group(1)), "file": os.path.join(out_dir, name)})
+
+entries.sort(key=lambda e: e["page"])
+print(json.dumps({"dir": out_dir, "pages": entries, "status": "created"}))
+PY

--- a/bundled-skills/liteparse/scripts/setup.sh
+++ b/bundled-skills/liteparse/scripts/setup.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# setup.sh - Verify that the `lit` CLI and optional converters are installed.
+# Usage: setup.sh
+
+set -euo pipefail
+
+missing=()
+
+if ! command -v lit >/dev/null 2>&1; then
+  missing+=("lit")
+fi
+
+if [ ${#missing[@]} -gt 0 ]; then
+  cat >&2 <<'EOF'
+Error: The `lit` CLI from LlamaIndex liteparse is required but was not found on PATH.
+
+Install one of the following:
+
+  Homebrew (macOS / Linux):
+    brew install llamaindex-liteparse
+
+  npm (global):
+    npm install -g @llamaindex/liteparse
+
+After installation, re-run this skill. The `lit` binary must be reachable from the shell Notesage launches scripts in.
+
+Optional dependencies (install only if you need non-PDF formats):
+  - LibreOffice   -> required for .doc/.docx/.ppt/.pptx/.xls/.xlsx
+  - ImageMagick   -> required for .jpg/.png/.gif/.bmp/.tiff/.webp/.svg
+EOF
+  exit 1
+fi
+
+lit_version=$(lit --version 2>/dev/null || echo "unknown")
+
+libreoffice_status="missing"
+if command -v soffice >/dev/null 2>&1 || command -v libreoffice >/dev/null 2>&1; then
+  libreoffice_status="installed"
+fi
+
+imagemagick_status="missing"
+if command -v magick >/dev/null 2>&1 || command -v convert >/dev/null 2>&1; then
+  imagemagick_status="installed"
+fi
+
+printf '{"lit":"%s","libreoffice":"%s","imagemagick":"%s","status":"ready"}\n' \
+  "$lit_version" "$libreoffice_status" "$imagemagick_status"


### PR DESCRIPTION
Wraps the `lit` CLI from LlamaIndex liteparse as a user-invocable
skill with two scripts (parse, screenshot) plus a setup check. Users
can ask the AI to extract markdown text from PDFs, DOCX, PPTX, XLSX,
or images (with OCR), or render PDF pages as PNGs for vision models.

The `Usage:` comments follow the existing skill-tool-parser convention,
so scripts auto-register as `skill__liteparse__parse` and
`skill__liteparse__screenshot` tool calls for any AI provider. The
setup script verifies `lit` is on PATH and reports the status of
optional LibreOffice / ImageMagick dependencies without attempting
to install them.

https://claude.ai/code/session_01E5egaGpKAy2huTcrjfpe9M