### PR TITLE
test(quiet-sidebar): add double-click folder rename integration tests for #59

### DIFF
--- a/src/components/sidebar/quiet/ProjectsSection.tsx
+++ b/src/components/sidebar/quiet/ProjectsSection.tsx
@@ -467,11 +467,11 @@ export function ProjectsSection({ onAdd, filter }: ProjectsSectionProps) {
   }, []);
   const cancelRename = useCallback(() => setRenamingPath(null), []);
   const commitRename = useCallback(
-    async (oldPath: string, newBasename: string) => {
+    async (oldPath: string, newBasename: string, isDirectory?: boolean) => {
       setRenamingPath(null);
       const oldName = pathBasename(oldPath);
       if (newBasename === oldName) return;
-      const newPath = resolveRenamePath(oldPath, newBasename);
+      const newPath = resolveRenamePath(oldPath, newBasename, isDirectory);
       try {
         await renamePath(oldPath, newPath);
         toast.success(`Renamed to ${pathBasename(newPath)}`);
@@ -591,31 +591,26 @@ export function ProjectsSection({ onAdd, filter }: ProjectsSectionProps) {
     return unsubscribe;
   }, [projects]);
 
-  // Collect every currently-visible child FILE path so the event listener
-  // can decide whether it owns this rename request. Projects + folders +
-  // overflow markers are intentionally excluded — they are not renameable
-  // in this task.
-  const visibleChildFilePaths = useMemo(() => {
+  // Collect every currently-visible child path (files AND folders) so the
+  // event listener can decide whether it owns this rename request. Project
+  // roots and overflow markers are intentionally excluded.
+  const visibleChildPaths = useMemo(() => {
     const paths = new Set<string>();
     for (const row of rows) {
-      if (
-        row.kind === "child" &&
-        row.entry &&
-        !row.entry.is_directory
-      ) {
+      if (row.kind === "child" && row.entry) {
         paths.add(row.entry.path);
       }
     }
     return paths;
   }, [rows]);
 
-  // Rename context-menu event. Only activate on visible child file paths;
-  // project roots and folders are skipped.
+  // Rename context-menu event. Activate on any visible child path (files or
+  // folders); project roots are skipped.
   useEffect(() => {
     function handleRenameEvent(event: Event) {
       const detail = (event as CustomEvent<{ filePath: string }>).detail;
       if (!detail?.filePath) return;
-      if (!visibleChildFilePaths.has(detail.filePath)) return;
+      if (!visibleChildPaths.has(detail.filePath)) return;
       setRenamingPath(detail.filePath);
     }
     window.addEventListener(
@@ -628,7 +623,7 @@ export function ProjectsSection({ onAdd, filter }: ProjectsSectionProps) {
         handleRenameEvent,
       );
     };
-  }, [visibleChildFilePaths]);
+  }, [visibleChildPaths]);
 
   const openProject = useCallback(async (project: WorkspaceProject) => {
     if (project.fileTree.length === 0) return;
@@ -1255,7 +1250,7 @@ interface ChildRowProps {
   onKeyDown: (event: KeyboardEvent<HTMLDivElement>) => void;
   onFocus: () => void;
   onStartRename: (path: string) => void;
-  onCommitRename: (oldPath: string, newBasename: string) => void;
+  onCommitRename: (oldPath: string, newBasename: string, isDirectory?: boolean) => void;
   onCancelRename: () => void;
   registerRef: (el: HTMLDivElement | null) => void;
 }
@@ -1349,13 +1344,13 @@ function ChildRow({
   // not — only file paths can be pinned in Phase 1. Projects themselves
   // (row.kind === "project") stay non-draggable too.
   const draggable = !entry.is_directory;
-  // Rename support — files only. Folders and project roots are explicitly
-  // out of scope in this task.
-  const renameable = !entry.is_directory;
+  // F2 rename — files only (folders excluded per task #40).
+  // Double-click rename — files AND folders (task #62).
+  const renameableViaKeyboard = !entry.is_directory;
 
   // Chain rename-aware handling with the parent's navigation handler.
   const handleRowKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-    if (renameable && event.key === "F2") {
+    if (renameableViaKeyboard && event.key === "F2") {
       event.preventDefault();
       onStartRename(entry.path);
       return;
@@ -1364,7 +1359,7 @@ function ChildRow({
   };
 
   const handleRowClick = (event: ReactMouseEvent<HTMLDivElement>) => {
-    if (renameable && event.detail === 2) {
+    if (event.detail === 2) {
       event.preventDefault();
       event.stopPropagation();
       onStartRename(entry.path);
@@ -1412,7 +1407,7 @@ function ChildRow({
           mode="rename"
           initialValue={entry.name}
           validate={validateRenameBasename}
-          onCommit={(value) => onCommitRename(entry.path, value)}
+          onCommit={(value) => onCommitRename(entry.path, value, entry.is_directory)}
           onCancel={onCancelRename}
           className="flex-1 min-w-0"
         />

--- a/src/components/sidebar/quiet/__tests__/ProjectsSection.test.tsx
+++ b/src/components/sidebar/quiet/__tests__/ProjectsSection.test.tsx
@@ -805,6 +805,160 @@ describe('ProjectsSection — inline rename (#40)', () => {
 });
 
 // ----------------------------------------------------------------------------
+// Task #62 — folder double-click rename
+// ----------------------------------------------------------------------------
+
+describe('ProjectsSection — folder double-click rename (#62)', () => {
+  const project: WorkspaceProject = {
+    path: '/Users/me/Notesage/alpha',
+    fileTree: [
+      makeFile('note.md', '/Users/me/Notesage/alpha/note.md'),
+      makeDir('docs', '/Users/me/Notesage/alpha/docs', [
+        makeFile('intro.md', '/Users/me/Notesage/alpha/docs/intro.md'),
+      ]),
+    ],
+  };
+
+  it('double-clicking a directory child row renders SidebarInlineEdit with the folder basename', async () => {
+    setProjects([project]);
+    renderWithProviders(<ProjectsSection />);
+
+    const projectRow = screen.getByRole('treeitem', {
+      name: /open project alpha/i,
+    });
+    fireEvent.keyDown(projectRow, { key: 'ArrowRight' }); // expand
+
+    const folderRow = screen.getByRole('treeitem', {
+      name: /open folder docs/i,
+    }) as HTMLElement;
+    fireEvent.click(folderRow, { detail: 2 });
+
+    const input = (await screen.findByLabelText(/rename/i)) as HTMLInputElement;
+    expect(input.value).toBe('docs');
+    // Must NOT open the folder.
+    expect(mockOpenFile).not.toHaveBeenCalled();
+  });
+
+  it('committing a folder rename calls renamePath with the new folder path', async () => {
+    const user = userEvent.setup();
+    setProjects([project]);
+    renderWithProviders(<ProjectsSection />);
+
+    const projectRow = screen.getByRole('treeitem', {
+      name: /open project alpha/i,
+    });
+    fireEvent.keyDown(projectRow, { key: 'ArrowRight' });
+
+    const folderRow = screen.getByRole('treeitem', {
+      name: /open folder docs/i,
+    }) as HTMLElement;
+    fireEvent.click(folderRow, { detail: 2 });
+
+    const input = (await screen.findByLabelText(/rename/i)) as HTMLInputElement;
+    await user.clear(input);
+    await user.type(input, 'documents{Enter}');
+
+    await waitFor(() => {
+      expect(mockRenamePath).toHaveBeenCalledWith(
+        '/Users/me/Notesage/alpha/docs',
+        '/Users/me/Notesage/alpha/documents',
+      );
+    });
+  });
+
+  it('Escape cancels folder rename without calling renamePath', async () => {
+    setProjects([project]);
+    renderWithProviders(<ProjectsSection />);
+
+    const projectRow = screen.getByRole('treeitem', {
+      name: /open project alpha/i,
+    });
+    fireEvent.keyDown(projectRow, { key: 'ArrowRight' });
+
+    const folderRow = screen.getByRole('treeitem', {
+      name: /open folder docs/i,
+    }) as HTMLElement;
+    fireEvent.click(folderRow, { detail: 2 });
+
+    const input = await screen.findByLabelText(/rename/i);
+    fireEvent.keyDown(input, { key: 'Escape' });
+
+    await waitFor(() => {
+      expect(screen.queryByLabelText(/rename/i)).toBeNull();
+    });
+    expect(mockRenamePath).not.toHaveBeenCalled();
+  });
+
+  it('double-clicking a project-root row does NOT render SidebarInlineEdit', async () => {
+    setProjects([project]);
+    renderWithProviders(<ProjectsSection />);
+
+    const projectRow = screen.getByRole('treeitem', {
+      name: /open project alpha/i,
+    }) as HTMLElement;
+    fireEvent.click(projectRow, { detail: 2 });
+
+    // Give React time to render any side-effects
+    await new Promise((r) => setTimeout(r, 50));
+    expect(screen.queryByLabelText(/rename/i)).toBeNull();
+  });
+
+  it('SIDEBAR_ENTER_RENAME_MODE_EVENT on a visible folder path enters rename mode', async () => {
+    setProjects([project]);
+    renderWithProviders(<ProjectsSection />);
+
+    // Expand the project so docs/ is visible.
+    const projectRow = screen.getByRole('treeitem', {
+      name: /open project alpha/i,
+    });
+    fireEvent.keyDown(projectRow, { key: 'ArrowRight' });
+
+    window.dispatchEvent(
+      new CustomEvent('sidebar:enter-rename-mode', {
+        detail: { filePath: '/Users/me/Notesage/alpha/docs' },
+      }),
+    );
+
+    const input = await screen.findByLabelText(/rename/i);
+    expect(input).toBeTruthy();
+  });
+
+  it('renaming a folder named "my.folder" preserves no extension (treated as directory)', async () => {
+    const user = userEvent.setup();
+    const projectWithDottedFolder: WorkspaceProject = {
+      path: '/Users/me/Notesage/alpha',
+      fileTree: [
+        makeDir('my.folder', '/Users/me/Notesage/alpha/my.folder'),
+      ],
+    };
+    setProjects([projectWithDottedFolder]);
+    renderWithProviders(<ProjectsSection />);
+
+    const projectRow = screen.getByRole('treeitem', {
+      name: /open project alpha/i,
+    });
+    fireEvent.keyDown(projectRow, { key: 'ArrowRight' });
+
+    const folderRow = screen.getByRole('treeitem', {
+      name: /open folder my\.folder/i,
+    }) as HTMLElement;
+    fireEvent.click(folderRow, { detail: 2 });
+
+    const input = (await screen.findByLabelText(/rename/i)) as HTMLInputElement;
+    await user.clear(input);
+    await user.type(input, 'my-folder{Enter}');
+
+    await waitFor(() => {
+      // isDirectory=true → resolveRenamePath must NOT preserve ".folder" extension
+      expect(mockRenamePath).toHaveBeenCalledWith(
+        '/Users/me/Notesage/alpha/my.folder',
+        '/Users/me/Notesage/alpha/my-folder',
+      );
+    });
+  });
+});
+
+// ----------------------------------------------------------------------------
 // Task #41 — inline create note
 // ----------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes #62

## Summary
Extends ProjectsSection's handleRowClick to trigger onStartRename on double-click for all child entries (files + folders); F2 stays file-only. `commitRename` now passes `isDirectory` to `resolveRenamePath` so folders skip the file-extension carry-over. Adds 6 new tests in `ProjectsSection.test.tsx` covering the folder rename path.

## Test plan
- [x] `pnpm test` — 4415 passed
- [x] `pnpm typecheck` — clean
- [x] Red tests confirmed RED before implementation

🤖 Generated by aw-tdd, opened manually pending repo-setting flip (now flipped — future runs auto-create).