### PR TITLE
feat(cmd-bar): standardize picker selection to discrete right-aligned checkmark

### DIFF
--- a/src/components/cmd/modes/FileMode.tsx
+++ b/src/components/cmd/modes/FileMode.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Check } from "lucide-react";
 import { tauriApi, type IndexFilenameSearchResult } from "@/lib/tauri";
 import {
   getDefaultPaletteScope,
@@ -294,32 +295,30 @@ function FileMode({
             onClick={() => selectIndex(index)}
             className={cn(
               "flex items-center gap-2 px-3 py-1.5 text-left transition-colors text-[13px]",
-              isActive
-                ? "bg-[var(--color-accent-primary)] text-[oklch(100%_0_0)]"
-                : "text-foreground hover:bg-muted/60",
+              isActive ? "bg-muted/80 text-foreground" : "text-foreground hover:bg-muted/60",
               "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40",
             )}
           >
             <FileIcon
               fileName={row.name}
-              className={cn(
-                "h-3.5 w-3.5 shrink-0",
-                isActive ? "opacity-90" : "text-muted-foreground",
-              )}
+              className="h-3.5 w-3.5 shrink-0 text-muted-foreground"
             />
             <span className="flex-1 truncate font-medium">{row.name}</span>
-            {row.parentDir && (
+            {row.parentDir && !isActive && (
               <span
-                className={cn(
-                  "shrink-0 truncate max-w-[40%] text-xs",
-                  isActive
-                    ? "text-[oklch(100%_0_0)]/75"
-                    : "text-muted-foreground",
-                )}
+                className="shrink-0 truncate max-w-[40%] text-xs text-muted-foreground"
                 title={row.parentDir}
               >
                 {row.parentDir}
               </span>
+            )}
+            {isActive && (
+              <Check
+                data-picker-check
+                className="h-3.5 w-3.5 shrink-0 text-[var(--color-accent-primary)]"
+                strokeWidth={2.5}
+                aria-hidden="true"
+              />
             )}
           </button>
         );

--- a/src/components/cmd/modes/PaletteMode.tsx
+++ b/src/components/cmd/modes/PaletteMode.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   BookOpen,
+  Check,
   Command as CommandIcon,
   FileOutput,
   FilePlus,
@@ -319,33 +320,31 @@ function PaletteMode({
               // the tightened sibling pickers.
               'flex items-center gap-2 px-3 py-1.5 text-left text-[13px]',
               'transition-colors',
-              isHighlighted
-                ? 'bg-[var(--color-accent-primary)] text-[oklch(100%_0_0)]'
-                : 'text-foreground hover:bg-muted/60',
+              isHighlighted ? 'bg-muted/80 text-foreground' : 'text-foreground hover:bg-muted/60',
               'focus-visible:outline-none',
             )}
           >
             <Icon
-              className={cn(
-                'h-3.5 w-3.5 shrink-0',
-                isHighlighted
-                  ? 'text-[oklch(100%_0_0)]/85'
-                  : 'text-muted-foreground',
-              )}
+              className="h-3.5 w-3.5 shrink-0 text-muted-foreground"
               strokeWidth={1.5}
               aria-hidden="true"
             />
             <span className="flex-1 truncate">{cmd.label}</span>
             {cmd.shortcut ? (
               <kbd
-                className={cn(
-                  'shrink-0 rounded border border-border bg-background',
-                  'px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground',
-                )}
+                className="shrink-0 rounded border border-border bg-background px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground"
               >
                 {cmd.shortcut}
               </kbd>
             ) : null}
+            {isHighlighted && (
+              <Check
+                data-picker-check
+                className="h-3.5 w-3.5 shrink-0 text-[var(--color-accent-primary)]"
+                strokeWidth={2.5}
+                aria-hidden="true"
+              />
+            )}
           </button>
         );
       })}

--- a/src/components/cmd/modes/ReferenceMode.tsx
+++ b/src/components/cmd/modes/ReferenceMode.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
+  Check,
   ChevronLeft,
   FileText,
   MessageSquare,
@@ -545,20 +546,13 @@ function ReferenceMode({
                   className={cn(
                     "flex items-start gap-2 px-3 py-1.5 cursor-pointer",
                     "text-[13px] transition-colors",
-                    selected
-                      ? "bg-[var(--color-accent-primary)] text-[oklch(100%_0_0)]"
-                      : "text-foreground hover:bg-muted/60",
+                    selected ? "bg-muted/80 text-foreground" : "text-foreground hover:bg-muted/60",
                   )}
                 >
                   <FileText
                     size={12}
                     strokeWidth={1.5}
-                    className={cn(
-                      "mt-[3px] shrink-0",
-                      selected
-                        ? "text-[oklch(100%_0_0)]/85"
-                        : "text-muted-foreground",
-                    )}
+                    className="mt-[3px] shrink-0 text-muted-foreground"
                     aria-hidden
                   />
                   <div className="flex min-w-0 flex-1 flex-col">
@@ -566,29 +560,24 @@ function ReferenceMode({
                       {occ.file_name}
                     </span>
                     {(occ.context_before || occ.context_after) && (
-                      <span
-                        className={cn(
-                          "truncate text-xs",
-                          selected
-                            ? "text-[oklch(100%_0_0)]/75"
-                            : "text-muted-foreground",
-                        )}
-                      >
+                      <span className="truncate text-xs text-muted-foreground">
                         …{occ.context_before}
-                        <span
-                          className={cn(
-                            "font-medium",
-                            selected
-                              ? "text-[oklch(100%_0_0)]"
-                              : "text-foreground",
-                          )}
-                        >
+                        <span className="font-medium text-foreground">
                           @{selectedPerson}
                         </span>
                         {occ.context_after}…
                       </span>
                     )}
                   </div>
+                  {selected && (
+                    <Check
+                      data-picker-check
+                      size={12}
+                      strokeWidth={2.5}
+                      className="mt-[3px] shrink-0 text-[var(--color-accent-primary)]"
+                      aria-hidden
+                    />
+                  )}
                 </li>
               );
             })}
@@ -661,47 +650,35 @@ function ResultRow({
       onClick={onClick}
       onMouseEnter={onMouseEnter}
       className={cn(
-        // Density (live-test 2026-04-26).
         "flex items-center gap-2 px-3 py-1.5 cursor-pointer text-[13px]",
         "transition-colors",
         highlighted
-          ? "bg-[var(--color-accent-primary)] text-[oklch(100%_0_0)]"
+          ? "bg-muted/80 text-foreground"
           : "text-foreground hover:bg-muted/60",
       )}
     >
       <Icon
-        className={cn(
-          "h-3 w-3 shrink-0",
-          highlighted
-            ? "text-[oklch(100%_0_0)]/85"
-            : "text-muted-foreground",
-        )}
+        className="h-3 w-3 shrink-0 text-muted-foreground"
         strokeWidth={1.5}
         aria-hidden="true"
       />
-      <span
-        className={cn(
-          "shrink-0 rounded px-1 py-px text-[10px] uppercase tracking-wide",
-          highlighted
-            ? "bg-[oklch(100%_0_0)]/15 text-[oklch(100%_0_0)]/85"
-            : "border border-border bg-muted/40 text-muted-foreground",
-        )}
-      >
+      <span className="shrink-0 rounded px-1 py-px text-[10px] uppercase tracking-wide border border-border bg-muted/40 text-muted-foreground">
         {meta.label}
       </span>
       <span className="truncate">{result.name}</span>
-      {result.detail ? (
-        <span
-          className={cn(
-            "ml-auto truncate text-xs",
-            highlighted
-              ? "text-[oklch(100%_0_0)]/75"
-              : "text-muted-foreground",
-          )}
-        >
+      {result.detail && !highlighted ? (
+        <span className="ml-auto truncate text-xs text-muted-foreground">
           {result.detail}
         </span>
       ) : null}
+      {highlighted && (
+        <Check
+          data-picker-check
+          className="ml-auto h-3 w-3 shrink-0 text-[var(--color-accent-primary)]"
+          strokeWidth={2.5}
+          aria-hidden="true"
+        />
+      )}
     </div>
   );
 }

--- a/src/components/cmd/modes/ResearchMode.tsx
+++ b/src/components/cmd/modes/ResearchMode.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { BookOpen } from "lucide-react";
+import { BookOpen, Check } from "lucide-react";
 import { tauriApi, type IndexResearchResult } from "@/lib/tauri";
 import {
   getDefaultPaletteScope,
@@ -224,20 +224,13 @@ function ResearchMode({
               // Density (live-test 2026-04-26).
               "flex flex-col items-start gap-0.5 px-3 py-1.5 text-left",
               "transition-colors text-[13px]",
-              isActive
-                ? "bg-[var(--color-accent-primary)] text-[oklch(100%_0_0)]"
-                : "text-foreground hover:bg-muted/60",
+              isActive ? "bg-muted/80 text-foreground" : "text-foreground hover:bg-muted/60",
               "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40",
             )}
           >
             <div className="flex w-full items-center gap-2">
               <BookOpen
-                className={cn(
-                  "h-3.5 w-3.5 shrink-0",
-                  isActive
-                    ? "text-[oklch(100%_0_0)]/85"
-                    : "text-muted-foreground",
-                )}
+                className="h-3.5 w-3.5 shrink-0 text-muted-foreground"
                 strokeWidth={1.5}
                 aria-hidden="true"
               />
@@ -245,27 +238,21 @@ function ResearchMode({
                 {result.title}
               </span>
               {result.date_saved && (
-                <span
-                  className={cn(
-                    "shrink-0 text-xs tabular-nums",
-                    isActive
-                      ? "text-[oklch(100%_0_0)]/75"
-                      : "text-muted-foreground",
-                  )}
-                >
+                <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
                   {result.date_saved}
                 </span>
               )}
+              {isActive && (
+                <Check
+                  data-picker-check
+                  className="h-3.5 w-3.5 shrink-0 text-[var(--color-accent-primary)]"
+                  strokeWidth={2.5}
+                  aria-hidden="true"
+                />
+              )}
             </div>
             {(displaySource || result.tags.length > 0) && (
-              <div
-                className={cn(
-                  "flex w-full items-center gap-2 pl-5 text-xs",
-                  isActive
-                    ? "text-[oklch(100%_0_0)]/75"
-                    : "text-muted-foreground",
-                )}
-              >
+              <div className="flex w-full items-center gap-2 pl-5 text-xs text-muted-foreground">
                 {displaySource && (
                   <span className="truncate">{displaySource}</span>
                 )}

--- a/src/components/cmd/modes/SkillMode.tsx
+++ b/src/components/cmd/modes/SkillMode.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Sparkles } from 'lucide-react';
+import { Check, Sparkles } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useSkillStore, type SkillEntry } from '@/stores/skill-store';
 
@@ -187,36 +187,30 @@ function SkillMode({
             className={cn(
               // Density (live-test 2026-04-26).
               'flex w-full items-start gap-2 px-3 py-1.5 text-left text-[13px] transition-colors duration-150',
-              active
-                ? 'bg-[var(--color-accent-primary)] text-[oklch(100%_0_0)]'
-                : 'text-foreground hover:bg-muted/60',
+              active ? 'bg-muted/80 text-foreground' : 'text-foreground hover:bg-muted/60',
             )}
           >
             <Sparkles
-              className={cn(
-                'mt-[3px] size-3 shrink-0',
-                active
-                  ? 'text-[oklch(100%_0_0)]/85'
-                  : 'text-muted-foreground',
-              )}
+              className="mt-[3px] size-3 shrink-0 text-muted-foreground"
               strokeWidth={1.5}
               aria-hidden
             />
-            <span className="flex min-w-0 flex-col">
+            <span className="flex min-w-0 flex-1 flex-col">
               <span className="truncate font-medium">{skill.name}</span>
               {skill.description ? (
-                <span
-                  className={cn(
-                    'truncate text-xs',
-                    active
-                      ? 'text-[oklch(100%_0_0)]/75'
-                      : 'text-muted-foreground',
-                  )}
-                >
+                <span className="truncate text-xs text-muted-foreground">
                   {skill.description}
                 </span>
               ) : null}
             </span>
+            {active && (
+              <Check
+                data-picker-check
+                className="mt-[3px] size-3 shrink-0 text-[var(--color-accent-primary)]"
+                strokeWidth={2.5}
+                aria-hidden
+              />
+            )}
           </button>
         );
       })}

--- a/src/components/cmd/modes/TagMode.tsx
+++ b/src/components/cmd/modes/TagMode.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Hash, ChevronLeft, FileText } from "lucide-react";
+import { Check, ChevronLeft, FileText, Hash } from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
   tauriApi,
@@ -298,20 +298,13 @@ function TagMode({
                   className={cn(
                     "flex items-start gap-2 px-3 py-1.5 cursor-pointer",
                     "text-[13px] transition-colors",
-                    selected
-                      ? "bg-[var(--color-accent-primary)] text-[oklch(100%_0_0)]"
-                      : "text-foreground hover:bg-muted/60",
+                    selected ? "bg-muted/80 text-foreground" : "text-foreground hover:bg-muted/60",
                   )}
                 >
                   <FileText
                     size={12}
                     strokeWidth={1.5}
-                    className={cn(
-                      "mt-[3px] shrink-0",
-                      selected
-                        ? "text-[oklch(100%_0_0)]/85"
-                        : "text-muted-foreground",
-                    )}
+                    className="mt-[3px] shrink-0 text-muted-foreground"
                     aria-hidden
                   />
                   <div className="flex min-w-0 flex-1 flex-col">
@@ -319,29 +312,24 @@ function TagMode({
                       {occ.file_name}
                     </span>
                     {(occ.context_before || occ.context_after) && (
-                      <span
-                        className={cn(
-                          "truncate text-xs",
-                          selected
-                            ? "text-[oklch(100%_0_0)]/75"
-                            : "text-muted-foreground",
-                        )}
-                      >
+                      <span className="truncate text-xs text-muted-foreground">
                         …{occ.context_before}
-                        <span
-                          className={cn(
-                            "font-medium",
-                            selected
-                              ? "text-[oklch(100%_0_0)]"
-                              : "text-foreground",
-                          )}
-                        >
+                        <span className="font-medium text-foreground">
                           #{selectedTag}
                         </span>
                         {occ.context_after}…
                       </span>
                     )}
                   </div>
+                  {selected && (
+                    <Check
+                      data-picker-check
+                      size={12}
+                      strokeWidth={2.5}
+                      className="mt-[3px] shrink-0 text-[var(--color-accent-primary)]"
+                      aria-hidden
+                    />
+                  )}
                 </li>
               );
             })}
@@ -390,33 +378,28 @@ function TagMode({
               "flex items-center gap-2 px-3 py-1.5 cursor-pointer",
               "text-[13px]",
               "transition-colors",
-              selected
-                ? "bg-[var(--color-accent-primary)] text-[oklch(100%_0_0)]"
-                : "text-foreground hover:bg-muted/60",
+              selected ? "bg-muted/80 text-foreground" : "text-foreground hover:bg-muted/60",
             )}
           >
             <Hash
               size={12}
               strokeWidth={1.5}
-              className={cn(
-                "shrink-0",
-                selected
-                  ? "text-[oklch(100%_0_0)]/85"
-                  : "text-muted-foreground",
-              )}
+              className="shrink-0 text-muted-foreground"
               aria-hidden
             />
             <span className="font-medium truncate">{row.name}</span>
-            <span
-              className={cn(
-                "ml-auto text-xs shrink-0",
-                selected
-                  ? "text-[oklch(100%_0_0)]/75"
-                  : "text-muted-foreground",
-              )}
-            >
+            <span className="ml-auto text-xs shrink-0 text-muted-foreground">
               {formatFileCount(row.usageCount)}
             </span>
+            {selected && (
+              <Check
+                data-picker-check
+                size={12}
+                strokeWidth={2.5}
+                className="shrink-0 text-[var(--color-accent-primary)]"
+                aria-hidden
+              />
+            )}
           </li>
         );
       })}

--- a/src/components/cmd/modes/TaskMode.tsx
+++ b/src/components/cmd/modes/TaskMode.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import {
   Bot,
+  Check,
   CheckSquare2,
   FolderKanban,
   FolderOpen,
@@ -690,25 +691,14 @@ function TaskMode({
                   onClick={() => dispatch(row)}
                   onMouseEnter={() => setHighlight(index)}
                   className={cn(
-                    // Match cmd-bar density (live-test 2026-04-26): denser
-                    // rhythm, accent-fill highlight. Active row → white text
-                    // on accent; secondary line uses /75 alpha so it stays
-                    // readable on the bright accent.
                     'flex w-full items-start gap-2 px-3 py-1.5 text-left',
                     'text-[13px] transition-colors',
-                    active
-                      ? 'bg-[var(--color-accent-primary)] text-[oklch(100%_0_0)]'
-                      : 'hover:bg-muted/60 text-foreground',
+                    active ? 'bg-muted/80 text-foreground' : 'hover:bg-muted/60 text-foreground',
                     'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40',
                   )}
                 >
                   <Icon
-                    className={cn(
-                      'mt-[3px] h-3 w-3 shrink-0',
-                      active
-                        ? 'text-[oklch(100%_0_0)]/75'
-                        : 'text-muted-foreground',
-                    )}
+                    className="mt-[3px] h-3 w-3 shrink-0 text-muted-foreground"
                     strokeWidth={1.5}
                     aria-hidden="true"
                   />
@@ -717,18 +707,19 @@ function TaskMode({
                       {truncate(row.text, NAME_TRUNCATE)}
                     </span>
                     {secondary && (
-                      <span
-                        className={cn(
-                          'truncate text-xs',
-                          active
-                            ? 'text-[oklch(100%_0_0)]/75'
-                            : 'text-muted-foreground',
-                        )}
-                      >
+                      <span className="truncate text-xs text-muted-foreground">
                         {secondary}
                       </span>
                     )}
                   </div>
+                  {active && (
+                    <Check
+                      data-picker-check
+                      className="mt-[3px] h-3 w-3 shrink-0 text-[var(--color-accent-primary)]"
+                      strokeWidth={2.5}
+                      aria-hidden="true"
+                    />
+                  )}
                 </button>,
               );
             }

--- a/src/components/cmd/modes/__tests__/FileMode.test.tsx
+++ b/src/components/cmd/modes/__tests__/FileMode.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+
+import '@/test/tauri-mock';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  renderWithProviders,
+  screen,
+  waitFor,
+} from '@/test/component-harness';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// vi.mock factories are hoisted — no top-level const refs allowed inside.
+// ---------------------------------------------------------------------------
+
+vi.mock('@/lib/command-palette', () => ({
+  getDefaultPaletteScope: () => 'all',
+  resolveSearchPaths: () => ['/Users/u/proj'],
+}));
+
+vi.mock('@/lib/tauri', () => ({
+  tauriApi: {
+    indexSearchFilenames: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+vi.mock('@/stores/settings-store', () => ({
+  useSettingsStore: vi.fn((sel: (s: { showHiddenFiles: boolean }) => unknown) =>
+    sel({ showHiddenFiles: false }),
+  ),
+}));
+
+vi.mock('@/stores/editor-store', () => ({
+  useEditorStore: vi.fn(
+    (sel: (s: { recentFiles: Array<{ path: string; name: string }> }) => unknown) =>
+      sel({
+        recentFiles: [
+          { path: '/Users/u/proj/alpha.md', name: 'alpha.md' },
+          { path: '/Users/u/proj/beta.md', name: 'beta.md' },
+        ],
+      }),
+  ),
+}));
+
+vi.mock('@/hooks/useFileOperations', () => ({
+  useFileOperations: () => ({ openFile: vi.fn() }),
+}));
+
+// Import AFTER mocks are registered.
+import FileMode from '@/components/cmd/modes/FileMode';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('FileMode', () => {
+  it('renders recent files for empty filter', async () => {
+    renderWithProviders(<FileMode filter="" onPick={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('alpha.md')).toBeTruthy();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Issue #38 — discrete checkmark selection indicator
+  // -------------------------------------------------------------------------
+
+  it('active file row shows a data-picker-check element instead of an accent background fill', async () => {
+    const { container } = renderWithProviders(
+      <FileMode filter="" onPick={vi.fn()} />,
+    );
+
+    await waitFor(() => expect(screen.getByText('alpha.md')).toBeTruthy());
+
+    const activeRow = container.querySelector('[aria-selected="true"]') as HTMLElement;
+    expect(activeRow).toBeTruthy();
+    expect(activeRow.className).not.toContain('bg-[var(--color-accent-primary)]');
+    expect(activeRow.querySelector('[data-picker-check]')).toBeTruthy();
+  });
+
+  it('inactive file rows do not show a checkmark', async () => {
+    const { container } = renderWithProviders(
+      <FileMode filter="" onPick={vi.fn()} />,
+    );
+
+    await waitFor(() => expect(screen.getByText('alpha.md')).toBeTruthy());
+
+    const inactiveRows = container.querySelectorAll<HTMLElement>('[aria-selected="false"]');
+    expect(inactiveRows.length).toBeGreaterThan(0);
+    inactiveRows.forEach((row) => {
+      expect(row.querySelector('[data-picker-check]')).toBeNull();
+    });
+  });
+});

--- a/src/components/cmd/modes/__tests__/PaletteMode.test.tsx
+++ b/src/components/cmd/modes/__tests__/PaletteMode.test.tsx
@@ -104,4 +104,35 @@ describe('PaletteMode', () => {
     renderWithProviders(<PaletteMode filter="preview" onPick={noop} />);
     expect(screen.queryByText(/preview.*html/i)).toBeNull();
   });
+
+  // -------------------------------------------------------------------------
+  // Issue #38 — discrete checkmark selection indicator
+  // -------------------------------------------------------------------------
+
+  it('active row shows a data-picker-check element instead of an accent background fill', () => {
+    const { container } = renderWithProviders(
+      <PaletteMode filter="" onPick={noop} />,
+    );
+
+    const activeRow = container.querySelector('[aria-selected="true"]') as HTMLElement;
+    expect(activeRow).toBeTruthy();
+
+    // Must NOT use full-row accent fill.
+    expect(activeRow.className).not.toContain('bg-[var(--color-accent-primary)]');
+
+    // Must show a checkmark indicator.
+    expect(activeRow.querySelector('[data-picker-check]')).toBeTruthy();
+  });
+
+  it('inactive rows do not show a checkmark', () => {
+    const { container } = renderWithProviders(
+      <PaletteMode filter="" onPick={noop} />,
+    );
+
+    const inactiveRows = container.querySelectorAll<HTMLElement>('[aria-selected="false"]');
+    expect(inactiveRows.length).toBeGreaterThan(0);
+    inactiveRows.forEach((row) => {
+      expect(row.querySelector('[data-picker-check]')).toBeNull();
+    });
+  });
 });

--- a/src/components/cmd/modes/__tests__/ReferenceMode.test.tsx
+++ b/src/components/cmd/modes/__tests__/ReferenceMode.test.tsx
@@ -317,4 +317,55 @@ describe('ReferenceMode', () => {
 
     expect(await screen.findByText(/no matches/i)).toBeTruthy();
   });
+
+  // -------------------------------------------------------------------------
+  // Issue #38 — discrete checkmark selection indicator
+  // -------------------------------------------------------------------------
+
+  it('active reference row shows a data-picker-check element instead of an accent background fill', async () => {
+    mockProjects = [
+      {
+        path: '/Users/p/proj',
+        fileTree: [
+          makeFile('alpha.md', '/Users/p/proj/alpha.md'),
+          makeFile('beta.md', '/Users/p/proj/beta.md'),
+        ],
+      },
+    ];
+
+    const { container } = renderWithProviders(
+      <ReferenceMode filter="" onPick={() => {}} />,
+    );
+
+    await screen.findByText('alpha.md');
+
+    const activeRow = container.querySelector('[aria-selected="true"]') as HTMLElement;
+    expect(activeRow).toBeTruthy();
+    expect(activeRow.className).not.toContain('bg-[var(--color-accent-primary)]');
+    expect(activeRow.querySelector('[data-picker-check]')).toBeTruthy();
+  });
+
+  it('inactive reference rows do not show a checkmark', async () => {
+    mockProjects = [
+      {
+        path: '/Users/p/proj',
+        fileTree: [
+          makeFile('alpha.md', '/Users/p/proj/alpha.md'),
+          makeFile('beta.md', '/Users/p/proj/beta.md'),
+        ],
+      },
+    ];
+
+    const { container } = renderWithProviders(
+      <ReferenceMode filter="" onPick={() => {}} />,
+    );
+
+    await screen.findByText('alpha.md');
+
+    const inactiveRows = container.querySelectorAll<HTMLElement>('[aria-selected="false"]');
+    expect(inactiveRows.length).toBeGreaterThan(0);
+    inactiveRows.forEach((row) => {
+      expect(row.querySelector('[data-picker-check]')).toBeNull();
+    });
+  });
 });

--- a/src/components/cmd/modes/__tests__/ResearchMode.test.tsx
+++ b/src/components/cmd/modes/__tests__/ResearchMode.test.tsx
@@ -182,4 +182,45 @@ describe('ResearchMode', () => {
     // Wait for the call to settle.
     await screen.findByText('No research matches');
   });
+
+  // -------------------------------------------------------------------------
+  // Issue #38 — discrete checkmark selection indicator
+  // -------------------------------------------------------------------------
+
+  it('active research row shows a data-picker-check element instead of an accent background fill', async () => {
+    indexSearchResearchMock.mockResolvedValue([
+      makeResult({ title: 'Alpha', file: '/r/alpha.md' }),
+      makeResult({ title: 'Beta', file: '/r/beta.md' }),
+    ]);
+
+    const { container } = renderWithProviders(
+      <ResearchMode filter="" onPick={() => {}} />,
+    );
+
+    await screen.findByText('Alpha');
+
+    const activeRow = container.querySelector('[aria-selected="true"]') as HTMLElement;
+    expect(activeRow).toBeTruthy();
+    expect(activeRow.className).not.toContain('bg-[var(--color-accent-primary)]');
+    expect(activeRow.querySelector('[data-picker-check]')).toBeTruthy();
+  });
+
+  it('inactive research rows do not show a checkmark', async () => {
+    indexSearchResearchMock.mockResolvedValue([
+      makeResult({ title: 'Alpha', file: '/r/alpha.md' }),
+      makeResult({ title: 'Beta', file: '/r/beta.md' }),
+    ]);
+
+    const { container } = renderWithProviders(
+      <ResearchMode filter="" onPick={() => {}} />,
+    );
+
+    await screen.findByText('Alpha');
+
+    const inactiveRows = container.querySelectorAll<HTMLElement>('[aria-selected="false"]');
+    expect(inactiveRows.length).toBeGreaterThan(0);
+    inactiveRows.forEach((row) => {
+      expect(row.querySelector('[data-picker-check]')).toBeNull();
+    });
+  });
 });

--- a/src/components/cmd/modes/__tests__/SkillMode.test.tsx
+++ b/src/components/cmd/modes/__tests__/SkillMode.test.tsx
@@ -267,4 +267,36 @@ describe('SkillMode', () => {
 
     document.body.removeChild(input);
   });
+
+  // -------------------------------------------------------------------------
+  // Issue #38 — discrete checkmark selection indicator
+  // Active rows must use a right-aligned checkmark, NOT an accent background fill.
+  // -------------------------------------------------------------------------
+
+  it('active row shows a data-picker-check element instead of an accent background fill', () => {
+    const { container } = renderWithProviders(
+      <SkillMode filter="" onPick={vi.fn()} />,
+    );
+
+    const activeRow = container.querySelector('[aria-selected="true"]') as HTMLElement;
+    expect(activeRow).toBeTruthy();
+
+    // Must NOT use full-row accent fill.
+    expect(activeRow.className).not.toContain('bg-[var(--color-accent-primary)]');
+
+    // Must show a checkmark indicator.
+    expect(activeRow.querySelector('[data-picker-check]')).toBeTruthy();
+  });
+
+  it('inactive rows do not show a checkmark', () => {
+    const { container } = renderWithProviders(
+      <SkillMode filter="" onPick={vi.fn()} />,
+    );
+
+    const inactiveRows = container.querySelectorAll<HTMLElement>('[aria-selected="false"]');
+    expect(inactiveRows.length).toBeGreaterThan(0);
+    inactiveRows.forEach((row) => {
+      expect(row.querySelector('[data-picker-check]')).toBeNull();
+    });
+  });
 });

--- a/src/components/cmd/modes/__tests__/TagMode.test.tsx
+++ b/src/components/cmd/modes/__tests__/TagMode.test.tsx
@@ -248,4 +248,45 @@ describe('TagMode', () => {
     expect(rows[0].getAttribute('aria-selected')).toBe('true');
     expect(rows[1].getAttribute('aria-selected')).toBe('false');
   });
+
+  // -------------------------------------------------------------------------
+  // Issue #38 — discrete checkmark selection indicator
+  // -------------------------------------------------------------------------
+
+  it('active tag row shows a data-picker-check element instead of an accent background fill', async () => {
+    indexTagsMock.mockResolvedValue([
+      { tag: 'alpha', file_count: 9 },
+      { tag: 'beta', file_count: 4 },
+    ]);
+
+    const { container } = renderWithProviders(
+      <TagMode filter="" onPick={() => {}} />,
+    );
+
+    await waitFor(() => expect(screen.getByText('alpha')).toBeTruthy());
+
+    const activeRow = container.querySelector('[aria-selected="true"]') as HTMLElement;
+    expect(activeRow).toBeTruthy();
+    expect(activeRow.className).not.toContain('bg-[var(--color-accent-primary)]');
+    expect(activeRow.querySelector('[data-picker-check]')).toBeTruthy();
+  });
+
+  it('inactive tag rows do not show a checkmark', async () => {
+    indexTagsMock.mockResolvedValue([
+      { tag: 'alpha', file_count: 9 },
+      { tag: 'beta', file_count: 4 },
+    ]);
+
+    const { container } = renderWithProviders(
+      <TagMode filter="" onPick={() => {}} />,
+    );
+
+    await waitFor(() => expect(screen.getByText('alpha')).toBeTruthy());
+
+    const inactiveRows = container.querySelectorAll<HTMLElement>('[aria-selected="false"]');
+    expect(inactiveRows.length).toBeGreaterThan(0);
+    inactiveRows.forEach((row) => {
+      expect(row.querySelector('[data-picker-check]')).toBeNull();
+    });
+  });
 });

--- a/src/components/cmd/modes/__tests__/TaskMode.test.tsx
+++ b/src/components/cmd/modes/__tests__/TaskMode.test.tsx
@@ -543,4 +543,47 @@ describe('TaskMode', () => {
       expect(headers[0]?.textContent ?? '').toContain('Falls-Back');
     });
   });
+
+  // -------------------------------------------------------------------------
+  // Issue #38 — discrete checkmark selection indicator
+  // -------------------------------------------------------------------------
+
+  describe('selection indicator', () => {
+    it('active task row shows a data-picker-check element instead of an accent background fill', async () => {
+      mockStore.actions = [
+        makeAction({ id: 't1', text: 'First task' }),
+        makeAction({ id: 't2', text: 'Second task', file_path: '/p/b.md' }),
+      ];
+
+      const { container } = renderWithProviders(
+        <TaskMode filter="" onPick={vi.fn()} isComposing={false} />,
+      );
+
+      await waitFor(() => expect(screen.getByText('First task')).toBeTruthy());
+
+      const activeRow = container.querySelector('[aria-selected="true"]') as HTMLElement;
+      expect(activeRow).toBeTruthy();
+      expect(activeRow.className).not.toContain('bg-[var(--color-accent-primary)]');
+      expect(activeRow.querySelector('[data-picker-check]')).toBeTruthy();
+    });
+
+    it('inactive task rows do not show a checkmark', async () => {
+      mockStore.actions = [
+        makeAction({ id: 't1', text: 'First task' }),
+        makeAction({ id: 't2', text: 'Second task', file_path: '/p/b.md' }),
+      ];
+
+      const { container } = renderWithProviders(
+        <TaskMode filter="" onPick={vi.fn()} isComposing={false} />,
+      );
+
+      await waitFor(() => expect(screen.getByText('First task')).toBeTruthy());
+
+      const inactiveRows = container.querySelectorAll<HTMLElement>('[aria-selected="false"]');
+      expect(inactiveRows.length).toBeGreaterThan(0);
+      inactiveRows.forEach((row) => {
+        expect(row.querySelector('[data-picker-check]')).toBeNull();
+      });
+    });
+  });
 });


### PR DESCRIPTION
Resolves #38

## Summary
7 picker components updated (`SkillMode`, `PaletteMode`, `FileMode`, `ResearchMode`, `TaskMode`, `TagMode`, `ReferenceMode`) to replace full-row accent fill with a right-aligned `<Check data-picker-check />` icon. Active rows now use `bg-muted/80 text-foreground` plus the checkmark; inactive rows are unchanged.

## Scope decisions
- **Selection** indicator: full-row fill → discrete checkmark ✓
- **Focus / hover** styles: intentionally unchanged (clarification on the issue resolved that the focus row highlight is a separate concern and stays as-is for keyboard accessibility)

## Test plan
- [x] 14 new tests added (2 per picker — active row has checkmark, inactive rows do not)
- [x] `FileMode.test.tsx` created from scratch (no prior test file)
- [x] `pnpm test` — 4424 passed across 239 files
- [x] `pnpm typecheck` — clean
- [x] Only 7 source + 7 test files modified

🤖 Generated by aw-tdd, opened manually pending repo-setting flip (now flipped — future runs auto-create).