### PR TITLE
fix(cmd): unify cmd-mode picker active row with PickerItem (no accent border)

### DIFF
--- a/src/components/cmd/__tests__/FileMode.test.tsx
+++ b/src/components/cmd/__tests__/FileMode.test.tsx
@@ -283,7 +283,7 @@ describe('FileMode — selection (#8)', () => {
   // #88 — active row styling: muted bg + accent border replaces solid fill
   // -------------------------------------------------------------------------
 
-  it('active row uses muted bg with accent border instead of solid accent fill (#88)', async () => {
+  it('active row uses neutral bg-muted/80 (matches PickerItem) — no accent border, no accent fill', async () => {
     setMockInvokeHandler('index_search_filenames', () => [
       { path: '/p/alpha/notes.md', file_name: 'notes.md', parent_dir: '/p/alpha', project_root: '/p/alpha' },
     ]);
@@ -293,8 +293,8 @@ describe('FileMode — selection (#8)', () => {
     });
     const activeRow = screen.getByRole('option', { name: /notes\.md/i });
     // New styling
-    expect(activeRow.classList.contains('bg-muted')).toBe(true);
-    expect(activeRow.className).toContain('border-[var(--color-accent-primary)]');
+    expect(activeRow.className).toContain('bg-muted/80');
+    expect(activeRow.className).not.toContain('border-[var(--color-accent-primary)]');
     expect(activeRow.classList.contains('text-foreground')).toBe(true);
     // Old solid accent fill must be gone
     expect(activeRow.className).not.toContain('bg-[var(--color-accent-primary)]');

--- a/src/components/cmd/modes/FileMode.tsx
+++ b/src/components/cmd/modes/FileMode.tsx
@@ -295,7 +295,7 @@ function FileMode({
             className={cn(
               "flex items-center gap-2 px-3 py-1.5 text-left transition-colors text-[13px]",
               isActive
-                ? "bg-muted border border-[var(--color-accent-primary)] rounded-md text-foreground"
+                ? "bg-muted/80 text-foreground"
                 : "text-foreground hover:bg-muted/60",
               "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40",
             )}

--- a/src/components/cmd/modes/PaletteMode.tsx
+++ b/src/components/cmd/modes/PaletteMode.tsx
@@ -320,7 +320,7 @@ function PaletteMode({
               'flex items-center gap-2 px-3 py-1.5 text-left text-[13px]',
               'transition-colors',
               isHighlighted
-                ? 'bg-muted border border-[var(--color-accent-primary)] rounded-md text-foreground'
+                ? 'bg-muted/80 text-foreground'
                 : 'text-foreground hover:bg-muted/60',
               'focus-visible:outline-none',
             )}

--- a/src/components/cmd/modes/ReferenceMode.tsx
+++ b/src/components/cmd/modes/ReferenceMode.tsx
@@ -546,7 +546,7 @@ function ReferenceMode({
                     "flex items-start gap-2 px-3 py-1.5 cursor-pointer",
                     "text-[13px] transition-colors",
                     selected
-                      ? "bg-muted border border-[var(--color-accent-primary)] rounded-md text-foreground"
+                      ? "bg-muted/80 text-foreground"
                       : "text-foreground hover:bg-muted/60",
                   )}
                 >
@@ -646,7 +646,7 @@ function ResultRow({
         "flex items-center gap-2 px-3 py-1.5 cursor-pointer text-[13px]",
         "transition-colors",
         highlighted
-          ? "bg-muted border border-[var(--color-accent-primary)] rounded-md text-foreground"
+          ? "bg-muted/80 text-foreground"
           : "text-foreground hover:bg-muted/60",
       )}
     >

--- a/src/components/cmd/modes/ResearchMode.tsx
+++ b/src/components/cmd/modes/ResearchMode.tsx
@@ -225,7 +225,7 @@ function ResearchMode({
               "flex flex-col items-start gap-0.5 px-3 py-1.5 text-left",
               "transition-colors text-[13px]",
               isActive
-                ? "bg-muted border border-[var(--color-accent-primary)] rounded-md text-foreground"
+                ? "bg-muted/80 text-foreground"
                 : "text-foreground hover:bg-muted/60",
               "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40",
             )}

--- a/src/components/cmd/modes/SkillMode.tsx
+++ b/src/components/cmd/modes/SkillMode.tsx
@@ -188,7 +188,7 @@ function SkillMode({
               // Density (live-test 2026-04-26).
               'flex w-full items-start gap-2 px-3 py-1.5 text-left text-[13px] transition-colors duration-150',
               active
-                ? 'bg-muted border border-[var(--color-accent-primary)] rounded-md text-foreground'
+                ? 'bg-muted/80 text-foreground'
                 : 'text-foreground hover:bg-muted/60',
             )}
           >

--- a/src/components/cmd/modes/TagMode.tsx
+++ b/src/components/cmd/modes/TagMode.tsx
@@ -299,7 +299,7 @@ function TagMode({
                     "flex items-start gap-2 px-3 py-1.5 cursor-pointer",
                     "text-[13px] transition-colors",
                     selected
-                      ? "bg-muted border border-[var(--color-accent-primary)] rounded-md text-foreground"
+                      ? "bg-muted/80 text-foreground"
                       : "text-foreground hover:bg-muted/60",
                   )}
                 >
@@ -372,7 +372,7 @@ function TagMode({
               "text-[13px]",
               "transition-colors",
               selected
-                ? "bg-muted border border-[var(--color-accent-primary)] rounded-md text-foreground"
+                ? "bg-muted/80 text-foreground"
                 : "text-foreground hover:bg-muted/60",
             )}
           >

--- a/src/components/cmd/modes/TaskMode.tsx
+++ b/src/components/cmd/modes/TaskMode.tsx
@@ -693,7 +693,7 @@ function TaskMode({
                     'flex w-full items-start gap-2 px-3 py-1.5 text-left',
                     'text-[13px] transition-colors',
                     active
-                      ? 'bg-muted border border-[var(--color-accent-primary)] rounded-md text-foreground'
+                      ? 'bg-muted/80 text-foreground'
                       : 'hover:bg-muted/60 text-foreground',
                     'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40',
                   )}

--- a/src/components/cmd/modes/__tests__/FileMode.test.tsx
+++ b/src/components/cmd/modes/__tests__/FileMode.test.tsx
@@ -69,8 +69,8 @@ describe('FileMode', () => {
     expect(activeRow).toBeTruthy();
 
     // New style: muted background + border with accent color.
-    expect(activeRow.className).toContain('bg-muted');
-    expect(activeRow.className).toContain('border-[var(--color-accent-primary)]');
+    expect(activeRow.className).toContain('bg-muted/80');
+    expect(activeRow.className).not.toContain('border-[var(--color-accent-primary)]');
 
     // Old solid-fill style must be gone.
     expect(activeRow.className).not.toContain('bg-[var(--color-accent-primary)]');

--- a/src/components/cmd/modes/__tests__/PaletteMode.test.tsx
+++ b/src/components/cmd/modes/__tests__/PaletteMode.test.tsx
@@ -109,13 +109,13 @@ describe('PaletteMode', () => {
   // #88 — active row styling: muted bg + accent border replaces solid fill
   // -------------------------------------------------------------------------
 
-  it('active row uses muted bg with accent border instead of solid accent fill (#88)', () => {
+  it('active row uses neutral bg-muted/80 (matches PickerItem) — no accent border, no accent fill', () => {
     const { container } = renderWithProviders(<PaletteMode filter="" onPick={noop} />);
     const activeRow = container.querySelector('[aria-selected="true"]') as HTMLElement;
     expect(activeRow).toBeTruthy();
     // New styling
-    expect(activeRow.classList.contains('bg-muted')).toBe(true);
-    expect(activeRow.className).toContain('border-[var(--color-accent-primary)]');
+    expect(activeRow.className).toContain('bg-muted/80');
+    expect(activeRow.className).not.toContain('border-[var(--color-accent-primary)]');
     expect(activeRow.classList.contains('text-foreground')).toBe(true);
     // Old solid accent fill must be gone
     expect(activeRow.className).not.toContain('bg-[var(--color-accent-primary)]');

--- a/src/components/cmd/modes/__tests__/ReferenceMode.test.tsx
+++ b/src/components/cmd/modes/__tests__/ReferenceMode.test.tsx
@@ -322,7 +322,7 @@ describe('ReferenceMode', () => {
   // #88 — active row styling: muted bg + accent border replaces solid fill
   // -------------------------------------------------------------------------
 
-  it('active row uses muted bg with accent border instead of solid accent fill (#88)', async () => {
+  it('active row uses neutral bg-muted/80 (matches PickerItem) — no accent border, no accent fill', async () => {
     mockProjects = [
       {
         path: '/Users/p/proj',
@@ -336,8 +336,8 @@ describe('ReferenceMode', () => {
     const activeRow = container.querySelector('[aria-selected="true"]') as HTMLElement;
     expect(activeRow).toBeTruthy();
     // New styling
-    expect(activeRow.classList.contains('bg-muted')).toBe(true);
-    expect(activeRow.className).toContain('border-[var(--color-accent-primary)]');
+    expect(activeRow.className).toContain('bg-muted/80');
+    expect(activeRow.className).not.toContain('border-[var(--color-accent-primary)]');
     expect(activeRow.classList.contains('text-foreground')).toBe(true);
     // Old solid accent fill must be gone
     expect(activeRow.className).not.toContain('bg-[var(--color-accent-primary)]');

--- a/src/components/cmd/modes/__tests__/ResearchMode.test.tsx
+++ b/src/components/cmd/modes/__tests__/ResearchMode.test.tsx
@@ -187,7 +187,7 @@ describe('ResearchMode', () => {
   // #88 — active row styling: muted bg + accent border replaces solid fill
   // -------------------------------------------------------------------------
 
-  it('active row uses muted bg with accent border instead of solid accent fill (#88)', async () => {
+  it('active row uses neutral bg-muted/80 (matches PickerItem) — no accent border, no accent fill', async () => {
     indexSearchResearchMock.mockResolvedValue([
       makeResult({ file: '/r/alpha.md', title: 'Alpha' }),
     ]);
@@ -198,8 +198,8 @@ describe('ResearchMode', () => {
     const activeRow = container.querySelector('[aria-selected="true"]') as HTMLElement;
     expect(activeRow).toBeTruthy();
     // New styling
-    expect(activeRow.classList.contains('bg-muted')).toBe(true);
-    expect(activeRow.className).toContain('border-[var(--color-accent-primary)]');
+    expect(activeRow.className).toContain('bg-muted/80');
+    expect(activeRow.className).not.toContain('border-[var(--color-accent-primary)]');
     expect(activeRow.classList.contains('text-foreground')).toBe(true);
     // Old solid accent fill must be gone
     expect(activeRow.className).not.toContain('bg-[var(--color-accent-primary)]');

--- a/src/components/cmd/modes/__tests__/SkillMode.test.tsx
+++ b/src/components/cmd/modes/__tests__/SkillMode.test.tsx
@@ -272,13 +272,13 @@ describe('SkillMode', () => {
   // #88 — active row styling: muted bg + accent border replaces solid fill
   // -------------------------------------------------------------------------
 
-  it('active row uses muted bg with accent border instead of solid accent fill (#88)', () => {
+  it('active row uses neutral bg-muted/80 (matches PickerItem) — no accent border, no accent fill', () => {
     const { container } = renderWithProviders(<SkillMode filter="" onPick={vi.fn()} />);
     const activeRow = container.querySelector('[aria-selected="true"]') as HTMLElement;
     expect(activeRow).toBeTruthy();
     // New styling
-    expect(activeRow.classList.contains('bg-muted')).toBe(true);
-    expect(activeRow.className).toContain('border-[var(--color-accent-primary)]');
+    expect(activeRow.className).toContain('bg-muted/80');
+    expect(activeRow.className).not.toContain('border-[var(--color-accent-primary)]');
     expect(activeRow.classList.contains('text-foreground')).toBe(true);
     // Old solid accent fill must be gone
     expect(activeRow.className).not.toContain('bg-[var(--color-accent-primary)]');

--- a/src/components/cmd/modes/__tests__/TagMode.test.tsx
+++ b/src/components/cmd/modes/__tests__/TagMode.test.tsx
@@ -253,7 +253,7 @@ describe('TagMode', () => {
   // #88 — active row styling: muted bg + accent border replaces solid fill
   // -------------------------------------------------------------------------
 
-  it('active row uses muted bg with accent border instead of solid accent fill (#88)', async () => {
+  it('active row uses neutral bg-muted/80 (matches PickerItem) — no accent border, no accent fill', async () => {
     indexTagsMock.mockResolvedValue([
       { tag: 'work', file_count: 5 },
     ]);
@@ -264,8 +264,8 @@ describe('TagMode', () => {
     const activeRow = container.querySelector('[aria-selected="true"]') as HTMLElement;
     expect(activeRow).toBeTruthy();
     // New styling
-    expect(activeRow.classList.contains('bg-muted')).toBe(true);
-    expect(activeRow.className).toContain('border-[var(--color-accent-primary)]');
+    expect(activeRow.className).toContain('bg-muted/80');
+    expect(activeRow.className).not.toContain('border-[var(--color-accent-primary)]');
     expect(activeRow.classList.contains('text-foreground')).toBe(true);
     // Old solid accent fill must be gone
     expect(activeRow.className).not.toContain('bg-[var(--color-accent-primary)]');

--- a/src/components/cmd/modes/__tests__/TaskMode.test.tsx
+++ b/src/components/cmd/modes/__tests__/TaskMode.test.tsx
@@ -548,7 +548,7 @@ describe('TaskMode', () => {
   // #88 — active row styling: muted bg + accent border replaces solid fill
   // -------------------------------------------------------------------------
 
-  it('active row uses muted bg with accent border instead of solid accent fill (#88)', async () => {
+  it('active row uses neutral bg-muted/80 (matches PickerItem) — no accent border, no accent fill', async () => {
     mockStore.actions = [
       makeAction({ id: 't1', text: 'Fix the bug' }),
     ];
@@ -559,8 +559,8 @@ describe('TaskMode', () => {
     const activeRow = container.querySelector('[aria-selected="true"]') as HTMLElement;
     expect(activeRow).toBeTruthy();
     // New styling
-    expect(activeRow.classList.contains('bg-muted')).toBe(true);
-    expect(activeRow.className).toContain('border-[var(--color-accent-primary)]');
+    expect(activeRow.className).toContain('bg-muted/80');
+    expect(activeRow.className).not.toContain('border-[var(--color-accent-primary)]');
     expect(activeRow.classList.contains('text-foreground')).toBe(true);
     // Old solid accent fill must be gone
     expect(activeRow.className).not.toContain('bg-[var(--color-accent-primary)]');


### PR DESCRIPTION
## Summary

Follow-up to #95 (canonical `<PickerItem>` primitive) and #90 (cmd-mode picker accent-fill removal). Drops the leftover accent-color border on the cmd-mode pickers' active row so every picker in the app uses the same `bg-muted/80` neutral muted active-row treatment — no chromatic affordance on the row itself, anywhere.

## Background

- **#90** replaced solid-accent-fill with `bg-muted` + accent border on the 7 cmd-mode pickers (SkillMode, FileMode, ReferenceMode, ResearchMode, TagMode, TaskMode, PaletteMode). Step in the right direction but introduced a chromatic affordance on the row.
- **#95** shipped the canonical `<PickerItem>` primitive (used everywhere else in the app: provider pickers, project picker, model picker, mode picker, thinking-effort picker, settings dialog) whose active/highlighted row uses `data-[highlighted]:bg-muted/80` — neutral, no border, no chromatic anything. Selection is conveyed by a right-aligned accent `Check` icon when relevant.

The cmd-mode pickers were the last remaining pickers using the accent-border treatment. After this PR, every picker in the app uses the same `bg-muted/80` for "where am I in the list."

## Why not migrate to `<PickerItem>` literally

The cmd-mode pickers are **combobox-style action pickers** (typing filters + arrow keys highlight + Enter invokes), not radio-style state pickers:
- Wrong ARIA pattern: `role="option"` + `aria-selected` (combobox) vs `role="menuitemradio"` + `aria-checked` (menu)
- Wrong keyboard model: parent-driven `activeIndex` (FloatingCommandBar's textarea) vs Radix-managed
- Wrong primitive base: cmdk / WAI-ARIA combobox vs Radix DropdownMenu

Visual unification only — implementation stays appropriate to each pattern.

## Files changed

**7 picker components** (`src/components/cmd/modes/*.tsx`) — replace `bg-muted border border-[var(--color-accent-primary)] rounded-md text-foreground` → `bg-muted/80 text-foreground` (9 occurrences total).

**8 regression-lock tests** — flip the assertion from `expect(...).toContain('border-[var(--color-accent-primary)]')` to `.not.toContain(...)`. The regression-lock now prevents the accent border from coming back instead of requiring it.

Resolves the open visual-consistency thread between #87 and #88. No new issue; this is the closure on both.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test --run` — 4429 tests pass, 1 skipped, 0 failed
- [x] All 8 cmd-mode regression tests still validate "no accent fill on row" (the original #88 intent) and now also validate "no accent border" (the new #95 alignment)
- [ ] (reviewer) live-test all 7 prefix modes (`/` skill, `:` palette, `:file`, `@`, `#`, `?`, `!`) and confirm active row matches the visual of the upper-row provider/project/model pickers

🤖 Generated with [Claude Code](https://claude.com/claude-code)