### PR TITLE
chore(aw): WORKFLOW_PAT for PR-creating workflows (resolves #118)

### DIFF
--- a/.claude/skills/aw-tdd/SKILL.md
+++ b/.claude/skills/aw-tdd/SKILL.md
@@ -96,18 +96,18 @@ When all gates pass:
 3. Push the branch.
 4. Open a **draft** PR via `gh pr create --draft --title "..." --body "..."`. Title pattern: same as commit subject. Body template below.
 
-   **Always attempt the PR creation.** Do NOT pre-emptively decide it will fail because the run is acting as `github-actions[bot]` — the workflow grants `pull-requests: write` to `GITHUB_TOKEN`. If `gh pr create` succeeds, capture the URL for the done comment.
+   The aw-tdd workflow uses the `WORKFLOW_PAT` fine-grained token (not `GITHUB_TOKEN`) for PR creation. The PAT has `pull-requests: write` and `workflows: write`, so `gh pr create` succeeds AND the resulting `pull_request: opened` event fires CI normally — the recursion guard does NOT apply to PAT-initiated events. See `docs/agentic-workflow.md` → "Choice: WORKFLOW_PAT for bot-PR CI gating" for the rationale.
+5. Update the subtask issue: add `review`, remove `tdd`. Post the done comment.
 
-   **If `gh pr create` returns the error `GitHub Actions is not permitted to create or approve pull requests`** (a repo-level setting under Settings → Actions → General → "Workflow permissions"), the skill cannot create the PR but the work is done. Post the **PR creation blocked** comment template (below) including the exact branch name and the auto-close keyword line so a human can paste them into a manual `gh pr create` command. Still flip `tdd → review` so the queue advances; the human will create the PR.
-5. Update the subtask issue: add `review`, remove `tdd`. Post the done comment (or the **PR creation blocked** template if step 4 hit the repo-setting block).
+6. **Optional: explicitly dispatch `aw-review`.**
 
-6. **Dispatch `aw-review` on the new PR.** Run:
+   Since the PR was created via `WORKFLOW_PAT`, `aw-review.yml`'s `pull_request: opened` trigger fires automatically — no explicit dispatch is required. The dispatch step below is kept as a defence-in-depth safety net in case the `pull_request` event was somehow missed (e.g. CI was paused on the repo).
 
    ```
    gh workflow run aw-review.yml --field pr_number=<N>
    ```
 
-   This is required because the PR was created via `gh pr create` using `GITHUB_TOKEN`, and per GitHub's recursion guard, events triggered by `GITHUB_TOKEN` do NOT fire downstream workflows (only `workflow_dispatch` and `repository_dispatch` are exempt). Without this explicit dispatch, `aw-review` never runs on bot-authored PRs and the independent-review gate is silently bypassed. Skip this step ONLY when the **PR creation blocked** path was taken (step 4) — there's no PR to review.
+   If you ran step 4 successfully, you can skip step 6.
 
 ## On failure
 
@@ -131,40 +131,6 @@ Following red-green-refactor:
 4. Opening draft PR if all gates pass
 
 Will update this comment thread with progress.
-```
-
-**PR creation blocked (repo setting):**
-
-Use this template ONLY when `gh pr create` returned `GitHub Actions is not permitted to create or approve pull requests`. Tests, branch, and commit are all done — only the PR creation step was blocked by the repo-level "Allow GitHub Actions to create and approve pull requests" setting.
-
-```
-> *Implementation complete. Branch pushed, but PR creation is blocked by a repo setting.*
-
-All hard gates passed:
-- Red phase: <N> tests written, all initially failing ✓
-- Green phase: minimum implementation, all <N> tests passing ✓
-- Full test suite: passing ✓
-- Typecheck: clean ✓
-
-**To open the PR, a maintainer can either:**
-
-A. Enable the setting (one-time fix for future runs too) — Settings → Actions → General → "Workflow permissions" → check **"Allow GitHub Actions to create and approve pull requests"** → Save. Then re-run `aw-tdd` via `gh workflow run aw-tdd.yml --field issue_number=<N>`.
-
-B. Open the PR manually:
-\`\`\`
-gh pr create --draft \\
-  --base main \\
-  --head <branch-name> \\
-  --title "<commit subject>" \\
-  --body "<Fixes|Resolves> #<N>
-
-## Summary
-<one-paragraph summary>
-"
-\`\`\`
-
-Branch: \`<branch-name>\`
-Auto-close keyword: \`<Fixes|Resolves> #<N>\`
 ```
 
 **Done (PR opened):**

--- a/.github/workflows/aw-iterate.yml
+++ b/.github/workflows/aw-iterate.yml
@@ -38,10 +38,15 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          # Use the fine-grained PAT so the follow-up commit push fires
+          # `pull_request: synchronize` and re-runs CI on the PR. See
+          # "Choice: WORKFLOW_PAT for bot-PR CI gating" in
+          # docs/agentic-workflow.md.
+          token: ${{ secrets.WORKFLOW_PAT }}
 
       - name: Switch to PR head branch
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.WORKFLOW_PAT }}
           PR: ${{ inputs.pr_number }}
         run: |
           set -euo pipefail
@@ -49,8 +54,6 @@ jobs:
           echo "PR #$PR is on branch: $BRANCH"
           git fetch origin "$BRANCH"
           git checkout "$BRANCH"
-          # Match the GitHub Actions bot identity so commits author cleanly
-          # and pushes via GITHUB_TOKEN don't trigger downstream workflows.
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
@@ -70,8 +73,9 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # See aw-pipeline.yml for the rationale.
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # WORKFLOW_PAT (not GITHUB_TOKEN) so the follow-up commit push
+          # triggers `pull_request: synchronize` and CI re-runs on the PR.
+          github_token: ${{ secrets.WORKFLOW_PAT }}
           allowed_bots: "github-actions[bot]"
           claude_args: |
             --max-turns 100

--- a/.github/workflows/aw-pipeline.yml
+++ b/.github/workflows/aw-pipeline.yml
@@ -201,6 +201,11 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          # WORKFLOW_PAT — the tdd job opens PRs and may push edits to
+          # .github/workflows/, which GITHUB_TOKEN can't write to. See
+          # "Choice: WORKFLOW_PAT for bot-PR CI gating" in
+          # docs/agentic-workflow.md.
+          token: ${{ secrets.WORKFLOW_PAT }}
       - uses: pnpm/action-setup@v4
         with:
           version: 9
@@ -214,12 +219,12 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # Use GITHUB_TOKEN so the agent's gh calls (label changes, comments,
-          # PR creation) trigger the built-in recursion guard — downstream
-          # workflows listening on issues.labeled / issue_comment / pull_request
-          # do NOT fire for our own actions. Bot identity becomes
-          # github-actions[bot] (not claude[bot]).
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Use WORKFLOW_PAT for the tdd job specifically — the bot-authored
+          # PR it creates needs to fire `pull_request` events to run CI.
+          # GITHUB_TOKEN's recursion guard suppresses those events.
+          # The other stages in this pipeline (triage / refine / slice)
+          # don't open PRs and stay on GITHUB_TOKEN.
+          github_token: ${{ secrets.WORKFLOW_PAT }}
           allowed_bots: "github-actions[bot]"
           claude_args: |
             --max-turns 200

--- a/.github/workflows/aw-retrospect.yml
+++ b/.github/workflows/aw-retrospect.yml
@@ -37,13 +37,18 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0   # need history to look at post-merge commits
+          # WORKFLOW_PAT — aw-retrospect opens skill-patch PRs; pushing the
+          # branch via GITHUB_TOKEN would suppress CI on those PRs.
+          token: ${{ secrets.WORKFLOW_PAT }}
 
       - name: Run aw-retrospect skill
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # See aw-pipeline.yml for the rationale.
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # WORKFLOW_PAT so the draft retro PR fires CI normally — see
+          # "Choice: WORKFLOW_PAT for bot-PR CI gating" in
+          # docs/agentic-workflow.md.
+          github_token: ${{ secrets.WORKFLOW_PAT }}
           allowed_bots: "github-actions[bot]"
           claude_args: |
             --max-turns 60

--- a/.github/workflows/aw-sweep.yml
+++ b/.github/workflows/aw-sweep.yml
@@ -295,6 +295,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          # WORKFLOW_PAT — same rationale as aw-pipeline.yml's tdd job:
+          # the bot-authored PR needs to fire `pull_request` events for CI.
+          token: ${{ secrets.WORKFLOW_PAT }}
 
       - uses: pnpm/action-setup@v4
         with:
@@ -312,8 +315,8 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # See aw-pipeline.yml for the rationale.
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # WORKFLOW_PAT — same rationale as aw-pipeline.yml's tdd job.
+          github_token: ${{ secrets.WORKFLOW_PAT }}
           claude_args: |
             --max-turns 200
             --allowedTools "Bash,Edit,Write,Read,Grep,Glob"

--- a/.github/workflows/aw-tdd.yml
+++ b/.github/workflows/aw-tdd.yml
@@ -36,6 +36,11 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          # Use the fine-grained PAT so the agent can later push branches
+          # — including .github/workflows/ edits, which GITHUB_TOKEN can't
+          # touch. See "Choice: WORKFLOW_PAT for bot-PR CI gating" in
+          # docs/agentic-workflow.md.
+          token: ${{ secrets.WORKFLOW_PAT }}
 
       - uses: pnpm/action-setup@v4
         with:
@@ -101,8 +106,12 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # See aw-pipeline.yml for the rationale.
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Use the fine-grained PAT (WORKFLOW_PAT) instead of GITHUB_TOKEN
+          # so the bot-authored PR fires `pull_request` events normally
+          # — without it, the recursion guard suppresses `test.yml` and the
+          # PR ends up with no CI checks. See "Choice: WORKFLOW_PAT for
+          # bot-PR CI gating" in docs/agentic-workflow.md.
+          github_token: ${{ secrets.WORKFLOW_PAT }}
           allowed_bots: "github-actions[bot]"
           claude_args: |
             --max-turns 200

--- a/docs/agentic-workflow.md
+++ b/docs/agentic-workflow.md
@@ -162,6 +162,8 @@ Ten workflow files. One *pipeline* + one *sweep* + four *standalones* + one *ret
 
 Each precheck-bearing workflow finds candidates with `gh + jq` before invoking the LLM (zero token cost on empty sweeps). Cron tick is every 15 minutes.
 
+**Token usage per workflow.** Workflows that create PRs or push to PR branches use `WORKFLOW_PAT` (a fine-grained PAT secret, see "Choice: WORKFLOW_PAT for bot-PR CI gating" below): `aw-tdd.yml`, `aw-iterate.yml`, `aw-retrospect.yml`, and the `tdd:` jobs in `aw-pipeline.yml` and `aw-sweep.yml`. Everything else (`aw-triage`, `aw-refine`, `aw-slice`, `aw-feedback`, `aw-review`, and the non-tdd jobs in pipeline/sweep) uses `GITHUB_TOKEN` so label/comment edits are suppressed by the recursion guard.
+
 ## Lifecycle (worked example, default path)
 
 | Step | Issue state |
@@ -267,6 +269,33 @@ We chose a hybrid: pipeline workflow for the happy path (one trigger, jobs chain
 **What we keep.** OAuth still authenticates the LLM call via `claude_code_oauth_token` — that's separate from the GitHub API token. We still get subscription quota, not pay-per-token.
 
 **Side effect — explicit dispatch from** `aw-feedback`**.** A consequence of the recursion guard is that when one of our workflows flips a label on the human's behalf (`aw-feedback` resetting `hitl → afk`, `→ refine`, `→ slice`, etc.), the corresponding standalone does NOT auto-fire from the `issues.labeled` event. Without intervention, the next sweep cron tick (\~15 min later) would eventually pick it up, breaking the conversational tightness the feedback loop is built for. Fix: every label-flip action in `aw-feedback`'s skill is followed by an explicit `gh workflow run <next>.yml --field issue_number=N`. `workflow_dispatch` events ARE exempt from the recursion guard (along with `repository_dispatch`), so the dispatched workflow fires immediately.
+
+### Choice: WORKFLOW_PAT for bot-PR CI gating (#118)
+
+**The problem.** The GITHUB_TOKEN choice above is correct for label/comment edits — recursion guard suppression keeps the Actions tab honest. But it has a downside the original choice didn't address: **PRs created by `gh pr create` via `GITHUB_TOKEN` also don't fire `pull_request` events.** That means `test.yml` (which listens on `pull_request: opened/synchronize/reopened`) never runs on bot-authored PRs. We were merging bot PRs based only on the agent's local-runner test pass, with zero CI verification — the agent's container can't even compile some platform-specific code (`glib-2.0` for the Rust backend on Linux), so Rust regressions silently slipped through. Plus a separate gap: `GITHUB_TOKEN` lacks the `workflows:write` scope, so bot PRs that need to touch `.github/workflows/` couldn't be pushed at all (cost a manual-rerun on PR #105 yesterday).
+
+**The fix.** A fine-grained Personal Access Token (`WORKFLOW_PAT`) scoped to this repo only, with `Contents:R&W + Pull requests:R&W + Workflows:R&W + Issues:R&W + Actions:R + Metadata:R`. Used by every workflow that creates PRs or pushes commits to PR branches:
+
+- `aw-tdd.yml` (standalone), `aw-pipeline.yml` `tdd:` job, `aw-sweep.yml` `tdd:` job — open the implementation PR
+- `aw-iterate.yml` — pushes follow-up commits, needs `pull_request: synchronize` to fire CI
+- `aw-retrospect.yml` — opens skill-patch PRs, same CI gating need
+
+The other workflows (`aw-triage`, `aw-refine`, `aw-slice`, `aw-feedback`, `aw-review`, and the non-tdd jobs in pipeline/sweep) keep `GITHUB_TOKEN` because they only flip labels and post comments — operations that benefit from recursion-guard suppression and don't need CI re-firing.
+
+**Side effects.**
+
+- Bot identity for PR-creating runs becomes the PAT owner (the human who minted the token), not `github-actions[bot]`. The `allowed_bots: "github-actions[bot]"` filter still works because `claude-code-action`'s internal git operations are still bot-attributed.
+- `aw-tdd`'s SKILL.md "PR creation blocked" fallback paragraph (for the case where the repo setting "Allow GitHub Actions to create and approve pull requests" is off) is now unreachable — the PAT has the rights regardless of that repo setting. The fallback was removed when this choice landed.
+- `aw-tdd`'s SKILL.md step "Dispatch `aw-review` on the new PR" was also marked optional — the PR's `pull_request: opened` event now fires automatically (the recursion guard does NOT suppress PAT-initiated events), so `aw-review.yml` triggers on its own. The explicit dispatch is kept as a defence-in-depth safety net.
+- The repo-level "Allow GitHub Actions to create and approve pull requests" setting can be turned OFF (one less attack surface) — PR creation no longer routes through the `github-actions[bot]` identity.
+
+**Token rotation cadence.** Fine-grained PATs expire at most every 365 days but typically configured for 90 days. Calendar reminder for the human owner of the token to regenerate before expiry; secret value updates without any workflow file changes.
+
+**Why not GitHub App.** Strictly more secure but significantly more setup (app creation, private key management, install on repo, `actions/create-github-app-token` in every workflow). Overkill for solo-dev / one repo today; revisit if multi-repo expansion happens later.
+
+**Why not `pull_request_target`.** Would solve the CI gap by running tests in the base-branch context with secrets available, but [GitHub Security Lab guidance](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/) treats this pattern as dangerous because it exposes secrets to potentially-untrusted PR code. Bot PRs are trusted today, but the precedent leaks to any future contributor PRs.
+
+**Regression lock.** `src/lib/__tests__/aw-workflow-pat.test.ts` parses every `aw-*.yml` and asserts the PAT/GITHUB_TOKEN choice per workflow — catches drift if a future edit accidentally swaps the token in the wrong direction.
 
 ### Choice: claude-code-action with OAuth (not gh-aw, not API key)
 

--- a/src/lib/__tests__/aw-workflow-pat.test.ts
+++ b/src/lib/__tests__/aw-workflow-pat.test.ts
@@ -1,0 +1,206 @@
+// Regression-lock tests for the AW pipeline's WORKFLOW_PAT vs GITHUB_TOKEN
+// convention.
+//
+// Issue #118 — `pull_request` workflows (e.g. test.yml) do NOT fire when
+// the PR is created by an action using GITHUB_TOKEN, because of GitHub's
+// built-in recursion guard. Workflows that create PRs (`aw-tdd.yml`,
+// `aw-iterate.yml`, `aw-retrospect.yml`, plus the `tdd:` jobs in
+// `aw-pipeline.yml` and `aw-sweep.yml`) must use a fine-grained PAT
+// (`WORKFLOW_PAT`) so the resulting PR fires CI normally. Workflows that
+// only flip labels and post comments (`aw-triage`, `aw-refine`,
+// `aw-slice`, `aw-feedback`, `aw-review`, the non-tdd jobs in
+// pipeline/sweep) keep `GITHUB_TOKEN` so the recursion guard suppresses
+// the noise.
+//
+// These tests parse every `aw-*.yml` and assert which token each
+// claude-code-action invocation uses. They catch the drift case where a
+// future edit accidentally swaps the token in either direction:
+//
+// - Wrong direction A: a PR-creating workflow downgraded to GITHUB_TOKEN
+//   → bot PRs would silently lose CI checks again (the symptom that
+//   caused #118)
+// - Wrong direction B: a label-flipping workflow upgraded to WORKFLOW_PAT
+//   → label edits would start firing downstream workflow runs again,
+//   re-introducing the noise that the original GITHUB_TOKEN choice
+//   eliminated
+//
+// The same parsing approach used by the concurrency-lock test
+// (`aw-workflow-concurrency.test.ts`) — workflow YAML is the source of
+// truth, this just asserts the convention.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { parse as parseYaml } from 'yaml';
+
+interface ClaudeStep {
+  uses?: string;
+  with?: {
+    github_token?: string;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+interface CheckoutStep {
+  uses?: string;
+  with?: {
+    token?: string;
+    [key: string]: unknown;
+  };
+}
+
+interface JobYaml {
+  steps?: Array<ClaudeStep | CheckoutStep | Record<string, unknown>>;
+  [key: string]: unknown;
+}
+
+interface WorkflowYaml {
+  jobs: Record<string, JobYaml>;
+}
+
+function loadWorkflow(name: string): WorkflowYaml {
+  const path = resolve(__dirname, '../../../.github/workflows', `${name}.yml`);
+  return parseYaml(readFileSync(path, 'utf-8')) as WorkflowYaml;
+}
+
+/** Find the `claude-code-action` step within a job and return its `github_token` value. */
+function getClaudeTokenInJob(job: JobYaml): string | undefined {
+  if (!job.steps) return undefined;
+  for (const step of job.steps as ClaudeStep[]) {
+    if (typeof step.uses === 'string' && step.uses.includes('anthropics/claude-code-action')) {
+      return step.with?.github_token;
+    }
+  }
+  return undefined;
+}
+
+/** Find the `actions/checkout` step within a job and return its `token` value (or undefined if not set). */
+function getCheckoutTokenInJob(job: JobYaml): string | undefined {
+  if (!job.steps) return undefined;
+  for (const step of job.steps as CheckoutStep[]) {
+    if (typeof step.uses === 'string' && step.uses.includes('actions/checkout')) {
+      return step.with?.token;
+    }
+  }
+  return undefined;
+}
+
+const PAT = '${{ secrets.WORKFLOW_PAT }}';
+const GH_TOKEN = '${{ secrets.GITHUB_TOKEN }}';
+
+describe('AW workflow token convention (#118 — bot-PR CI gating)', () => {
+  // ── Workflows that create PRs or push to PR branches → must use WORKFLOW_PAT ──
+
+  describe('aw-tdd.yml — opens implementation PRs', () => {
+    const wf = loadWorkflow('aw-tdd');
+
+    it('the code job uses WORKFLOW_PAT for the claude-code-action github_token', () => {
+      expect(getClaudeTokenInJob(wf.jobs.code)).toBe(PAT);
+    });
+
+    it('the code job uses WORKFLOW_PAT for actions/checkout token (so git push fires CI)', () => {
+      expect(getCheckoutTokenInJob(wf.jobs.code)).toBe(PAT);
+    });
+  });
+
+  describe('aw-iterate.yml — pushes follow-up commits to PR branches', () => {
+    const wf = loadWorkflow('aw-iterate');
+
+    it('the iterate job uses WORKFLOW_PAT for the claude-code-action github_token', () => {
+      expect(getClaudeTokenInJob(wf.jobs.iterate)).toBe(PAT);
+    });
+
+    it('the iterate job uses WORKFLOW_PAT for actions/checkout token (so push triggers pull_request:synchronize)', () => {
+      expect(getCheckoutTokenInJob(wf.jobs.iterate)).toBe(PAT);
+    });
+  });
+
+  describe('aw-retrospect.yml — opens skill-patch PRs', () => {
+    const wf = loadWorkflow('aw-retrospect');
+
+    it('the retrospect job uses WORKFLOW_PAT for the claude-code-action github_token', () => {
+      expect(getClaudeTokenInJob(wf.jobs.retrospect)).toBe(PAT);
+    });
+
+    it('the retrospect job uses WORKFLOW_PAT for actions/checkout token', () => {
+      expect(getCheckoutTokenInJob(wf.jobs.retrospect)).toBe(PAT);
+    });
+  });
+
+  describe('aw-pipeline.yml — only the tdd job creates PRs', () => {
+    const wf = loadWorkflow('aw-pipeline');
+
+    it('the tdd job uses WORKFLOW_PAT for the claude-code-action github_token', () => {
+      expect(getClaudeTokenInJob(wf.jobs.tdd)).toBe(PAT);
+    });
+
+    it('the tdd job uses WORKFLOW_PAT for actions/checkout token', () => {
+      expect(getCheckoutTokenInJob(wf.jobs.tdd)).toBe(PAT);
+    });
+
+    it('triage / refine / slice jobs use GITHUB_TOKEN (no PRs created → recursion guard suppression is desired)', () => {
+      expect(getClaudeTokenInJob(wf.jobs.triage)).toBe(GH_TOKEN);
+      expect(getClaudeTokenInJob(wf.jobs.refine)).toBe(GH_TOKEN);
+      expect(getClaudeTokenInJob(wf.jobs.slice)).toBe(GH_TOKEN);
+    });
+  });
+
+  describe('aw-sweep.yml — only the tdd job creates PRs', () => {
+    const wf = loadWorkflow('aw-sweep');
+
+    it('the tdd job uses WORKFLOW_PAT for the claude-code-action github_token', () => {
+      expect(getClaudeTokenInJob(wf.jobs.tdd)).toBe(PAT);
+    });
+
+    it('the tdd job uses WORKFLOW_PAT for actions/checkout token', () => {
+      expect(getCheckoutTokenInJob(wf.jobs.tdd)).toBe(PAT);
+    });
+
+    it('triage / refine / slice skill jobs use GITHUB_TOKEN', () => {
+      expect(getClaudeTokenInJob(wf.jobs.triage)).toBe(GH_TOKEN);
+      expect(getClaudeTokenInJob(wf.jobs.refine)).toBe(GH_TOKEN);
+      expect(getClaudeTokenInJob(wf.jobs.slice)).toBe(GH_TOKEN);
+    });
+  });
+
+  // ── Workflows that only flip labels / comments → must use GITHUB_TOKEN ──
+
+  describe('aw-triage.yml — only classifies issues', () => {
+    const wf = loadWorkflow('aw-triage');
+    it('uses GITHUB_TOKEN (label edits should NOT fire downstream)', () => {
+      expect(getClaudeTokenInJob(wf.jobs.triage)).toBe(GH_TOKEN);
+    });
+  });
+
+  describe('aw-refine.yml — only rewrites issue body + label edits', () => {
+    const wf = loadWorkflow('aw-refine');
+    it('uses GITHUB_TOKEN', () => {
+      expect(getClaudeTokenInJob(wf.jobs.refine)).toBe(GH_TOKEN);
+    });
+  });
+
+  describe('aw-slice.yml — creates peer issues but not PRs', () => {
+    const wf = loadWorkflow('aw-slice');
+    it('uses GITHUB_TOKEN', () => {
+      expect(getClaudeTokenInJob(wf.jobs.slice)).toBe(GH_TOKEN);
+    });
+  });
+
+  describe('aw-feedback.yml — only flips labels + posts comments', () => {
+    const wf = loadWorkflow('aw-feedback');
+    it('uses GITHUB_TOKEN', () => {
+      // Feedback workflow's job name is `feedback` per its YAML
+      const jobName = Object.keys(wf.jobs)[0];
+      expect(getClaudeTokenInJob(wf.jobs[jobName])).toBe(GH_TOKEN);
+    });
+  });
+
+  describe('aw-review.yml — modifies PR state but does not create new PRs', () => {
+    const wf = loadWorkflow('aw-review');
+    it('uses GITHUB_TOKEN', () => {
+      const jobName = Object.keys(wf.jobs)[0];
+      expect(getClaudeTokenInJob(wf.jobs[jobName])).toBe(GH_TOKEN);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Resolves #118 — the CI-doesn't-fire-on-bot-PRs gap. PR-creating workflows now use a fine-grained `WORKFLOW_PAT` secret instead of `GITHUB_TOKEN`, so the resulting bot PR fires `pull_request: opened` and `test.yml` runs normally on the rollup.

## What changed

| File | Change |
|---|---|
| `aw-tdd.yml` | `github_token` + checkout `token` → `WORKFLOW_PAT` |
| `aw-iterate.yml` | Same — pushes follow-up commits, needs `pull_request: synchronize` to fire |
| `aw-retrospect.yml` | Same — opens skill-patch PRs |
| `aw-pipeline.yml` | Only the `tdd:` job swapped (other stages don't open PRs, keep `GITHUB_TOKEN` for recursion-guard noise suppression) |
| `aw-sweep.yml` | Same — only the `tdd:` job swapped |
| `aw-tdd/SKILL.md` | Removed the unreachable "PR creation blocked" fallback paragraph (~30 lines); downgraded the explicit `aw-review` dispatch step to optional with a defence-in-depth note |
| `docs/agentic-workflow.md` | New "Choice: WORKFLOW_PAT for bot-PR CI gating (#118)" section under design decisions; updated Workflows table footer with token usage per workflow |
| `src/lib/__tests__/aw-workflow-pat.test.ts` (NEW) | 17 regression-lock tests parsing every `aw-*.yml` and asserting which token each invocation uses |

## What you've already done (steps 1–3)

- ✅ Created the fine-grained PAT (`notesage-aw-workflow`, 90-day expiry)
- ✅ Saved as repo secret `WORKFLOW_PAT`
- ✅ Optionally turned off "Allow GitHub Actions to create and approve pull requests" repo setting

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test --run` — 4538 pass, 1 skipped, 0 fail (17 new tests in `aw-workflow-pat.test.ts`)
- [x] Token assignment audit — every PR-creating invocation uses `WORKFLOW_PAT`, every label-only invocation uses `GITHUB_TOKEN`
- [ ] **(this PR itself)** verifies the fix works: this PR is human-authored from your account, so it'll fire CI normally — confirms the test workflow exists and gates merge. The REAL test of the fix is the next bot-authored PR after this lands. Watch for the three CI checks (Frontend / Playwright / Rust) appearing on a bot PR's rollup.
- [ ] (post-merge) file a small test issue, watch `aw-tdd` open a PR, confirm CI checks appear on it within ~60s

## Calendar reminder

PAT expires **2026-08-01**. Regenerate at https://github.com/settings/personal-access-tokens with the same permissions, update the `WORKFLOW_PAT` secret value. No workflow file changes needed.

## Security context

The new "Choice" section in `docs/agentic-workflow.md` documents WHY this beats the alternatives:
- **Not GitHub App** — overkill for solo-dev / one repo, more setup overhead
- **Not `pull_request_target`** — would expose secrets to bot PR code, a smell that leaks to future contributor PRs (per [GitHub Security Lab guidance](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/))

🤖 Generated with [Claude Code](https://claude.com/claude-code)