### PR TITLE
fix(aw-sweep): prevent duplicate concurrent runs on atomic label swaps

### DIFF
--- a/.github/workflows/aw-sweep.yml
+++ b/.github/workflows/aw-sweep.yml
@@ -42,11 +42,25 @@ permissions:
   actions: write        # tdd dispatches aw-review.yml after the PR is created
   id-token: write       # claude-code-action OIDC
 
-# NOTE: workflow-level concurrency removed. Per-skill-job concurrency
-# uses `aw-stage-{stage}-{candidate}` so it shares a key with the
-# pipeline + standalone for that same issue+stage (#98). The find_*
-# jobs run unconditionally on each tick (they're cheap precheck-only)
-# and don't need concurrency gating.
+# Workflow-level concurrency — scoped to the triggering issue (#103).
+#
+# When `gh issue edit --add-label tdd --remove-label slice` fires, GitHub
+# emits TWO events (one `labeled` and one `unlabeled`) which can trigger
+# two concurrent sweep runs. Scoping the group to the issue number collapses
+# those into a single slot; `cancel-in-progress: true` cancels the second
+# run since it delivers no new information.
+#
+# For cron ticks (no issue.number) the fallback to `github.run_id` keeps
+# each cron run in its own slot — cron sweeps are independent and should
+# never cancel each other.
+#
+# The per-skill-job concurrency groups (aw-stage-{stage}-{candidate}) are
+# RETAINED unchanged — they guard cross-workflow races between the pipeline,
+# sweep, and standalone workflows for the same issue+stage (#98). This
+# workflow-level block only prevents duplicate SWEEP runs for the same issue.
+concurrency:
+  group: aw-sweep-${{ github.event.issue.number || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   # ── triage ────────────────────────────────────────────────────────────────

--- a/src/lib/__tests__/aw-workflow-concurrency.test.ts
+++ b/src/lib/__tests__/aw-workflow-concurrency.test.ts
@@ -129,8 +129,26 @@ describe('AW workflow concurrency convention (#98)', () => {
   describe('Sweep workflow — find/skill split + per-skill concurrency', () => {
     const sweep = loadWorkflow('aw-sweep');
 
-    it('has NO workflow-level concurrency (per-job groups on the skill jobs)', () => {
-      expect(sweep.concurrency).toBeUndefined();
+    // Issue #103 — when `gh issue edit --add-label tdd --remove-label slice`
+    // fires, GitHub emits TWO events (labeled + unlabeled) which can trigger
+    // two concurrent sweep runs. A workflow-level concurrency block scoped to
+    // the issue number collapses those two events into a single run.
+    // `cancel-in-progress: true` ensures the second event (which delivers no
+    // new information) cancels instead of racing the first.
+    // The `github.run_id` fallback preserves isolation for cron ticks
+    // (where `github.event.issue.number` is empty).
+    it('has workflow-level concurrency block to prevent duplicate issue-event runs', () => {
+      expect(sweep.concurrency).toBeDefined();
+    });
+
+    it('uses issue-scoped group with run_id fallback for cron isolation', () => {
+      expect(sweep.concurrency!.group).toBe(
+        "aw-sweep-${{ github.event.issue.number || github.run_id }}",
+      );
+    });
+
+    it('uses cancel-in-progress: true to collapse duplicate labeled/unlabeled events', () => {
+      expect(sweep.concurrency!['cancel-in-progress']).toBe(true);
     });
 
     for (const stage of STAGES) {


### PR DESCRIPTION
Fixes #103

## Summary

When `gh issue edit --add-label tdd --remove-label slice` fires, GitHub emits two separate events (`labeled` for `tdd` and `unlabeled` for `slice`). This triggers two concurrent sweep workflow runs that race through the same precheck and can spawn duplicate agent sessions for the same issue.

The fix adds a workflow-level concurrency block to `aw-sweep.yml` scoped to the triggering issue number (`github.event.issue.number`). With `cancel-in-progress: true`, when two events from the same atomic label swap arrive, the second run is cancelled — it delivers no new information. For cron ticks (where `github.event.issue.number` is empty), the `github.run_id` fallback preserves per-run isolation so cron sweeps never cancel each other.

The per-skill-job concurrency groups (`aw-stage-{stage}-{candidate}`) are retained unchanged — they guard cross-workflow races between the pipeline, sweep, and standalone workflows for the same issue+stage (issue #98).

## Red tests added

- `src/lib/__tests__/aw-workflow-concurrency.test.ts::has workflow-level concurrency block to prevent duplicate issue-event runs` — asserts `sweep.concurrency` is defined (was undefined before fix)
- `src/lib/__tests__/aw-workflow-concurrency.test.ts::uses issue-scoped group with run_id fallback for cron isolation` — asserts the group expression is `aw-sweep-${{ github.event.issue.number || github.run_id }}`
- `src/lib/__tests__/aw-workflow-concurrency.test.ts::uses cancel-in-progress: true to collapse duplicate labeled/unlabeled events` — asserts `cancel-in-progress` is `true`

## Green implementation

- `.github/workflows/aw-sweep.yml`: Added workflow-level `concurrency` block with `group: aw-sweep-${{ github.event.issue.number || github.run_id }}` and `cancel-in-progress: true`. Replaced the previous comment noting workflow-level concurrency had been removed with the new block and its rationale.
- `src/lib/__tests__/aw-workflow-concurrency.test.ts`: Replaced the test asserting `sweep.concurrency` is `undefined` with three new tests asserting the new workflow-level concurrency structure.

## Refactor

Skipped — implementation is already minimal.

## Verification

- [x] Red tests were red before implementation
- [x] All red tests now green
- [x] `pnpm test` passes (244 test files, 4540 tests + 1 skipped)
- [x] `pnpm typecheck` clean
- [x] No unrelated files modified

## Notes for reviewer

The previous test in `aw-workflow-concurrency.test.ts` that asserted `sweep.concurrency` is `undefined` was the direct conflict with this fix — it needed to be replaced with tests for the new behavior. The old test was correct for the previous design (workflow-level concurrency intentionally removed as per the comment in the file); this fix reverses that decision specifically for the issue-event trigger path while preserving cron isolation via the `run_id` fallback.

The per-job concurrency groups on the skill jobs remain unchanged (`cancel-in-progress: false`) — those guard cross-workflow races, not same-workflow duplicate event races.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the `aw-tdd` skill.