### PR TITLE
fix(aw): defensive post-checks + max-turns bump to catch silent success on budget exhaustion

### DIFF
--- a/.github/workflows/aw-pipeline.yml
+++ b/.github/workflows/aw-pipeline.yml
@@ -54,7 +54,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           allowed_bots: "github-actions[bot]"
           claude_args: |
-            --max-turns 30
+            --max-turns 50
             --allowedTools "Bash(gh:*),Read"
           prompt: |
             Run the `aw-triage` skill at `.claude/skills/aw-triage/SKILL.md`
@@ -63,6 +63,23 @@ jobs:
             precisely. Apply exactly one of `bug` / `enhancement` / `chore`,
             add `refine` (action label), or close as duplicate / wontfix
             per the skill rules.
+      - name: Verify triage actually completed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          STATE=$(gh issue view ${{ github.event.issue.number }} --json state --jq '.state')
+          if [[ "$STATE" != "OPEN" ]]; then
+            echo "Issue closed (duplicate/wontfix). Triage complete."
+            exit 0
+          fi
+          LABELS=$(gh issue view ${{ github.event.issue.number }} --json labels --jq '[.labels[].name]')
+          HAS_CATEGORY=$(echo "$LABELS" | jq -r 'any(. == "bug" or . == "enhancement" or . == "chore")')
+          HAS_REFINE=$(echo "$LABELS" | jq -r 'any(. == "refine")')
+          if [[ "$HAS_CATEGORY" != "true" ]] || [[ "$HAS_REFINE" != "true" ]]; then
+            echo "::error::aw-triage agent exited cleanly but did NOT flip labels (category=$HAS_CATEGORY, refine=$HAS_REFINE). Likely ran out of --max-turns budget. Sweep cron will recover within 15 min."
+            exit 1
+          fi
       - name: Check classification
         id: check
         env:
@@ -111,7 +128,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           allowed_bots: "github-actions[bot]"
           claude_args: |
-            --max-turns 30
+            --max-turns 50
             --allowedTools "Bash(gh:*),Read"
           prompt: |
             Run the `aw-refine` skill at `.claude/skills/aw-refine/SKILL.md`
@@ -119,6 +136,18 @@ jobs:
             (PeterBlenessy/notesage). Read the skill in full and follow it
             precisely. Add `refined` (state) + `slice` (action); remove
             `refine`. Pick the right template for the category.
+      - name: Verify refine actually completed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          LABELS=$(gh issue view ${{ github.event.issue.number }} --json labels --jq '[.labels[].name]')
+          HAS_SLICE=$(echo "$LABELS" | jq -r 'any(. == "slice")')
+          HAS_REFINED=$(echo "$LABELS" | jq -r 'any(. == "refined")')
+          if [[ "$HAS_SLICE" != "true" ]] || [[ "$HAS_REFINED" != "true" ]]; then
+            echo "::error::aw-refine agent exited cleanly but did NOT flip labels (slice=$HAS_SLICE, refined=$HAS_REFINED). Likely ran out of --max-turns budget. Sweep cron will recover within 15 min."
+            exit 1
+          fi
       - name: Check ready-to-slice
         id: check
         env:
@@ -168,6 +197,32 @@ jobs:
             N-1 new peer issues for the remaining values (no GraphQL
             sub-issue link). If under-specified, create ONE research peer
             and set the original to `awaiting-research`.
+      - name: Verify slice actually completed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          LABELS=$(gh issue view "$ISSUE" --json labels --jq '[.labels[].name]')
+          HAS_TDD=$(echo "$LABELS" | jq -r 'any(. == "tdd")')
+          HAS_AFK_OR_HITL=$(echo "$LABELS" | jq -r 'any(. == "afk" or . == "hitl")')
+          HAS_AWAITING=$(echo "$LABELS" | jq -r 'any(. == "awaiting-research")')
+          # Valid outcomes: (tdd + afk|hitl) OR awaiting-research OR issue was split
+          # (peer issues now carry tdd; original may have been rewritten)
+          if [[ "$HAS_AWAITING" == "true" ]]; then
+            echo "Slice set awaiting-research. OK."
+            exit 0
+          fi
+          if [[ "$HAS_TDD" == "true" && "$HAS_AFK_OR_HITL" == "true" ]]; then
+            echo "Slice set tdd + afk/hitl. OK."
+            exit 0
+          fi
+          # Check if the issue was sliced (original rewritten as peer slice 1)
+          HAS_SLICE=$(echo "$LABELS" | jq -r 'any(. == "slice")')
+          if [[ "$HAS_SLICE" == "false" ]]; then
+            echo "::error::aw-slice agent exited cleanly but did NOT produce a valid outcome (tdd=$HAS_TDD, afk/hitl=$HAS_AFK_OR_HITL, awaiting-research=$HAS_AWAITING). Likely ran out of --max-turns budget. Sweep cron will recover within 15 min."
+            exit 1
+          fi
       - name: Check if original issue is ready for tdd
         id: check
         env:
@@ -239,3 +294,24 @@ jobs:
             `pnpm test` and `pnpm typecheck` must pass; only the files
             listed in the subtask body may be modified. Open the PR as
             DRAFT (`gh pr create --draft`). Re-add `afk` on any failure.
+      - name: Verify tdd actually completed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          LABELS=$(gh issue view "$ISSUE" --json labels --jq '[.labels[].name]')
+          HAS_REVIEW=$(echo "$LABELS" | jq -r 'any(. == "review")')
+          if [[ "$HAS_REVIEW" == "true" ]]; then
+            echo "aw-tdd opened a PR and set review label. OK."
+            exit 0
+          fi
+          # Also accept if a draft PR referencing this issue already exists
+          # (label write can have latency; PR existence is authoritative).
+          PR_COUNT=$(gh pr list --search "fixes #$ISSUE OR resolves #$ISSUE" --state open --json number --jq 'length')
+          if [[ "$PR_COUNT" -gt 0 ]]; then
+            echo "aw-tdd opened a PR (found $PR_COUNT). OK."
+            exit 0
+          fi
+          echo "::error::aw-tdd agent exited cleanly but did NOT open a PR or set the review label (review=$HAS_REVIEW, open PRs=$PR_COUNT). Likely ran out of --max-turns budget or hit a hard gate. Sweep cron will recover within 15 min."
+          exit 1

--- a/.github/workflows/aw-refine.yml
+++ b/.github/workflows/aw-refine.yml
@@ -75,7 +75,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           allowed_bots: "github-actions[bot]"
           claude_args: |
-            --max-turns 30
+            --max-turns 50
             --allowedTools "Bash(gh:*),Read"
           prompt: |
             Run the `aw-refine` skill at `.claude/skills/aw-refine/SKILL.md`

--- a/.github/workflows/aw-sweep.yml
+++ b/.github/workflows/aw-sweep.yml
@@ -102,7 +102,7 @@ jobs:
           # downstream skipped runs. Bot identity becomes github-actions[bot].
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: |
-            --max-turns 30
+            --max-turns 50
             --allowedTools "Bash(gh:*),Read"
           prompt: |
             Run the `aw-triage` skill at `.claude/skills/aw-triage/SKILL.md`
@@ -165,7 +165,7 @@ jobs:
           # See aw-pipeline.yml for the rationale.
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: |
-            --max-turns 30
+            --max-turns 50
             --allowedTools "Bash(gh:*),Read"
           prompt: |
             Run the `aw-refine` skill at `.claude/skills/aw-refine/SKILL.md`

--- a/.github/workflows/aw-triage.yml
+++ b/.github/workflows/aw-triage.yml
@@ -70,7 +70,7 @@ jobs:
           # downstream skipped runs. Bot identity becomes github-actions[bot].
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: |
-            --max-turns 30
+            --max-turns 50
             --allowedTools "Bash(gh:*),Read"
           prompt: |
             Run the `aw-triage` skill at `.claude/skills/aw-triage/SKILL.md`

--- a/docs/agentic-workflow.md
+++ b/docs/agentic-workflow.md
@@ -376,8 +376,8 @@ Self-improvement loop. On claude\[bot\] PR merge, look for divergence between th
 - **AFK** — agent-OK-to-run-autonomously. `afk`-labeled issue is picked up by aw-tdd without approval.
 - **Hard gate** — a check in aw-tdd that aborts the run on failure (red-not-red, tests fail, typecheck fail, unrelated files modified).
 - **Pipeline workflow** — `aw-pipeline.yml`. Single workflow with sequential jobs that runs the happy path on issue creation.
-- **Standalone workflow** — `aw-triage.yml`, `aw-refine.yml`, `aw-slice.yml`, `aw-tdd.yml`. Manual-and-targeted entry points (`workflow_dispatch` + `issues.labeled`). Cron-driven discovery happens in `aw-sweep.yml`, not here.
-- **Sweep workflow** — `aw-sweep.yml`. The single cron-driven backstop. Four parallel jobs (one per pipeline stage) with precheck-first gating so idle ticks finish in \~20s with no checkouts and no installs.
+- **Standalone workflow** — `aw-triage.yml`, `aw-refine.yml`, `aw-slice.yml`, `aw-tdd.yml`. Manual-and-targeted entry points (`workflow_dispatch`-only). Called explicitly by `aw-feedback` via `gh workflow run` after a label flip. Auto-discovery on cron and label-edit events is handled by the sweep, not the standalones.
+- **Sweep workflow** — `aw-sweep.yml`. The single cron-driven auto-trigger backstop: cron every 15 min plus `issues.labeled/unlabeled` for instant pickup on label edits. Four parallel jobs (one per pipeline stage) with precheck-first gating so idle ticks finish in \~20s with no checkouts and no installs.
 - **Review workflow** — `aw-review.yml`. Independent review of a bot-authored draft PR on a fresh runner. Read-only on code; only modifies labels, PR state, and posts comments. Bounded to 2 reset cycles before escalating via the `needs-human` label.
 - **needs-human** — escalation label set by `aw-review` when 2 retry cycles have already happened on an issue.
 - **Retro PR** — draft PR opened by aw-retrospect proposing a SKILL.md patch.

--- a/src/lib/__tests__/aw-workflow-defensive-checks.test.ts
+++ b/src/lib/__tests__/aw-workflow-defensive-checks.test.ts
@@ -1,0 +1,212 @@
+// Regression-lock tests for the AW pipeline's defensive post-check pattern
+// and turn-budget convention.
+//
+// Issue #101 — when aw-pipeline.yml's refine (or triage/slice/tdd) job's
+// `claude-code-action` step exits cleanly but the agent did NOT complete its
+// expected side-effects (no comment posted, labels not flipped), the job
+// silently exits `success`. There is no red tile in the Actions audit trail.
+//
+// The fix has two parts:
+//
+// 1. Defensive post-check steps: after each `claude-code-action` step in
+//    aw-pipeline.yml, add a bash step that queries the issue labels and
+//    exits 1 with a ::error:: annotation if the expected labels are absent.
+//    This produces a visible red tile and a diagnostic message.
+//
+// 2. Turn budget bump: raise `--max-turns` from 30 to 50 for the triage and
+//    refine stages across all entry points (pipeline, sweep, standalones).
+//    Slice (60) and tdd (200) are already above the threshold.
+//
+// These tests parse the actual YAML files so they catch any future drift at
+// PR-review time rather than at production-incident time. YAML is the
+// source of truth; the tests assert the convention.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { parse as parseYaml } from 'yaml';
+
+interface StepYaml {
+  name?: string;
+  uses?: string;
+  run?: string;
+  if?: string;
+  id?: string;
+  env?: Record<string, string>;
+  with?: Record<string, unknown>;
+}
+
+interface JobYaml {
+  'runs-on'?: string;
+  needs?: string | string[];
+  if?: string;
+  outputs?: Record<string, string>;
+  concurrency?: { group: string; 'cancel-in-progress'?: boolean };
+  steps?: StepYaml[];
+  [key: string]: unknown;
+}
+
+interface WorkflowYaml {
+  name: string;
+  on?: unknown;
+  jobs: Record<string, JobYaml>;
+  concurrency?: { group: string; 'cancel-in-progress'?: boolean };
+}
+
+function loadWorkflow(name: string): WorkflowYaml {
+  const path = resolve(__dirname, '../../../.github/workflows', `${name}.yml`);
+  return parseYaml(readFileSync(path, 'utf-8')) as WorkflowYaml;
+}
+
+/** Return the index of the claude-code-action step in a job's steps array. */
+function agentStepIndex(job: JobYaml): number {
+  if (!job.steps) return -1;
+  return job.steps.findIndex(
+    (s) => typeof s.uses === 'string' && s.uses.includes('anthropics/claude-code-action'),
+  );
+}
+
+/**
+ * Return true iff the job has a bash step that contains `exit 1` at some
+ * position AFTER the claude-code-action step. This is the defensive
+ * post-check: if expected labels are missing, fail loudly.
+ */
+function hasVerifyStepAfterAgent(job: JobYaml): boolean {
+  const idx = agentStepIndex(job);
+  if (idx < 0 || !job.steps) return false;
+  return job.steps
+    .slice(idx + 1)
+    .some((s) => typeof s.run === 'string' && s.run.includes('exit 1'));
+}
+
+/**
+ * Parse `--max-turns N` from the claude_args string in a job's
+ * claude-code-action step and return N, or -1 if not found.
+ */
+function getMaxTurns(job: JobYaml): number {
+  if (!job.steps) return -1;
+  for (const step of job.steps) {
+    if (typeof step.uses !== 'string' || !step.uses.includes('anthropics/claude-code-action')) {
+      continue;
+    }
+    const args = step.with?.claude_args as string | undefined;
+    if (!args) return -1;
+    const m = args.match(/--max-turns\s+(\d+)/);
+    return m ? parseInt(m[1], 10) : -1;
+  }
+  return -1;
+}
+
+// ── Defensive post-check steps ──────────────────────────────────────────────
+
+describe('AW pipeline defensive post-checks (#101)', () => {
+  const pipeline = loadWorkflow('aw-pipeline');
+
+  it('triage job has a verify step after the agent step that can exit 1', () => {
+    expect(hasVerifyStepAfterAgent(pipeline.jobs.triage)).toBe(true);
+  });
+
+  it('refine job has a verify step after the agent step that can exit 1', () => {
+    expect(hasVerifyStepAfterAgent(pipeline.jobs.refine)).toBe(true);
+  });
+
+  it('slice job has a verify step after the agent step that can exit 1', () => {
+    expect(hasVerifyStepAfterAgent(pipeline.jobs.slice)).toBe(true);
+  });
+
+  it('tdd job has a verify step after the agent step that can exit 1', () => {
+    expect(hasVerifyStepAfterAgent(pipeline.jobs.tdd)).toBe(true);
+  });
+});
+
+// ── Turn budget — triage and refine must be >= 50 ───────────────────────────
+
+describe('AW workflow turn budget (#101 — max-turns >= 50 for triage and refine)', () => {
+  describe('aw-pipeline.yml', () => {
+    const pipeline = loadWorkflow('aw-pipeline');
+
+    it('triage job uses --max-turns >= 50', () => {
+      expect(getMaxTurns(pipeline.jobs.triage)).toBeGreaterThanOrEqual(50);
+    });
+
+    it('refine job uses --max-turns >= 50', () => {
+      expect(getMaxTurns(pipeline.jobs.refine)).toBeGreaterThanOrEqual(50);
+    });
+  });
+
+  describe('aw-sweep.yml', () => {
+    const sweep = loadWorkflow('aw-sweep');
+
+    it('triage skill job uses --max-turns >= 50', () => {
+      expect(getMaxTurns(sweep.jobs.triage)).toBeGreaterThanOrEqual(50);
+    });
+
+    it('refine skill job uses --max-turns >= 50', () => {
+      expect(getMaxTurns(sweep.jobs.refine)).toBeGreaterThanOrEqual(50);
+    });
+  });
+
+  describe('standalone aw-triage.yml', () => {
+    const triage = loadWorkflow('aw-triage');
+    it('uses --max-turns >= 50', () => {
+      // The standalone has one job; find the one with the agent step.
+      const jobWithAgent = Object.values(triage.jobs).find(
+        (j) => agentStepIndex(j) >= 0,
+      );
+      expect(jobWithAgent).toBeDefined();
+      expect(getMaxTurns(jobWithAgent!)).toBeGreaterThanOrEqual(50);
+    });
+  });
+
+  describe('standalone aw-refine.yml', () => {
+    const refine = loadWorkflow('aw-refine');
+    it('uses --max-turns >= 50', () => {
+      const jobWithAgent = Object.values(refine.jobs).find(
+        (j) => agentStepIndex(j) >= 0,
+      );
+      expect(jobWithAgent).toBeDefined();
+      expect(getMaxTurns(jobWithAgent!)).toBeGreaterThanOrEqual(50);
+    });
+  });
+});
+
+// ── Standalone workflows are workflow_dispatch-only ──────────────────────────
+
+describe('Standalone workflows are workflow_dispatch-only (#101)', () => {
+  const STAGES = ['triage', 'refine', 'slice', 'tdd'] as const;
+
+  for (const stage of STAGES) {
+    it(`aw-${stage}.yml has no schedule: trigger (standalones are manual-only)`, () => {
+      const wf = loadWorkflow(`aw-${stage}`);
+      const on = wf.on as Record<string, unknown> | null | undefined;
+      // `schedule:` should not appear at all; standalones are workflow_dispatch only.
+      expect(on?.schedule).toBeUndefined();
+    });
+  }
+});
+
+// ── Doc accuracy ─────────────────────────────────────────────────────────────
+
+describe('docs/agentic-workflow.md accurately describes standalone trigger model (#101)', () => {
+  const docPath = resolve(__dirname, '../../../docs/agentic-workflow.md');
+  const doc = readFileSync(docPath, 'utf-8');
+
+  it('glossary standalone entry does not mention issues.labeled as a standalone trigger', () => {
+    // Extract the Glossary "Standalone workflow" bullet. It should say
+    // workflow_dispatch-only, not "workflow_dispatch + issues.labeled".
+    const match = doc.match(/\*\*Standalone workflow\*\*[^\n]*/);
+    expect(match).not.toBeNull();
+    const entry = match![0];
+    // The entry must NOT pair workflow_dispatch with issues.labeled
+    // (that was the stale description from before the sweep consolidation).
+    expect(entry).not.toMatch(/workflow_dispatch.*issues\.labeled/);
+  });
+
+  it('glossary sweep entry mentions it is the auto-trigger backstop with cron and issues.labeled', () => {
+    // The sweep is the auto-trigger; its glossary entry should mention this.
+    const match = doc.match(/\*\*Sweep workflow\*\*[^\n]*/);
+    expect(match).not.toBeNull();
+    const entry = match![0];
+    expect(entry).toMatch(/cron|auto-trigger|backstop/i);
+  });
+});


### PR DESCRIPTION
Fixes #101

## What changed

**Root cause:** When a pipeline job's `claude-code-action` step exits cleanly but the agent exhausted its `--max-turns 30` budget without completing expected side-effects (labels not flipped, no comment posted), the job silently returned `success`. The Actions audit trail showed green tiles with no alert; recovery only happened via the sweep cron ~15 min later, invisibly.

## Changes

### Defensive post-checks (`aw-pipeline.yml`)

Added a `"Verify * actually completed"` bash step after each of the four `claude-code-action` steps:

- **triage** — checks that the issue either closed (duplicate/wontfix) OR has a category label (`bug`/`enhancement`/`chore`) AND the `refine` action label. Fails with `::error::` and `exit 1` otherwise.
- **refine** — checks that `slice` + `refined` labels are both present.
- **slice** — checks one of three valid outcomes: `awaiting-research`, `tdd + afk|hitl`, or the issue was split (inferred from `slice` label still absent meaning agent didn't complete).
- **tdd** — checks that either the `review` label is set OR at least one open PR exists for the issue.

Each step emits `::error::` annotation and `exit 1`. The sweep cron recovers within ~15 min (the step deliberately does NOT retry — that's the sweep's job).

### Turn budget bump

Bumped `--max-turns 30` → `--max-turns 50` for triage and refine stages in:
- `aw-pipeline.yml` (triage + refine jobs)
- `aw-sweep.yml` (triage + refine skill jobs)
- `aw-triage.yml` (standalone)
- `aw-refine.yml` (standalone)

`aw-slice.yml` (60) and `aw-tdd.yml` (200) already exceed 50 — unchanged.

### Doc fix (`docs/agentic-workflow.md`)

Updated the Glossary to accurately describe the trigger model:
- **Standalone** — `workflow_dispatch`-only manual entry points (not `workflow_dispatch + issues.labeled`)
- **Sweep** — the single cron + `issues.labeled/unlabeled` auto-trigger backstop

### Regression-lock tests (`src/lib/__tests__/aw-workflow-defensive-checks.test.ts`)

16 tests covering:
- All 4 pipeline jobs have a verify step with `exit 1` after the agent step
- triage and refine stages have `--max-turns >= 50` across pipeline, sweep, and standalones
- Standalone workflows have no `schedule:` trigger (workflow_dispatch-only)
- Doc glossary uses accurate language (standalones are dispatch-only; sweep is the backstop)

## Test plan

- [x] `pnpm vitest run src/lib/__tests__/aw-workflow-defensive-checks.test.ts` — 16/16 pass
- [x] `pnpm test` — 245 test files, 4554 tests pass
- [x] `pnpm typecheck` — clean
- [ ] Manual: verify a capped-budget run (`--max-turns 5` on triage) shows a red tile in Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)