### PR TITLE
chore(aw): author-association gate so external issues require explicit approval

### DIFF
--- a/.github/workflows/aw-mark-external.yml
+++ b/.github/workflows/aw-mark-external.yml
@@ -1,0 +1,62 @@
+name: AW — Mark external issues
+
+# Tiny no-LLM gatekeeper: when a non-trusted author opens a new issue,
+# label it `external`. The AW pipeline + sweep both gate on this label
+# (or `aw-approved`) to prevent untrusted external issues from auto-
+# flowing through triage → refine → slice → tdd → bot PR without
+# explicit owner approval.
+#
+# Trusted associations (issue flows normally with no `external` label):
+#   - OWNER         — repo owner
+#   - COLLABORATOR  — has push access
+#   - MEMBER        — org member (n/a for personal repos)
+#
+# Everyone else (CONTRIBUTOR / FIRST_TIME_CONTRIBUTOR / FIRST_TIMER /
+# NONE / MANNEQUIN) gets the `external` label.
+#
+# To opt-in an external issue: add the `aw-approved` label
+# (`gh issue edit N --add-label aw-approved`). The next sweep tick
+# will pick it up.
+#
+# Cost: ~3s of runner time per non-trusted issue, zero LLM cost.
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+concurrency:
+  # Per-issue: don't double-label if multiple events fire (shouldn't
+  # happen for `opened`, but defence-in-depth).
+  group: aw-mark-external-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  mark:
+    if: |
+      github.event.issue.author_association != 'OWNER' &&
+      github.event.issue.author_association != 'COLLABORATOR' &&
+      github.event.issue.author_association != 'MEMBER'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Add external label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+          ASSOC: ${{ github.event.issue.author_association }}
+        run: |
+          set -euo pipefail
+          echo "Issue #$ISSUE author_association: $ASSOC — labelling 'external'"
+          gh issue edit "$ISSUE" --repo "$REPO" --add-label external
+          gh issue comment "$ISSUE" --repo "$REPO" --body "$(cat <<'EOF'
+          > *Marked `external` automatically by the AW gatekeeper.*
+
+          This issue was filed by an account without write access to the repo, so the AW pipeline (`aw-triage` → `aw-refine` → `aw-slice` → `aw-tdd`) will NOT auto-process it. The repo owner reviews external issues before letting them into the agent pipeline.
+
+          **For the maintainer:** to opt this issue in, add the `aw-approved` label. The next sweep tick (every 15 min) will pick it up and run it through the normal pipeline.
+          EOF
+          )"

--- a/.github/workflows/aw-pipeline.yml
+++ b/.github/workflows/aw-pipeline.yml
@@ -32,6 +32,18 @@ permissions:
 
 jobs:
   triage:
+    # Author-association gate: only auto-process issues from trusted
+    # authors (OWNER / COLLABORATOR / MEMBER), OR issues the owner has
+    # explicitly opted-in by adding the `aw-approved` label. External
+    # issues sit in the queue until the owner reviews and approves them.
+    # See aw-mark-external.yml for the auto-labelling helper, and
+    # `Choice: author-association gate for external issues` in
+    # docs/agentic-workflow.md for the rationale.
+    if: |
+      github.event.issue.author_association == 'OWNER' ||
+      github.event.issue.author_association == 'COLLABORATOR' ||
+      github.event.issue.author_association == 'MEMBER' ||
+      contains(github.event.issue.labels.*.name, 'aw-approved')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     concurrency:

--- a/.github/workflows/aw-sweep.yml
+++ b/.github/workflows/aw-sweep.yml
@@ -65,14 +65,19 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
+          # Filter out external-but-not-approved issues. The author-association
+          # gate (aw-mark-external.yml) labels untrusted-author issues as
+          # `external`. Owner reviews and adds `aw-approved` to opt them in.
+          # See `Choice: author-association gate for external issues` in
+          # docs/agentic-workflow.md.
           CAND=$(gh issue list \
             --repo PeterBlenessy/notesage \
             --state open \
             --limit 10 \
             --json number,labels \
-            --jq '[.[] | select(([.labels[].name] | any(. == "bug" or . == "enhancement" or . == "chore" or . == "duplicate" or . == "wontfix")) | not) | .number] | first(.[])? // empty')
+            --jq '[.[] | select(([.labels[].name] | any(. == "bug" or . == "enhancement" or . == "chore" or . == "duplicate" or . == "wontfix")) | not) | select(([.labels[].name] | any(. == "external") | not) or ([.labels[].name] | any(. == "aw-approved"))) | .number] | first(.[])? // empty')
           if [[ -z "$CAND" ]]; then
-            echo "No untriaged issues. Skipping LLM step."
+            echo "No untriaged issues (or all eligible candidates are external+unapproved). Skipping LLM step."
             echo "candidate=" >> "$GITHUB_OUTPUT"
           else
             echo "Found triage candidate: #$CAND"
@@ -132,15 +137,16 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
+          # Same external-author gate as the triage precheck above.
           CAND=$(gh issue list \
             --repo PeterBlenessy/notesage \
             --label refine \
             --state open \
             --limit 5 \
             --json number,labels \
-            --jq '[.[] | select([.labels[].name] | any(. == "refined") | not) | .number] | first(.[])? // empty')
+            --jq '[.[] | select([.labels[].name] | any(. == "refined") | not) | select(([.labels[].name] | any(. == "external") | not) or ([.labels[].name] | any(. == "aw-approved"))) | .number] | first(.[])? // empty')
           if [[ -z "$CAND" ]]; then
-            echo "No refine candidates. Skipping LLM step."
+            echo "No refine candidates (or all are external+unapproved). Skipping LLM step."
             echo "candidate=" >> "$GITHUB_OUTPUT"
           else
             echo "Found refine candidate: #$CAND"
@@ -198,6 +204,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
+          # Same external-author gate as the triage precheck above.
           CAND=$(gh issue list \
             --repo PeterBlenessy/notesage \
             --label slice \
@@ -205,7 +212,7 @@ jobs:
             --state open \
             --limit 5 \
             --json number,labels \
-            --jq '[.[] | select(([.labels[].name] | any(. == "sliced" or . == "awaiting-research")) | not) | .number] | first(.[])? // empty')
+            --jq '[.[] | select(([.labels[].name] | any(. == "sliced" or . == "awaiting-research")) | not) | select(([.labels[].name] | any(. == "external") | not) or ([.labels[].name] | any(. == "aw-approved"))) | .number] | first(.[])? // empty')
           if [[ -z "$CAND" ]]; then
             echo "No slicing candidates. Skipping LLM step."
             echo "candidate=" >> "$GITHUB_OUTPUT"
@@ -266,6 +273,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
+          # Same external-author gate as the triage precheck above.
           CAND=$(gh issue list \
             --repo PeterBlenessy/notesage \
             --label tdd \
@@ -274,9 +282,9 @@ jobs:
             --state open \
             --limit 10 \
             --json number,labels \
-            --jq '[.[] | select(([.labels[].name] | any(. == "review")) | not) | .number] | first(.[])? // empty')
+            --jq '[.[] | select(([.labels[].name] | any(. == "review")) | not) | select(([.labels[].name] | any(. == "external") | not) or ([.labels[].name] | any(. == "aw-approved"))) | .number] | first(.[])? // empty')
           if [[ -z "$CAND" ]]; then
-            echo "No tdd candidates. Skipping LLM step."
+            echo "No tdd candidates (or all are external+unapproved). Skipping LLM step."
             echo "candidate=" >> "$GITHUB_OUTPUT"
           else
             echo "Found tdd candidate: #$CAND"

--- a/docs/agentic-workflow.md
+++ b/docs/agentic-workflow.md
@@ -120,6 +120,8 @@ Labels are the state of the system.
 
 **Escalation marker**: `needs-human` — set by `aw-review` when 2 retry cycles have already happened on an issue. Signals that `aw-tdd` has been unable to fully address the issue autonomously and a human reviewer must take over (merge as-is, land a fix on the branch, or comment new guidance and remove the label to allow another retry).
 
+**Author-association gate**: `external` (auto-set on `issues.opened` for non-trusted authors by `aw-mark-external.yml`) blocks the AW pipeline + sweep from auto-processing the issue. `aw-approved` (set manually by the owner after review) opts an external issue into the pipeline. Trusted authors (OWNER / COLLABORATOR / MEMBER) bypass the gate entirely. See "Choice: author-association gate for external issues" below for the rationale.
+
 ## Skills
 
 Each skill is a markdown file with action rules. Workflows just point the agent at it. SKILL.md is the source of truth for behavior.
@@ -149,7 +151,8 @@ Ten workflow files. One *pipeline* + one *sweep* + four *standalones* + one *ret
 
 | Workflow | Triggers | Purpose |
 | --- | --- | --- |
-| `aw-pipeline.yml` | `issues.opened` / `issues.reopened` | Happy path: 4 jobs chained via `needs:` (triage → refine → slice → tdd). Single workflow run, stages back-to-back. Each job carries its own `aw-stage-{stage}-{issue}` concurrency group (#98) so it shares a queue with the sweep + standalone for the same issue+stage. |
+| `aw-pipeline.yml` | `issues.opened` / `issues.reopened` | Happy path: 4 jobs chained via `needs:` (triage → refine → slice → tdd). Single workflow run, stages back-to-back. The triage job carries an author-association `if:` gate so external issues don't auto-flow through the pipeline (see "Choice: author-association gate for external issues"). Each job carries its own `aw-stage-{stage}-{issue}` concurrency group (#98) so it shares a queue with the sweep + standalone for the same issue+stage. |
+| `aw-mark-external.yml` | `issues.opened` | Tiny no-LLM gatekeeper. Adds the `external` label + an explanatory comment to issues opened by non-trusted authors (anyone other than OWNER / COLLABORATOR / MEMBER). The pipeline + sweep prechecks then skip these issues until the owner adds `aw-approved`. |
 | `aw-sweep.yml` | cron `*/15`, `workflow_dispatch`, `issues.labeled` / `issues.unlabeled` | The single cron-driven backstop AND the auto-trigger for label edits. Eight parallel jobs — four `find_<stage>` precheck pairs (just `gh + jq`, output the candidate issue number) and four `<stage>` skill jobs gated on `needs.find_<stage>.outputs.candidate != ''`. The find/skill split makes the candidate available to the skill job's `aw-stage-{stage}-{candidate}` concurrency group at job-evaluation time (#98). Idle ticks finish in \~20s with no checkouts. |
 | `aw-triage.yml` | `workflow_dispatch` | Manual one-off re-triage entry point. Workflow-level `aw-stage-triage-{...}` concurrency, shared with pipeline + sweep. |
 | `aw-refine.yml` | `workflow_dispatch` | Manual one-off entry point. Also the dispatch target for `aw-feedback`'s "redo refined scope" action. Workflow-level `aw-stage-refine-{...}` concurrency, shared with pipeline + sweep. |
@@ -296,6 +299,37 @@ The other workflows (`aw-triage`, `aw-refine`, `aw-slice`, `aw-feedback`, `aw-re
 **Why not `pull_request_target`.** Would solve the CI gap by running tests in the base-branch context with secrets available, but [GitHub Security Lab guidance](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/) treats this pattern as dangerous because it exposes secrets to potentially-untrusted PR code. Bot PRs are trusted today, but the precedent leaks to any future contributor PRs.
 
 **Regression lock.** `src/lib/__tests__/aw-workflow-pat.test.ts` parses every `aw-*.yml` and asserts the PAT/GITHUB_TOKEN choice per workflow — catches drift if a future edit accidentally swaps the token in the wrong direction.
+
+### Choice: author-association gate for external issues
+
+**The risk.** This is a public repo with `issues.opened` triggers wired into a bot pipeline that opens PRs and (post-#118) can modify `.github/workflows/*.yml` via the `WORKFLOW_PAT`. A crafted issue from a random external account could ride the pipeline through triage → refine → slice → tdd, producing a malicious draft PR that touches workflow files. Even if the user catches it before merging, they've burned LLM tokens and the system has briefly trusted untrusted input. Spam issues are a smaller version of the same threat (token cost without the malicious payload).
+
+**The fix.** Two-layer gate:
+
+1. **Pipeline-level `if:` on the triage job** in `aw-pipeline.yml`. Cascades to all downstream stages via `needs:`. Lets through:
+   - `OWNER` author-association (the repo owner)
+   - `COLLABORATOR` (anyone with push access)
+   - `MEMBER` (org members — n/a for personal repo, kept for portability)
+   - OR any issue with the `aw-approved` label (manual owner opt-in)
+
+2. **Sweep precheck filters** in each `find_<stage>` job. The JQ expression now requires `NOT external OR aw-approved`. External-but-not-approved issues never become candidates, even after the next cron tick or label edit.
+
+3. **Auto-labelling helper** (`aw-mark-external.yml`). Tiny no-LLM workflow that fires on `issues.opened` for non-trusted authors and adds the `external` label + a comment explaining the gate. Cost: \~3s of runner time per external issue, zero LLM tokens.
+
+**Owner workflow for an external issue:**
+
+1. External issue arrives → `aw-mark-external` labels it `external` and posts a comment
+2. Owner reviews the body — for spam / malicious / off-topic, just close it
+3. For legitimate requests, owner adds `aw-approved` label (`gh issue edit N --add-label aw-approved`)
+4. Next sweep tick (\~15 min) picks it up and runs the normal pipeline. The pipeline workflow itself doesn't re-fire (the `issues.opened` event is one-shot), but the sweep cron is the always-on safety net.
+
+**Trusted-author flow is unchanged.** Owner-filed issues skip the gate entirely — `author_association == 'OWNER'` matches the pipeline `if:` clause and the sweep precheck (no `external` label means the precheck condition `NOT external OR aw-approved` is true).
+
+**Why not GitHub branch-protection rules.** Branch protection gates merge, not workflow execution. By the time the bot PR exists, LLM tokens have been spent and the issue's intent has been "trusted" by the agent. The author-association gate stops that earlier.
+
+**Why not just rely on aw-slice's hitl-vs-afk heuristic.** That decision is LLM-judged, not author-judged. A persuasive external issue could pass aw-slice as `afk` ("looks localized and well-tested") and reach aw-tdd before any human review. Author-based gating is structurally more reliable than content-based.
+
+**Operational implication for the queue.** External issues sit in your queue with the `external` label, untouched by AW until you act. Treat the `external` label as "needs my eyes" — same role as `needs-human` but applied at the entry point instead of the escalation point.
 
 ### Choice: claude-code-action with OAuth (not gh-aw, not API key)
 

--- a/src/lib/__tests__/aw-author-association-gate.test.ts
+++ b/src/lib/__tests__/aw-author-association-gate.test.ts
@@ -1,0 +1,148 @@
+// Regression-lock tests for the AW author-association gate.
+//
+// The gate exists because this is a public repo with `issues.opened`
+// triggers wired into a bot pipeline that opens PRs and (post-#118)
+// can modify .github/workflows/*.yml via WORKFLOW_PAT. A crafted
+// external issue could ride the pipeline and produce a malicious draft
+// PR. The gate stops untrusted issues at the entry point.
+//
+// Three layers asserted by these tests:
+//
+// 1. `aw-mark-external.yml` exists and labels non-trusted issues with
+//    `external` (no LLM cost). Trusted authors (OWNER / COLLABORATOR /
+//    MEMBER) bypass the gate.
+// 2. `aw-pipeline.yml`'s triage job carries an `if:` clause that lets
+//    through trusted authors OR explicitly-approved issues. Cascades to
+//    all downstream stages via `needs:`.
+// 3. Each `find_<stage>` precheck in `aw-sweep.yml` filters out
+//    `external` issues unless they also carry `aw-approved`.
+//
+// If any of these protections regress, untrusted external issues would
+// silently flow through the pipeline. These tests catch that drift at
+// PR-review time, not at production-incident time.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'fs';
+import { resolve } from 'path';
+import { parse as parseYaml } from 'yaml';
+
+interface JobYaml {
+  if?: string;
+  steps?: Array<{ run?: string; [key: string]: unknown }>;
+  [key: string]: unknown;
+}
+
+interface WorkflowYaml {
+  name?: string;
+  on?: unknown;
+  jobs: Record<string, JobYaml>;
+}
+
+function loadWorkflow(name: string): WorkflowYaml {
+  const path = resolve(__dirname, '../../../.github/workflows', `${name}.yml`);
+  return parseYaml(readFileSync(path, 'utf-8')) as WorkflowYaml;
+}
+
+function workflowExists(name: string): boolean {
+  const path = resolve(__dirname, '../../../.github/workflows', `${name}.yml`);
+  return existsSync(path);
+}
+
+const TRUSTED_ASSOCIATIONS = ['OWNER', 'COLLABORATOR', 'MEMBER'];
+
+describe('AW author-association gate', () => {
+  describe('aw-mark-external.yml — labels non-trusted authors', () => {
+    it('exists', () => {
+      expect(workflowExists('aw-mark-external')).toBe(true);
+    });
+
+    const wf = workflowExists('aw-mark-external') ? loadWorkflow('aw-mark-external') : null;
+
+    it('triggers on issues.opened', () => {
+      // The `on:` block needs to fire when issues are first opened.
+      // Note: yaml.parse returns boolean `true` for the YAML `on` key
+      // (it's a YAML 1.1 truthy value), so we need to access via 'on'
+      // string OR true depending on the parser.
+      const onBlock = (wf!.on ?? (wf as unknown as { true: unknown }).true) as
+        | { issues?: { types?: string[] } }
+        | undefined;
+      expect(onBlock?.issues?.types).toContain('opened');
+    });
+
+    it('skips trusted authors via if: condition (mark job runs only for non-trusted)', () => {
+      const ifClause = wf!.jobs.mark?.if ?? '';
+      // The if: clause must require author_association NOT in the trusted set.
+      // We verify by checking that each trusted association is referenced
+      // with a `!=` comparison.
+      for (const assoc of TRUSTED_ASSOCIATIONS) {
+        expect(ifClause).toContain(`author_association != '${assoc}'`);
+      }
+    });
+
+    it('only requires `issues: write` permission (no checkout, no LLM)', () => {
+      const perms = (wf as unknown as { permissions?: Record<string, string> })
+        .permissions;
+      expect(perms?.issues).toBe('write');
+      // Should NOT need contents:write (no code edits) or any LLM-related auth
+      expect(perms?.contents).toBeUndefined();
+    });
+
+    it('does not invoke claude-code-action (zero LLM cost per fired event)', () => {
+      const stepsRun = JSON.stringify(wf!.jobs.mark?.steps ?? []);
+      expect(stepsRun).not.toContain('claude-code-action');
+    });
+  });
+
+  describe('aw-pipeline.yml — triage job has author-association gate', () => {
+    const wf = loadWorkflow('aw-pipeline');
+
+    it('triage job has an if: clause', () => {
+      expect(wf.jobs.triage?.if).toBeDefined();
+    });
+
+    it('triage if: lets through trusted authors (OWNER / COLLABORATOR / MEMBER)', () => {
+      const ifClause = wf.jobs.triage?.if ?? '';
+      for (const assoc of TRUSTED_ASSOCIATIONS) {
+        expect(ifClause).toContain(`author_association == '${assoc}'`);
+      }
+    });
+
+    it('triage if: lets through explicitly-approved issues (aw-approved label)', () => {
+      const ifClause = wf.jobs.triage?.if ?? '';
+      expect(ifClause).toContain("'aw-approved'");
+    });
+
+    it('downstream jobs (refine / slice / tdd) cascade via needs: from triage', () => {
+      // Cascade is what makes the single triage gate cover all stages.
+      expect(wf.jobs.refine?.needs).toBe('triage');
+      expect(wf.jobs.slice?.needs).toBe('refine');
+      expect(wf.jobs.tdd?.needs).toBe('slice');
+    });
+  });
+
+  describe('aw-sweep.yml — every find_<stage> precheck filters external issues', () => {
+    const wf = loadWorkflow('aw-sweep');
+
+    const STAGES = ['triage', 'refine', 'slice', 'tdd'] as const;
+
+    for (const stage of STAGES) {
+      it(`find_${stage} precheck excludes external+unapproved issues`, () => {
+        const findJob = wf.jobs[`find_${stage}`];
+        expect(findJob).toBeDefined();
+
+        // Find the precheck step's `run:` block and grep for the JQ
+        // condition that filters external/aw-approved.
+        const steps = findJob.steps ?? [];
+        const precheckStep = steps.find(
+          (s) => typeof s.run === 'string' && s.run.includes('gh issue list'),
+        );
+        expect(precheckStep).toBeDefined();
+
+        const runScript = precheckStep!.run as string;
+        // The JQ expression must reference both labels for the gate to work.
+        expect(runScript).toContain('"external"');
+        expect(runScript).toContain('"aw-approved"');
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Public-repo safety. Today the AW pipeline auto-flows every newly-opened issue through triage → refine → slice → tdd → bot PR, regardless of who filed it. After PR #120 (`WORKFLOW_PAT` for bot-PR CI gating), bot PRs can also modify `.github/workflows/*.yml` files. A crafted external issue could ride the pipeline to produce a malicious draft PR. The owner would catch it before merging, but tokens are burned and the agent has briefly trusted untrusted input.

This PR adds a three-layer gate: external issues sit in the queue with an `external` label until the owner explicitly approves them.

## What changed

| File | Change |
|---|---|
| `aw-mark-external.yml` (NEW) | Tiny no-LLM workflow. Fires on `issues.opened` for non-trusted authors. Adds `external` label + an explanatory comment to the issue. ~3s of runner time per fired event, zero LLM cost. Trusted authors (OWNER / COLLABORATOR / MEMBER) bypass entirely. |
| `aw-pipeline.yml` | Triage job gets an `if:` clause: trusted author OR `aw-approved` label. Cascades to refine / slice / tdd via `needs:`. |
| `aw-sweep.yml` | Each `find_<stage>` precheck JQ updated: filter out issues that are `external` AND NOT `aw-approved`. Sweep cron + `issues.labeled` triggers all respect the gate. |
| `docs/agentic-workflow.md` | New "Choice: author-association gate for external issues" section explaining the threat model and the rationale. Updated label scheme + workflows table. |
| `src/lib/__tests__/aw-author-association-gate.test.ts` (NEW) | 13 regression-lock tests parsing the three workflow files and asserting the gate is intact. |

## Owner workflow for an external issue

1. External issue arrives → `aw-mark-external` labels it `external` and comments
2. Owner reviews body — for spam/malicious/off-topic, just close it
3. For legitimate requests, owner adds `aw-approved` label (`gh issue edit N --add-label aw-approved`)
4. Next sweep tick (~15 min) picks it up, runs through normal pipeline

Trusted-author flow is unchanged.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test --run` — 4551 pass, 1 skipped, 0 fail (13 new tests in `aw-author-association-gate.test.ts`)
- [x] All 3 workflow YAMLs parse with `python3 yaml.safe_load`
- [ ] (post-merge) verify `aw-mark-external` fires by checking the Actions tab on any external issue (won't actually happen until someone external files something)
- [ ] (post-merge) verify the gate blocks: file a test issue under a non-OWNER account → confirm pipeline skips it → add `aw-approved` → verify next sweep tick picks it up

## Why this beats the alternatives

Documented in detail in the new doc section. Quick summary:
- **Branch protection** — gates merge, not workflow execution. Tokens already spent by the time the bot PR exists.
- **Relying on aw-slice's `hitl` vs `afk` heuristic** — LLM-judged, not author-judged. A persuasive external issue could pass as `afk` and reach aw-tdd before any human review.
- **`pull_request_target`** — irrelevant for issue gating; only affects PR triggers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)