### PR TITLE
fix(copilot): stop killing the LSP on Strict Mode probe unmount

### DIFF
--- a/src-tauri/src/commands/copilot_lsp.rs
+++ b/src-tauri/src/commands/copilot_lsp.rs
@@ -285,13 +285,16 @@ pub async fn copilot_lsp_start(
         .ok_or_else(|| "copilot-language-server not found. Install via: npm install -g @github/copilot-language-server".to_string())?;
 
     // Spawn the LSP process — inject login shell PATH so the process
-    // (a Node.js script) can find Node and other dependencies
+    // (a Node.js script) can find Node and other dependencies.
+    // stderr is piped (not nulled) so panics, Node stack traces, and
+    // out-of-memory messages from the LSP surface in our logs instead of
+    // disappearing into /dev/null when the process exits unexpectedly.
     let mut spawn_cmd = tokio::process::Command::new(&binary_path);
     spawn_cmd
         .arg("--stdio")
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::null())
+        .stderr(std::process::Stdio::piped())
         .kill_on_drop(true);
     if let Some(shell_path) = get_shell_path() {
         spawn_cmd.env("PATH", shell_path);
@@ -303,6 +306,29 @@ pub async fn copilot_lsp_start(
     let child_pid = child.id();
     let stdin = child.stdin.take().ok_or("Failed to capture stdin")?;
     let stdout = child.stdout.take().ok_or("Failed to capture stdout")?;
+    let stderr = child.stderr.take().ok_or("Failed to capture stderr")?;
+
+    // Drain stderr line-by-line into the log so any panic/error from the
+    // LSP is visible. Without this, "LSP process exited unexpectedly"
+    // arrives with no diagnostic context.
+    {
+        use tokio::io::{AsyncBufReadExt, BufReader};
+        let mut reader = BufReader::new(stderr).lines();
+        tokio::spawn(async move {
+            loop {
+                match reader.next_line().await {
+                    Ok(Some(line)) => {
+                        log::error!(target: "notesage::copilot", "LSP stderr: {}", line);
+                    }
+                    Ok(None) => break,
+                    Err(e) => {
+                        log::warn!(target: "notesage::copilot", "LSP stderr read error: {}", e);
+                        break;
+                    }
+                }
+            }
+        });
+    }
 
     // Create the JSON-RPC transport (spawns reader loop)
     let pending_server_requests: PendingServerRequests = Arc::new(Mutex::new(HashMap::new()));

--- a/src/hooks/__tests__/useCopilotCompletion.test.ts
+++ b/src/hooks/__tests__/useCopilotCompletion.test.ts
@@ -363,21 +363,27 @@ describe('useCopilotCompletion', () => {
       expect(invoke).toHaveBeenCalledWith('copilot_lsp_stop');
     });
 
-    it('stops LSP on unmount when connection changes trigger effect re-run', async () => {
+    it('does NOT stop LSP on unmount when connection ID is unchanged', async () => {
+      // Regression-lock for the React Strict Mode double-mount bug: the
+      // previous implementation called copilot_lsp_stop on every effect-2
+      // cleanup, including Strict Mode's probe unmount. That sent
+      // shutdown+exit to a healthy LSP and surfaced as the bogus
+      // "process exited unexpectedly" error.
+      //
+      // Backend `kill_on_drop(true)` on the Child handle covers app-exit
+      // cleanup, so the frontend doesn't need to stop on unmount.
       const conn = makeAgentManagedConnection();
       setupWithConnection(conn);
       setupWithProject('/project');
 
       const { rerender, unmount } = renderHook(() => useCopilotCompletion(null));
 
-      // Let LSP start — this sets lspReady to true
+      // Let LSP start
       await act(async () => {
         await vi.runAllTimersAsync();
       });
 
-      // Force a re-render so the effect re-runs with lspReady=true in its closure.
-      // This simulates a workingDir change which causes the effect to re-register
-      // its cleanup with the current lspReady value.
+      // Trigger an effect re-run with the SAME connection ID — should not stop.
       act(() => {
         useWorkspaceStore.setState({
           projects: [{ path: '/project2', fileTree: [] }],
@@ -394,7 +400,7 @@ describe('useCopilotCompletion', () => {
 
       unmount();
 
-      expect(invoke).toHaveBeenCalledWith('copilot_lsp_stop');
+      expect(invoke).not.toHaveBeenCalledWith('copilot_lsp_stop');
     });
   });
 

--- a/src/hooks/useCopilotCompletion.ts
+++ b/src/hooks/useCopilotCompletion.ts
@@ -110,16 +110,26 @@ export function useCopilotCompletion(editor: Editor | null) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [connection?.id, workingDir, lspReady]);
 
-  // Stop the LSP when the connection changes or the hook unmounts.
-  // Pulled out of the start effect so a working-directory change does NOT
-  // trigger a stop — the backend handles folder updates in-place.
+  // Stop the LSP only when the user genuinely switches between different
+  // Copilot LSP connection IDs (A → B). The previous "stop on cleanup"
+  // pattern fired on every effect cleanup — including React Strict Mode's
+  // mount→unmount→mount probe in dev — which sent shutdown+exit to a
+  // healthy LSP and surfaced as the bogus "process exited unexpectedly"
+  // error. App-exit cleanup is covered by `kill_on_drop(true)` on the
+  // backend Child handle, so we don't need an unmount path here.
+  const prevConnectionIdRef = useRef<string | null>(null);
   useEffect(() => {
-    if (!connection) return;
-    return () => {
+    const currId = connection?.id ?? null;
+    const prevId = prevConnectionIdRef.current;
+    prevConnectionIdRef.current = currId;
+
+    // Real transition between two different connections (not initial mount,
+    // not Strict Mode re-mount with the same ID).
+    if (prevId !== null && prevId !== currId) {
       invoke('copilot_lsp_stop').catch(() => {});
       setLspReady(false);
       sentWorkingDir.current = null;
-    };
+    }
   }, [connection?.id]);
 
   // -------------------------------------------------------------------------
@@ -397,8 +407,15 @@ export function useCopilotCompletion(editor: Editor | null) {
   }, [editor, connection?.id]);
 
   // -------------------------------------------------------------------------
-  // Listen for status changes (for future UI indicators)
+  // Listen for status changes — auto-respawn on fatal exit with backoff
   // -------------------------------------------------------------------------
+
+  // Track recent crash timestamps to back off when the LSP keeps dying.
+  // Three crashes inside 60s → stop auto-restarting and surface a sticky
+  // toast so the user knows there's a real problem to investigate.
+  const crashTimestamps = useRef<number[]>([]);
+  const CRASH_WINDOW_MS = 60_000;
+  const CRASH_LIMIT = 3;
 
   useEffect(() => {
     if (!connection) return;
@@ -408,9 +425,34 @@ export function useCopilotCompletion(editor: Editor | null) {
 
     listen<{ message: string; kind: string }>('copilot-status-changed', (event) => {
       const { kind, message } = event.payload;
-      if (kind === 'Error') {
-        log.error('copilot', 'Status error', { kind, message });
+      if (kind !== 'Error') return;
+
+      log.error('copilot', 'Status error', { kind, message });
+
+      // Auto-respawn path — track recent crashes for backoff.
+      const now = Date.now();
+      crashTimestamps.current = crashTimestamps.current.filter(
+        (t) => now - t < CRASH_WINDOW_MS,
+      );
+      crashTimestamps.current.push(now);
+
+      if (crashTimestamps.current.length >= CRASH_LIMIT) {
+        toast.error(
+          'GitHub Copilot keeps crashing. Inline completions disabled — check the dev console for the LSP stderr trace.',
+          { id: 'copilot-lsp-crash-loop', duration: Infinity },
+        );
+        return;
       }
+
+      // Flip lspReady → false so the start effect re-fires and calls
+      // `copilot_lsp_start` again. The backend's start command is idempotent
+      // and self-heals stale state via `child.try_wait()`.
+      setLspReady(false);
+      sentWorkingDir.current = null;
+      toast.warning(`Copilot LSP exited (${message}) — restarting`, {
+        id: 'copilot-lsp-restart',
+        duration: 3000,
+      });
     }).then((fn) => {
       if (mounted) {
         unlistenFn = fn;


### PR DESCRIPTION
## Summary

The "GitHub Copilot LSP process exited unexpectedly" error users saw on every dev-mode launch was self-inflicted. React Strict Mode's mount→cleanup→mount probe fired a `useEffect` cleanup in `useCopilotCompletion` that called `copilot_lsp_stop` → which sent `shutdown` + `exit` to the freshly-started LSP. The LSP did exactly what we asked: shut down. The reader saw EOF and surfaced it as an alarming error toast, with a respawn cascade right behind it.

The heartbeat test in Settings showed green because the LSP responded to `checkStatus` before dying — the test captured the response, but didn't observe the death.

## Diagnosis path (for future reference)

Without LSP stderr capture, the exit was a black box. First step was to pipe `Stdio::null()` → `Stdio::piped()` and drain stderr into the `notesage::copilot` log target. That showed **no stderr output** — meaning the LSP exited gracefully, not by crash. Cross-referencing the `id=2 result=null` reply just before EOF against `grep -n "send_request" src-tauri/src/commands/copilot_lsp.rs` pinpointed `copilot_lsp_stop` (which sends `shutdown` → null reply → `exit`). From there it was one grep to find the unconditional `invoke('copilot_lsp_stop')` in the second `useEffect` cleanup.

## Fix

Three changes:

1. **`src-tauri/src/commands/copilot_lsp.rs`** — pipe LSP stderr instead of `Stdio::null()`, drain into log target. Now any future LSP crash surfaces its actual reason.
2. **`src/hooks/useCopilotCompletion.ts`** — replaced the buggy "stop on every effect-2 cleanup" with a `prevConnectionIdRef` pattern. Stop fires only when `connection.id` genuinely transitions between two values (A→B or A→null). Initial mount, Strict Mode probe, and unmount no longer kill the LSP — backend `kill_on_drop(true)` covers app-exit cleanup. Also kept the auto-respawn-with-backoff added during diagnosis as a safety net for genuinely external future crashes.
3. **`src/hooks/__tests__/useCopilotCompletion.test.ts`** — flipped the test that asserted the buggy "stop on unmount" behavior into a regression-lock for "do NOT stop on unmount when connection ID is unchanged".

## Verification

End-to-end live test in `pnpm tauri dev`:

- LSP reaches `didChangeStatus { busy: false, kind: "Normal" }` — the steady-ready state that the dying process #1 from the bug never reached
- Exactly **1** `LSP ← response: id=` line (the `initialize` reply) — no respawn cascade
- **0** `Reader fatal`, **0** `LSP process exited unexpectedly`, **0** `LSP stderr:` lines for a 5+ minute monitor window
- Existing `useCopilotCompletion` test suite + all copilot tests pass (39 + 80 = 119 tests)

## Test plan

- [ ] Pull, run `pnpm tauri dev`, confirm no "exited unexpectedly" toast appears at startup
- [ ] Trigger an inline completion in a markdown file inside a project — ghost text appears
- [ ] Switch chat-footer project selection → confirm LSP picks up the new working dir without dying
- [ ] (Optional) Switch interactive routing slot to a different Copilot connection (if you have two) → confirm LSP stops and respawns cleanly for the transition

🤖 Generated with [Claude Code](https://claude.com/claude-code)