### PR TITLE
feat(prewarm): pre-warm parse cache at startup from recent + pinned files

### DIFF
--- a/src/hooks/useAppLifecycle.ts
+++ b/src/hooks/useAppLifecycle.ts
@@ -16,6 +16,7 @@ import { log, setLogLevel } from "@/lib/logger";
 import { stopAcpAgent } from "@/hooks/useAIOperations";
 import { stopTaskAgent } from "@/hooks/useAgentTaskOperations";
 import { emitCmdBarEvent } from "@/lib/cmd-bar-events";
+import { getPrewarmCandidates, prewarmParseCache } from "@/lib/prewarm-parse-cache";
 import { toast } from "sonner";
 import type { PaletteMode } from "@/lib/command-palette";
 
@@ -253,6 +254,10 @@ export function useAppLifecycle({ onOpenPalette }: UseAppLifecycleOptions) {
     };
 
     startupWithTimeout();
+
+    // Fire-and-forget: pre-warm the parsed-doc cache in the background.
+    // Runs concurrently with tree validation; never blocks startupReady.
+    prewarmParseCache(getPrewarmCandidates());
   }, []);
 
   // Mid-session iCloud detection used to live here as a separate

--- a/src/lib/__tests__/prewarm-parse-cache.test.ts
+++ b/src/lib/__tests__/prewarm-parse-cache.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// --- store mocks — use vi.hoisted so variables are available inside vi.mock factories ---
+const { mockEditorGetState, mockWorkspaceGetState } = vi.hoisted(() => ({
+  mockEditorGetState: vi.fn(),
+  mockWorkspaceGetState: vi.fn(),
+}));
+
+vi.mock("@/stores/editor-store", () => ({
+  useEditorStore: { getState: mockEditorGetState },
+}));
+
+vi.mock("@/stores/workspace-store", () => ({
+  useWorkspaceStore: { getState: mockWorkspaceGetState },
+}));
+
+// --- infrastructure mocks ---
+vi.mock("@/lib/tauri", () => ({
+  tauriApi: {
+    readFile: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/markdown-worker", () => ({
+  parseInWorker: vi.fn(),
+}));
+
+vi.mock("@/lib/frontmatter", () => ({
+  parseFrontmatter: vi.fn((raw: string) => ({ content: raw, frontmatter: null })),
+}));
+
+// Import AFTER mocks are registered
+import { getPrewarmCandidates, prewarmParseCache } from "@/lib/prewarm-parse-cache";
+import { tauriApi } from "@/lib/tauri";
+import { parseInWorker } from "@/lib/markdown-worker";
+import { parsedDocCache } from "@/lib/parsed-doc-cache";
+
+const mockReadFile = vi.mocked(tauriApi.readFile);
+const mockParseInWorker = vi.mocked(parseInWorker);
+
+// Minimal ParseResult fixture
+function makeResult(path: string) {
+  return {
+    type: "result" as const,
+    id: path,
+    doc: { type: "doc", content: [] },
+    annotationsEntries: [] as Array<[number, string]>,
+    nodeIdsEntries: [] as Array<[number, string]>,
+    tableMetadataEntries: [] as Array<[number, Array<[number, { colType?: string; colCurrency?: string; colAggregation?: string }]>]>,
+    timings: { preprocess: 0, parse: 0, total: 0 },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  parsedDocCache.clear();
+
+  mockEditorGetState.mockReturnValue({ recentFiles: [] });
+  mockWorkspaceGetState.mockReturnValue({ pinnedFiles: [], projects: [] });
+  mockReadFile.mockResolvedValue("# content");
+  mockParseInWorker.mockImplementation((md, root) =>
+    Promise.resolve(makeResult(`${root ?? ""}/${md}`))
+  );
+});
+
+afterEach(() => {
+  parsedDocCache.clear();
+});
+
+// ---------------------------------------------------------------------------
+// getPrewarmCandidates
+// ---------------------------------------------------------------------------
+
+describe("getPrewarmCandidates", () => {
+  it("returns recent .md files (up to 5)", () => {
+    mockEditorGetState.mockReturnValue({
+      recentFiles: [
+        { path: "/p/a.md", name: "a.md" },
+        { path: "/p/b.md", name: "b.md" },
+      ],
+    });
+    mockWorkspaceGetState.mockReturnValue({ pinnedFiles: [], projects: [] });
+
+    const result = getPrewarmCandidates();
+    expect(result).toContain("/p/a.md");
+    expect(result).toContain("/p/b.md");
+  });
+
+  it("includes pinned .md files", () => {
+    mockEditorGetState.mockReturnValue({ recentFiles: [] });
+    mockWorkspaceGetState.mockReturnValue({
+      pinnedFiles: ["/p/pinned.md"],
+      projects: [],
+    });
+
+    const result = getPrewarmCandidates();
+    expect(result).toContain("/p/pinned.md");
+  });
+
+  it("deduplicates files that are both recent and pinned, keeping them once", () => {
+    mockEditorGetState.mockReturnValue({
+      recentFiles: [{ path: "/p/both.md", name: "both.md" }],
+    });
+    mockWorkspaceGetState.mockReturnValue({
+      pinnedFiles: ["/p/both.md"],
+      projects: [],
+    });
+
+    const result = getPrewarmCandidates();
+    const count = result.filter((p) => p === "/p/both.md").length;
+    expect(count).toBe(1);
+  });
+
+  it("places recent files before pinned-only files", () => {
+    mockEditorGetState.mockReturnValue({
+      recentFiles: [{ path: "/p/recent.md", name: "recent.md" }],
+    });
+    mockWorkspaceGetState.mockReturnValue({
+      pinnedFiles: ["/p/pinned-only.md"],
+      projects: [],
+    });
+
+    const result = getPrewarmCandidates();
+    expect(result.indexOf("/p/recent.md")).toBeLessThan(
+      result.indexOf("/p/pinned-only.md")
+    );
+  });
+
+  it("excludes non-.md files from recent list", () => {
+    mockEditorGetState.mockReturnValue({
+      recentFiles: [
+        { path: "/p/note.md", name: "note.md" },
+        { path: "/p/image.png", name: "image.png" },
+        { path: "/p/data.json", name: "data.json" },
+      ],
+    });
+    mockWorkspaceGetState.mockReturnValue({ pinnedFiles: [], projects: [] });
+
+    const result = getPrewarmCandidates();
+    expect(result).toContain("/p/note.md");
+    expect(result).not.toContain("/p/image.png");
+    expect(result).not.toContain("/p/data.json");
+  });
+
+  it("excludes non-.md files from pinned list", () => {
+    mockEditorGetState.mockReturnValue({ recentFiles: [] });
+    mockWorkspaceGetState.mockReturnValue({
+      pinnedFiles: ["/p/note.md", "/p/doc.pdf"],
+      projects: [],
+    });
+
+    const result = getPrewarmCandidates();
+    expect(result).toContain("/p/note.md");
+    expect(result).not.toContain("/p/doc.pdf");
+  });
+
+  it("returns at most 5 recent entries even when more exist", () => {
+    mockEditorGetState.mockReturnValue({
+      recentFiles: [
+        { path: "/p/1.md", name: "1.md" },
+        { path: "/p/2.md", name: "2.md" },
+        { path: "/p/3.md", name: "3.md" },
+        { path: "/p/4.md", name: "4.md" },
+        { path: "/p/5.md", name: "5.md" },
+        { path: "/p/6.md", name: "6.md" },
+      ],
+    });
+    mockWorkspaceGetState.mockReturnValue({ pinnedFiles: [], projects: [] });
+
+    const result = getPrewarmCandidates();
+    const recentInResult = result.filter((p) => p.startsWith("/p/"));
+    expect(recentInResult.length).toBeLessThanOrEqual(5);
+  });
+
+  it("returns empty array when there are no recent or pinned .md files", () => {
+    mockEditorGetState.mockReturnValue({ recentFiles: [] });
+    mockWorkspaceGetState.mockReturnValue({ pinnedFiles: [], projects: [] });
+
+    expect(getPrewarmCandidates()).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// prewarmParseCache — concurrency
+// ---------------------------------------------------------------------------
+
+describe("prewarmParseCache", () => {
+  it("resolves without throwing for an empty candidate list", async () => {
+    await expect(prewarmParseCache([])).resolves.toBeUndefined();
+  });
+
+  it("populates the cache for each resolved file", async () => {
+    const paths = ["/p/a.md", "/p/b.md"];
+    mockReadFile.mockResolvedValue("# body");
+    mockParseInWorker.mockImplementation(() =>
+      Promise.resolve(makeResult(paths[0]))
+    );
+
+    await prewarmParseCache(paths);
+
+    for (const p of paths) {
+      expect(parsedDocCache.has(p)).toBe(true);
+    }
+  });
+
+  it("never runs more than 2 worker parses concurrently", async () => {
+    const paths = ["/p/1.md", "/p/2.md", "/p/3.md", "/p/4.md", "/p/5.md"];
+    let currentConcurrent = 0;
+    let maxConcurrent = 0;
+
+    // Resolvers kept so we can unblock parses one-by-one
+    const resolvers: Array<() => void> = [];
+
+    mockReadFile.mockResolvedValue("# body");
+    mockParseInWorker.mockImplementation(() =>
+      new Promise<ReturnType<typeof makeResult>>((resolve) => {
+        currentConcurrent++;
+        maxConcurrent = Math.max(maxConcurrent, currentConcurrent);
+        resolvers.push(() => {
+          currentConcurrent--;
+          resolve(makeResult("file"));
+        });
+      })
+    );
+
+    const prewarmPromise = prewarmParseCache(paths);
+
+    // Drain the microtask queue so the first batch of workers starts
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Unblock workers one at a time, checking the in-flight count never exceeds 2
+    while (resolvers.length > 0) {
+      expect(maxConcurrent).toBeLessThanOrEqual(2);
+      resolvers.shift()!();
+      await Promise.resolve();
+      await Promise.resolve();
+    }
+
+    await prewarmPromise;
+    expect(maxConcurrent).toBeLessThanOrEqual(2);
+  });
+
+  it("skips files already in the cache", async () => {
+    const path = "/p/already.md";
+    parsedDocCache.set(path, makeResult(path));
+
+    await prewarmParseCache([path]);
+
+    expect(mockReadFile).not.toHaveBeenCalledWith(path);
+    expect(mockParseInWorker).not.toHaveBeenCalled();
+  });
+
+  it("does not reject when readFile fails for one file", async () => {
+    mockReadFile.mockRejectedValueOnce(new Error("file not found"));
+    mockReadFile.mockResolvedValue("# ok");
+    mockParseInWorker.mockResolvedValue(makeResult("/p/b.md"));
+
+    await expect(prewarmParseCache(["/p/missing.md", "/p/b.md"])).resolves.toBeUndefined();
+  });
+
+  it("does not reject when parseInWorker fails for one file", async () => {
+    mockReadFile.mockResolvedValue("# body");
+    mockParseInWorker
+      .mockRejectedValueOnce(new Error("worker crashed"))
+      .mockResolvedValue(makeResult("/p/b.md"));
+
+    await expect(prewarmParseCache(["/p/crash.md", "/p/b.md"])).resolves.toBeUndefined();
+  });
+});

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -44,6 +44,7 @@ export const PERF = {
   treeOverlay: 'perf:tree-overlay',
   sidebar: 'perf:sidebar',
   focus: 'perf:focus',
+  prewarm: 'perf:prewarm',
 } as const;
 
 export type PerfCategory = typeof PERF[keyof typeof PERF];

--- a/src/lib/prewarm-parse-cache.ts
+++ b/src/lib/prewarm-parse-cache.ts
@@ -1,0 +1,108 @@
+/**
+ * Pre-warm the in-memory parsed-doc cache during app startup.
+ *
+ * Reads the top-5 recent .md files plus all pinned .md files, parses each
+ * in the markdown Web Worker, and stores the result in `parsedDocCache`.
+ * Runs in the background after startup — never blocks `startupReady`.
+ *
+ * Concurrency is bounded to MAX_CONCURRENT_WORKERS so we don't flood the
+ * parser thread with a burst of messages at startup.
+ */
+
+import { parsedDocCache } from "@/lib/parsed-doc-cache";
+import { parseInWorker } from "@/lib/markdown-worker";
+import { tauriApi } from "@/lib/tauri";
+import { parseFrontmatter } from "@/lib/frontmatter";
+import { useEditorStore } from "@/stores/editor-store";
+import { useWorkspaceStore } from "@/stores/workspace-store";
+import { log, PERF } from "@/lib/logger";
+
+const MAX_CONCURRENT_WORKERS = 2;
+const MAX_RECENT_FILES = 5;
+
+/**
+ * Returns the set of files that should be pre-warmed: up to
+ * `MAX_RECENT_FILES` recent `.md` files followed by all pinned `.md` files,
+ * deduplicated while preserving the recents-first order.
+ */
+export function getPrewarmCandidates(): string[] {
+  const { recentFiles = [] } = useEditorStore.getState();
+  const { pinnedFiles = [] } = useWorkspaceStore.getState();
+
+  const recent = recentFiles
+    .filter((f) => f.path.endsWith(".md"))
+    .slice(0, MAX_RECENT_FILES)
+    .map((f) => f.path);
+
+  const pinned = pinnedFiles.filter((p) => p.endsWith(".md"));
+
+  const seen = new Set<string>(recent);
+  const candidates = [...recent];
+  for (const p of pinned) {
+    if (!seen.has(p)) {
+      seen.add(p);
+      candidates.push(p);
+    }
+  }
+  return candidates;
+}
+
+/**
+ * Derive the project root for a given file path by checking which open
+ * project path is an ancestor of the file, mirroring the pattern used in
+ * `useActiveProject.ts`.
+ */
+function getProjectRoot(filePath: string): string | undefined {
+  const { projects } = useWorkspaceStore.getState();
+  return projects.find((p) => filePath.startsWith(p.path + "/"))?.path;
+}
+
+/**
+ * Pre-warm `parsedDocCache` for the given list of file paths.
+ *
+ * - Skips files already in the cache.
+ * - Per-file errors (missing file, worker crash) are swallowed so a single
+ *   bad file doesn't abort the whole batch.
+ * - Max `MAX_CONCURRENT_WORKERS` parses run in parallel at any time.
+ */
+export async function prewarmParseCache(filePaths: string[]): Promise<void> {
+  if (filePaths.length === 0) return;
+
+  const startMs = Date.now();
+  log.debug(PERF.prewarm, "started", { count: filePaths.length });
+
+  const pending = filePaths.filter((p) => !parsedDocCache.has(p));
+  let successCount = 0;
+
+  // Bounded concurrency via a semaphore-style pool
+  const queue = [...pending];
+  const workers: Array<Promise<void>> = [];
+
+  async function processNext(): Promise<void> {
+    while (queue.length > 0) {
+      const filePath = queue.shift()!;
+      try {
+        const raw = await tauriApi.readFile(filePath);
+        const { content: markdown } = parseFrontmatter(raw);
+        const projectRoot = getProjectRoot(filePath);
+        const result = await parseInWorker(markdown, projectRoot);
+        parsedDocCache.set(filePath, result);
+        successCount++;
+        log.debug(PERF.prewarm, "file cached", { filePath });
+      } catch {
+        log.debug(PERF.prewarm, "file skipped", { filePath });
+      }
+    }
+  }
+
+  for (let i = 0; i < Math.min(MAX_CONCURRENT_WORKERS, pending.length); i++) {
+    workers.push(processNext());
+  }
+
+  await Promise.all(workers);
+
+  log.debug(PERF.prewarm, "complete", {
+    count: successCount,
+    elapsedMs: Date.now() - startMs,
+  });
+}


### PR DESCRIPTION
## Summary

- Adds `src/lib/prewarm-parse-cache.ts` with `getPrewarmCandidates()` (top-5 recent + all pinned `.md` files, deduplicated) and `prewarmParseCache()` (bounded to 2 concurrent workers, per-file errors swallowed)
- Hooks into `useAppLifecycle.ts` as a fire-and-forget call alongside `startupWithTimeout()` — never blocks `startupReady`
- Adds `PERF.prewarm` constant to `src/lib/logger.ts`; emits `[perf:prewarm] started`, per-file, and `complete { count, elapsedMs }` log lines

## Test plan

- [x] 14 unit tests in `src/lib/__tests__/prewarm-parse-cache.test.ts`: `getPrewarmCandidates()` candidate selection/dedup/filtering, `prewarmParseCache()` cache population, max-2 concurrency, skip-if-cached, per-file error isolation
- [x] Full `pnpm test` suite passes (4605 tests; 1 pre-existing failure in `markdown-parse.core.test.ts` on base branch)
- [x] `pnpm typecheck` clean (pre-existing `markdown-parse.core.ts` missing-module errors on base branch are unrelated)

Resolves #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)