### PR TITLE
chore(#142): promote JSDoc shortcut table to typed JSON manifest + catalog

### DIFF
--- a/e2e/fixtures/triggerMenuCommand.ts
+++ b/e2e/fixtures/triggerMenuCommand.ts
@@ -1,0 +1,60 @@
+/**
+ * triggerMenuCommand — dispatches a keyboard chord from the app command
+ * manifest so e2e tests exercise the exact same code path as a real keystroke.
+ *
+ * Usage:
+ *   await triggerMenuCommand(page, "open-command-palette");
+ *   await triggerMenuCommand(page, "open-settings");
+ */
+import type { Page } from "@playwright/test";
+import manifest from "../../src/shared/appCommandManifest.json";
+
+type ChordDef = (typeof manifest.commands)[0]["chords"][0];
+
+/**
+ * Converts a ChordDef to a Playwright keyboard.press() string.
+ *
+ * Playwright accepts both `KeyboardEvent.key` values ("k", ",") and
+ * `KeyboardEvent.code` values ("KeyK", "Comma") in its press() method.
+ * We prefer `key` when present (matches how existing e2e tests are written),
+ * and fall back to `code` for chords where `key` is absent — e.g. ⌘⌥C where
+ * Option+C produces "ç" on macOS and we match by physical key position.
+ *
+ * Modifier mapping:
+ *   mod   → "Meta"   (platform command key)
+ *   ctrlKey → "Control"
+ *   shiftKey → "Shift"
+ *   altKey → "Alt"
+ */
+function chordToPressString(chord: ChordDef): string {
+  const parts: string[] = [];
+  if (chord.mod) parts.push("Meta");
+  if ("metaKey" in chord && chord.metaKey) parts.push("Meta");
+  if ("ctrlKey" in chord && chord.ctrlKey) parts.push("Control");
+  if ("shiftKey" in chord && chord.shiftKey) parts.push("Shift");
+  if ("altKey" in chord && chord.altKey) parts.push("Alt");
+  const keyStr =
+    "key" in chord && chord.key ? chord.key : (chord.code ?? "");
+  parts.push(keyStr);
+  return parts.join("+");
+}
+
+/**
+ * Look up `commandId` in the app command manifest and press its first chord.
+ *
+ * Throws if the command is not found so tests fail loudly rather than
+ * silently pressing nothing.
+ */
+export async function triggerMenuCommand(
+  page: Page,
+  commandId: string,
+): Promise<void> {
+  const command = manifest.commands.find((c) => c.id === commandId);
+  if (!command) {
+    throw new Error(
+      `triggerMenuCommand: command "${commandId}" not found in appCommandManifest.json`,
+    );
+  }
+  const pressStr = chordToPressString(command.chords[0]);
+  await page.keyboard.press(pressStr);
+}

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -4,70 +4,29 @@
  *
  * Batch G12 · task #76 — consolidated the scattered if/else soup of the
  * legacy hook into a declarative SHORTCUT table, added `uiPreview` awareness
- * so ⌘K / ⌘1–4 / ⌘⇧P route to the FloatingCommandBar under the Quiet
+ * so ⌘K / ⌢1–4 / ⌘⇧P route to the FloatingCommandBar under the Quiet
  * Composer preview, and pulled `useCommandBarShortcuts` into this hook
  * (composition) so App.tsx only has to mount one keyboard hook.
  *
- * ------------------------------------------------------------------------
- *   SHORTCUT INVENTORY — read this before editing.
- * ------------------------------------------------------------------------
+ * Shortcut inventory → `src/shared/appCommandManifest.json` (single source
+ * of truth for ids, chords, and display strings). The manifest is keyed by
+ * `id` in the typed catalog `src/lib/appCommandCatalog.ts`.
  *
- *   Legacy column = behaviour when `settings.uiPreview === "legacy"`
- *   QuietComposer column = behaviour when `settings.uiPreview === "quiet-composer"`
- *   A dash (—) means this hook does NOT handle the chord; see "Owner" column
- *   for the component that owns it at capture phase.
- *
- *   | Chord       | Legacy                             | QuietComposer                                  | Owner (if not this hook) |
- *   | ----------- | ---------------------------------- | ---------------------------------------------- | ------------------------ |
- *   | ⌘K          | Open CommandPalette (default mode) | emit cmd-bar `focus`                           | this hook (both paths)   |
- *   | ⌘1          | Open CommandPalette (actions)      | emit cmd-bar `focus` prefix `!`                | this hook (both paths)   |
- *   | ⌘2          | Open CommandPalette (mentions)     | emit cmd-bar `focus` prefix `@`                | this hook (both paths)   |
- *   | ⌘3          | Open CommandPalette (tags)         | emit cmd-bar `focus` prefix `#`                | this hook (both paths)   |
- *   | ⌘4          | Open CommandPalette (research)     | emit cmd-bar `focus` prefix `?`                | this hook (both paths)   |
- *   | ⌘⇧1…4       | same as unshifted (same action)    | same as unshifted                              | this hook (both paths)   |
- *   | ⌘⇧P         | Open CommandPalette (commands `>`) | emit cmd-bar `focus` prefix `>`                | this hook (both paths)   |
- *   | ⌘⇧H         | Open find-replace in editor        | Open find-replace in editor                    | this hook                |
- *   | ⌘⇧F         | Open CommandPalette (files)        | emit cmd-bar `focus` (no prefix — file search) | this hook (both paths)   |
- *   | ⌘F          | Open find in editor                | Open find in editor                            | this hook                |
- *   | ⌘W          | Close active tab (dirty guard)     | Close active tab (dirty guard)                 | this hook                |
- *   | ⌘.          | Toggle focus mode                  | —                                              | useFocusMode (capture)   |
- *   | ⌘⇧E         | Open Export dialog                 | Open Export dialog                             | this hook (both paths since sidebar #22) |
- *   | ⌘⇧O         | Open document outline              | Open document outline                          | this hook                |
- *   | ⌘⇧L         | Toggle sidebar pin                 | Toggle sidebar pin                             | this hook                |
- *   | ⌘⇧A         | Toggle activity strip              | emit agent-orb `toggle`                        | this hook                |
- *   | ⌘⇧C         | Toggle chat panel                  | unpin cmd bar (if expanded+pinned) else focus  | this hook                |
- *   | ⌘⇧R         | Toggle recording                   | Toggle recording                               | this hook                |
- *   | ⌘⇧K         | Open Keyboard Shortcuts dialog     | Open Keyboard Shortcuts dialog                 | this hook                |
- *   | ⌘,          | Open Settings                      | Open Settings                                  | this hook                |
- *   | ⌘T          | Toggle theme                       | Toggle theme                                   | this hook                |
- *   | ⌘N          | Open New Note dialog               | —                                              | QuietLayout (capture)    |
- *   | ⌘⇧N         | Open New Project dialog            | —                                              | QuietLayout (capture)    |
- *   | ⌘O          | Open folder picker                 | Open folder picker                             | this hook                |
- *   | ⌃⇧Tab       | Previous Recent doc (MRU)          | Previous Recent doc (MRU)                      | this hook → useRecentDocumentCycle |
- *   | ⌃Tab        | Next Recent doc (MRU)              | Next Recent doc (MRU)                          | this hook → useRecentDocumentCycle |
- *   | ⌘⌥C         | Copy active document's path        | Copy active document's path                    | this hook                |
- *   | ⌘⌥R         | Reveal active document in Finder   | Reveal active document in Finder               | this hook                |
- *   | Esc         | Exit focus mode (when active)      | —                                              | useFocusMode (capture)   |
- *   | ⌘⌥I         | Open Tauri devtools                | Open Tauri devtools                            | this hook                |
+ * Owner table (which component handles each chord) is in
+ * `docs/keyboard-shortcuts.md` — update both that doc and the manifest when
+ * adding or moving a chord.
  *
  * ⌘S (save) is context-aware and lives in `Editor.tsx` / `CodeEditor.tsx` so
- * markdown and code-file save paths can diverge. It's intentionally NOT here.
+ * markdown and code-file save paths can diverge. It is intentionally absent
+ * from the manifest.
  *
- * ------------------------------------------------------------------------
- *   Why the capture-phase listeners in other components aren't migrated.
- * ------------------------------------------------------------------------
+ * Why the capture-phase listeners in other components aren't migrated:
  *
- * `QuietLayout` owns ⌘⇧E (TreeOverlay), ⌘N, and ⌘⇧N at CAPTURE phase with
+ * `QuietLayout` owns ⌘N and ⌘⇧N at CAPTURE phase with
  * `stopImmediatePropagation`. `useFocusMode` owns ⌘. at capture phase.
  * That design predates this consolidation and is deliberate: the capture
  * phase lets those components preempt this hook's bubble-phase listener
- * when the Quiet Composer preview is active. If we absorbed them into this
- * hook, we'd need to conditionally skip them based on `uiPreview` + active
- * popover state + focus state — a worse abstraction than letting each
- * component own its own chord.
- *
- * The JSDoc table above is the single source of truth for "which component
- * owns which chord" — keep it in sync when moving listeners around.
+ * when the Quiet Composer preview is active.
  */
 
 import { useEffect } from "react";

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -4,7 +4,7 @@
  *
  * Batch G12 · task #76 — consolidated the scattered if/else soup of the
  * legacy hook into a declarative SHORTCUT table, added `uiPreview` awareness
- * so ⌘K / ⌢1–4 / ⌘⇧P route to the FloatingCommandBar under the Quiet
+ * so ⌘K / ⌘1–4 / ⌘⇧P route to the FloatingCommandBar under the Quiet
  * Composer preview, and pulled `useCommandBarShortcuts` into this hook
  * (composition) so App.tsx only has to mount one keyboard hook.
  *

--- a/src/lib/__tests__/appCommandCatalog.test.ts
+++ b/src/lib/__tests__/appCommandCatalog.test.ts
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { catalog, matchesChord } from "@/lib/appCommandCatalog";
+
+// Minimum number of entries expected in the manifest (from the JSDoc
+// SHORTCUT table in useKeyboardShortcuts.ts).
+const MIN_COMMANDS = 20;
+
+// Command IDs that must be present — one per shortcut from the JSDoc table.
+const REQUIRED_IDS = [
+  "open-command-palette",
+  "open-tasks",
+  "open-mentions",
+  "open-tags",
+  "open-research",
+  "open-commands-palette",
+  "find-replace",
+  "find-files",
+  "find-in-document",
+  "close-active-document",
+  "toggle-focus-mode",
+  "export-document",
+  "open-document-outline",
+  "toggle-sidebar",
+  "toggle-activity-agent",
+  "toggle-chat-panel",
+  "toggle-recording",
+  "keyboard-shortcuts",
+  "open-settings",
+  "toggle-theme",
+  "new-note",
+  "new-project",
+  "open-folder",
+  "cycle-recent-next",
+  "cycle-recent-previous",
+  "copy-document-path",
+  "reveal-in-finder",
+  "exit-focus-mode",
+  "open-devtools",
+];
+
+describe("appCommandCatalog structure", () => {
+  it("exports a non-empty catalog with at least MIN_COMMANDS entries", () => {
+    expect(Object.keys(catalog).length).toBeGreaterThanOrEqual(MIN_COMMANDS);
+  });
+
+  it("every command has id, label, display, and at least one chord", () => {
+    for (const cmd of Object.values(catalog)) {
+      expect(typeof cmd.id).toBe("string");
+      expect(cmd.id.length).toBeGreaterThan(0);
+      expect(typeof cmd.label).toBe("string");
+      expect(cmd.label.length).toBeGreaterThan(0);
+      expect(typeof cmd.display).toBe("string");
+      expect(cmd.display.length).toBeGreaterThan(0);
+      expect(Array.isArray(cmd.chords)).toBe(true);
+      expect(cmd.chords.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("every chord has at least one of key or code", () => {
+    for (const cmd of Object.values(catalog)) {
+      for (const chord of cmd.chords) {
+        expect(
+          chord.key !== undefined || chord.code !== undefined,
+          `command ${cmd.id} has a chord with neither key nor code`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it("punctuation chords carry both key and code for layout safety", () => {
+    const PUNCTUATION_KEYS = [",", ".", "[", "]", ";", "'", "\\", "/", "-", "="];
+    for (const cmd of Object.values(catalog)) {
+      for (const chord of cmd.chords) {
+        if (chord.key !== undefined && PUNCTUATION_KEYS.includes(chord.key)) {
+          expect(
+            chord.code,
+            `command ${cmd.id} chord with key="${chord.key}" is missing code (required for cross-keyboard-layout safety)`,
+          ).toBeDefined();
+        }
+      }
+    }
+  });
+
+  it.each(REQUIRED_IDS)("catalog has required command '%s'", (id) => {
+    expect(catalog[id]).toBeDefined();
+  });
+});
+
+describe("matchesChord", () => {
+  it("returns true when key and mod match", () => {
+    const chord = { key: "k", code: "KeyK", mod: true, shiftKey: false, altKey: false };
+    const event = new KeyboardEvent("keydown", { key: "k", code: "KeyK", metaKey: true });
+    expect(matchesChord(event, chord)).toBe(true);
+  });
+
+  it("returns false when mod is required but not present", () => {
+    const chord = { key: "k", code: "KeyK", mod: true, shiftKey: false, altKey: false };
+    const event = new KeyboardEvent("keydown", { key: "k", code: "KeyK" });
+    expect(matchesChord(event, chord)).toBe(false);
+  });
+
+  it("returns false when key does not match", () => {
+    const chord = { key: "k", code: "KeyK", mod: true, shiftKey: false, altKey: false };
+    const event = new KeyboardEvent("keydown", { key: "j", code: "KeyJ", metaKey: true });
+    expect(matchesChord(event, chord)).toBe(false);
+  });
+
+  it("matches by code even when key differs (Option+C → ç)", () => {
+    const chord = { code: "KeyC", mod: true, altKey: true };
+    const event = new KeyboardEvent("keydown", { key: "ç", code: "KeyC", metaKey: true, altKey: true });
+    expect(matchesChord(event, chord)).toBe(true);
+  });
+
+  it("matches ctrlKey-only chord (⌃Tab)", () => {
+    const chord = { key: "Tab", code: "Tab", ctrlKey: true, metaKey: false, shiftKey: false, altKey: false };
+    const event = new KeyboardEvent("keydown", { key: "Tab", code: "Tab", ctrlKey: true });
+    expect(matchesChord(event, chord)).toBe(true);
+  });
+
+  it("rejects ⌘Tab when ctrlKey chord requires ctrlKey but not metaKey", () => {
+    const chord = { key: "Tab", code: "Tab", ctrlKey: true, metaKey: false, shiftKey: false, altKey: false };
+    const event = new KeyboardEvent("keydown", { key: "Tab", code: "Tab", metaKey: true });
+    expect(matchesChord(event, chord)).toBe(false);
+  });
+
+  it("matches punctuation chord via key OR code", () => {
+    const chord = { key: ",", code: "Comma", mod: true };
+    const eventByKey = new KeyboardEvent("keydown", { key: ",", code: "Comma", metaKey: true });
+    const eventByCode = new KeyboardEvent("keydown", { key: ";", code: "Comma", metaKey: true });
+    expect(matchesChord(eventByKey, chord)).toBe(true);
+    expect(matchesChord(eventByCode, chord)).toBe(true);
+  });
+});

--- a/src/lib/__tests__/appCommandManifest-drift.test.ts
+++ b/src/lib/__tests__/appCommandManifest-drift.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+import manifest from "@/shared/appCommandManifest.json";
+
+const REQUIRED_IDS = [
+  "open-command-palette",
+  "open-tasks",
+  "open-mentions",
+  "open-tags",
+  "open-research",
+  "open-commands-palette",
+  "find-replace",
+  "find-files",
+  "find-in-document",
+  "close-active-document",
+  "toggle-focus-mode",
+  "export-document",
+  "open-document-outline",
+  "toggle-sidebar",
+  "toggle-activity-agent",
+  "toggle-chat-panel",
+  "toggle-recording",
+  "keyboard-shortcuts",
+  "open-settings",
+  "toggle-theme",
+  "new-note",
+  "new-project",
+  "open-folder",
+  "cycle-recent-next",
+  "cycle-recent-previous",
+  "copy-document-path",
+  "reveal-in-finder",
+  "exit-focus-mode",
+  "open-devtools",
+];
+
+describe("appCommandManifest drift vs docs/keyboard-shortcuts.md", () => {
+  it("manifest has at least 20 commands", () => {
+    expect(manifest.commands.length).toBeGreaterThanOrEqual(20);
+  });
+
+  it("every manifest display string appears in docs as a backtick-quoted string", () => {
+    const docs = readFileSync(
+      join(process.cwd(), "docs/keyboard-shortcuts.md"),
+      "utf-8",
+    );
+    for (const cmd of manifest.commands) {
+      expect(
+        docs,
+        `command "${cmd.id}" has display "${cmd.display}" which is not found in docs/keyboard-shortcuts.md as \`${cmd.display}\``,
+      ).toContain(`\`${cmd.display}\``);
+    }
+  });
+
+  it("manifest contains all required command IDs", () => {
+    const ids = new Set(manifest.commands.map((c: { id: string }) => c.id));
+    for (const requiredId of REQUIRED_IDS) {
+      expect(
+        ids.has(requiredId),
+        `required command id "${requiredId}" not found in manifest`,
+      ).toBe(true);
+    }
+  });
+});

--- a/src/lib/appCommandCatalog.ts
+++ b/src/lib/appCommandCatalog.ts
@@ -1,0 +1,75 @@
+import rawManifest from "@/shared/appCommandManifest.json";
+
+export interface ChordDef {
+  key?: string;
+  code?: string;
+  mod?: boolean;
+  metaKey?: boolean;
+  ctrlKey?: boolean;
+  shiftKey?: boolean;
+  altKey?: boolean;
+}
+
+export interface AppCommand {
+  id: string;
+  label: string;
+  display: string;
+  chords: ChordDef[];
+  owner?: string;
+}
+
+const commands = rawManifest.commands as AppCommand[];
+
+export const catalog: Record<string, AppCommand> = Object.fromEntries(
+  commands.map((cmd) => [cmd.id, cmd]),
+);
+
+/**
+ * Returns true when a KeyboardEvent matches a chord definition.
+ *
+ * Modifier fields are checked only when explicitly set in the chord:
+ *   - `mod`     → platform command key (metaKey || ctrlKey)
+ *   - `metaKey` → strict metaKey check
+ *   - `ctrlKey` → strict ctrlKey check (use for ⌃Tab — must not fire on ⌘Tab)
+ *   - `shiftKey`, `altKey` → straightforward equality
+ *
+ * Key/code matching:
+ *   - Both `key` and `code` defined → match via key OR code (cross-layout safety
+ *     for punctuation chords where the physical position matters more than the
+ *     produced character, e.g. ⌘, on a non-US layout).
+ *   - Only `code` defined → match by physical key position only (e.g. ⌘⌥C where
+ *     Option+C produces ç on macOS, not the letter C).
+ *   - Only `key` defined → match by produced character only.
+ */
+export function matchesChord(event: KeyboardEvent, chord: ChordDef): boolean {
+  // Platform-mod (metaKey || ctrlKey) check
+  if (chord.mod !== undefined) {
+    const isMod = event.metaKey || event.ctrlKey;
+    if (chord.mod && !isMod) return false;
+    if (!chord.mod && isMod) return false;
+  }
+
+  // Explicit metaKey check (used by ⌃Tab chord to reject ⌘Tab)
+  if (chord.metaKey !== undefined && event.metaKey !== chord.metaKey) return false;
+
+  // Explicit ctrlKey check
+  if (chord.ctrlKey !== undefined && event.ctrlKey !== chord.ctrlKey) return false;
+
+  // Shift and Alt
+  if (chord.shiftKey !== undefined && event.shiftKey !== chord.shiftKey) return false;
+  if (chord.altKey !== undefined && event.altKey !== chord.altKey) return false;
+
+  // Key / code matching
+  if (chord.key !== undefined && chord.code !== undefined) {
+    // Both defined: accept if either matches (cross-layout safe)
+    if (event.key !== chord.key && event.code !== chord.code) return false;
+  } else if (chord.key !== undefined) {
+    if (event.key !== chord.key) return false;
+  } else if (chord.code !== undefined) {
+    if (event.code !== chord.code) return false;
+  } else {
+    return false;
+  }
+
+  return true;
+}

--- a/src/shared/appCommandManifest.json
+++ b/src/shared/appCommandManifest.json
@@ -1,0 +1,241 @@
+{
+  "version": "1",
+  "commands": [
+    {
+      "id": "open-command-palette",
+      "label": "Open command palette",
+      "display": "⌘K",
+      "chords": [
+        { "key": "k", "code": "KeyK", "mod": true, "shiftKey": false, "altKey": false }
+      ]
+    },
+    {
+      "id": "open-tasks",
+      "label": "Open tasks",
+      "display": "⌘!",
+      "chords": [
+        { "key": "1", "code": "Digit1", "mod": true, "shiftKey": false, "altKey": false },
+        { "key": "!", "code": "Digit1", "mod": true, "shiftKey": true, "altKey": false }
+      ]
+    },
+    {
+      "id": "open-mentions",
+      "label": "Open mentions / references",
+      "display": "⌘@",
+      "chords": [
+        { "key": "2", "code": "Digit2", "mod": true, "shiftKey": false, "altKey": false },
+        { "key": "@", "code": "Digit2", "mod": true, "shiftKey": true, "altKey": false }
+      ]
+    },
+    {
+      "id": "open-tags",
+      "label": "Open tags",
+      "display": "⌘#",
+      "chords": [
+        { "key": "3", "code": "Digit3", "mod": true, "shiftKey": false, "altKey": false },
+        { "key": "#", "code": "Digit3", "mod": true, "shiftKey": true, "altKey": false }
+      ]
+    },
+    {
+      "id": "open-research",
+      "label": "Open research",
+      "display": "⌘?",
+      "chords": [
+        { "key": "4", "code": "Digit4", "mod": true, "shiftKey": false, "altKey": false },
+        { "key": "?", "code": "Digit4", "mod": true, "shiftKey": true, "altKey": false }
+      ]
+    },
+    {
+      "id": "open-commands-palette",
+      "label": "Open commands palette",
+      "display": "⌘⇧P",
+      "chords": [
+        { "key": "p", "code": "KeyP", "mod": true, "shiftKey": true, "altKey": false }
+      ]
+    },
+    {
+      "id": "find-replace",
+      "label": "Find and replace",
+      "display": "⌘⇧H",
+      "chords": [
+        { "key": "h", "code": "KeyH", "mod": true, "shiftKey": true, "altKey": false }
+      ]
+    },
+    {
+      "id": "find-files",
+      "label": "Find files",
+      "display": "⌘⇧F",
+      "chords": [
+        { "key": "f", "code": "KeyF", "mod": true, "shiftKey": true, "altKey": false }
+      ]
+    },
+    {
+      "id": "find-in-document",
+      "label": "Find in document",
+      "display": "⌘F",
+      "chords": [
+        { "key": "f", "code": "KeyF", "mod": true, "shiftKey": false, "altKey": false }
+      ]
+    },
+    {
+      "id": "close-active-document",
+      "label": "Close active document",
+      "display": "⌘W",
+      "chords": [
+        { "key": "w", "code": "KeyW", "mod": true, "shiftKey": false, "altKey": false }
+      ]
+    },
+    {
+      "id": "toggle-focus-mode",
+      "label": "Toggle focus mode",
+      "display": "⌘.",
+      "chords": [
+        { "key": ".", "code": "Period", "mod": true, "shiftKey": false, "altKey": false }
+      ]
+    },
+    {
+      "id": "export-document",
+      "label": "Export document",
+      "display": "⌘⇧E",
+      "chords": [
+        { "key": "e", "code": "KeyE", "mod": true, "shiftKey": true, "altKey": false }
+      ]
+    },
+    {
+      "id": "open-document-outline",
+      "label": "Open document outline",
+      "display": "⌘⇧O",
+      "chords": [
+        { "key": "o", "code": "KeyO", "mod": true, "shiftKey": true, "altKey": false }
+      ]
+    },
+    {
+      "id": "toggle-sidebar",
+      "label": "Toggle sidebar",
+      "display": "⌘⇧L",
+      "chords": [
+        { "key": "l", "code": "KeyL", "mod": true, "shiftKey": true, "altKey": false }
+      ]
+    },
+    {
+      "id": "toggle-activity-agent",
+      "label": "Toggle activity / agent panel",
+      "display": "⌘⇧A",
+      "chords": [
+        { "key": "a", "code": "KeyA", "mod": true, "shiftKey": true, "altKey": false }
+      ]
+    },
+    {
+      "id": "toggle-chat-panel",
+      "label": "Toggle chat panel",
+      "display": "⌘⇧C",
+      "chords": [
+        { "key": "c", "code": "KeyC", "mod": true, "shiftKey": true, "altKey": false }
+      ]
+    },
+    {
+      "id": "toggle-recording",
+      "label": "Toggle recording",
+      "display": "⌘⇧R",
+      "chords": [
+        { "key": "r", "code": "KeyR", "mod": true, "shiftKey": true, "altKey": false }
+      ]
+    },
+    {
+      "id": "keyboard-shortcuts",
+      "label": "Show keyboard shortcuts",
+      "display": "⌘⇧K",
+      "chords": [
+        { "key": "k", "code": "KeyK", "mod": true, "shiftKey": true, "altKey": false }
+      ]
+    },
+    {
+      "id": "open-settings",
+      "label": "Open settings",
+      "display": "⌘,",
+      "chords": [
+        { "key": ",", "code": "Comma", "mod": true, "shiftKey": false, "altKey": false }
+      ]
+    },
+    {
+      "id": "toggle-theme",
+      "label": "Toggle theme",
+      "display": "⌘T",
+      "chords": [
+        { "key": "t", "code": "KeyT", "mod": true, "shiftKey": false, "altKey": false }
+      ]
+    },
+    {
+      "id": "new-note",
+      "label": "New note",
+      "display": "⌘N",
+      "chords": [
+        { "key": "n", "code": "KeyN", "mod": true, "shiftKey": false, "altKey": false }
+      ]
+    },
+    {
+      "id": "new-project",
+      "label": "New project",
+      "display": "⌘⇧N",
+      "chords": [
+        { "key": "n", "code": "KeyN", "mod": true, "shiftKey": true, "altKey": false }
+      ]
+    },
+    {
+      "id": "open-folder",
+      "label": "Open folder",
+      "display": "⌘O",
+      "chords": [
+        { "key": "o", "code": "KeyO", "mod": true, "shiftKey": false, "altKey": false }
+      ]
+    },
+    {
+      "id": "cycle-recent-next",
+      "label": "Next recent document",
+      "display": "⌃Tab",
+      "chords": [
+        { "key": "Tab", "code": "Tab", "ctrlKey": true, "metaKey": false, "shiftKey": false, "altKey": false }
+      ]
+    },
+    {
+      "id": "cycle-recent-previous",
+      "label": "Previous recent document",
+      "display": "⌃⇧Tab",
+      "chords": [
+        { "key": "Tab", "code": "Tab", "ctrlKey": true, "metaKey": false, "shiftKey": true, "altKey": false }
+      ]
+    },
+    {
+      "id": "copy-document-path",
+      "label": "Copy document path",
+      "display": "⌘⌥C",
+      "chords": [
+        { "code": "KeyC", "mod": true, "altKey": true, "shiftKey": false }
+      ]
+    },
+    {
+      "id": "reveal-in-finder",
+      "label": "Reveal in Finder",
+      "display": "⌘⌥R",
+      "chords": [
+        { "code": "KeyR", "mod": true, "altKey": true, "shiftKey": false }
+      ]
+    },
+    {
+      "id": "exit-focus-mode",
+      "label": "Exit focus mode",
+      "display": "Esc",
+      "chords": [
+        { "key": "Escape", "code": "Escape" }
+      ]
+    },
+    {
+      "id": "open-devtools",
+      "label": "Open Tauri devtools",
+      "display": "⌘⌥I",
+      "chords": [
+        { "code": "KeyI", "mod": true, "altKey": true, "shiftKey": false }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Resolves #142

## Summary

- **`src/shared/appCommandManifest.json`** — 29 commands, each with `id`, `label`, `display` (glyph form matching the keyboard-shortcuts doc), and `chords`. Chords carry both `key` + `code` for punctuation (cross-layout safety) and `code`-only for Option+letter (avoids dead-key non-ASCII `event.key` values on macOS).
- **`src/lib/appCommandCatalog.ts`** — typed `Record<id, AppCommand>` indexed from the manifest; `matchesChord()` handles `mod` (platform command key), strict `ctrlKey`/`metaKey`, `shiftKey`, `altKey`, key-OR-code matching for punctuation, and `ctrlKey`-strict matching for ⌃Tab vs ⌘Tab disambiguation.
- **`src/lib/__tests__/appCommandCatalog.test.ts`** — catalog structure tests + 7 `matchesChord` unit tests (jsdom env).
- **`src/lib/__tests__/appCommandManifest-drift.test.ts`** — CI drift guard: catalog count ≥ 20, every `display` appears backtick-quoted in `docs/keyboard-shortcuts.md`, all 29 required IDs present.
- **`e2e/fixtures/triggerMenuCommand.ts`** — Playwright helper that looks up a command by ID, converts its first chord to a Playwright `keyboard.press()` string, and dispatches it — so e2e tests use the same code path as a real keystroke.
- **`src/hooks/useKeyboardShortcuts.ts`** — inline JSDoc SHORTCUT table replaced with a pointer to the manifest file; all handlers unchanged (no behavior change).

## Test plan

- [x] `pnpm test` — 253 files, 4642 tests pass
- [x] `pnpm typecheck` — clean
- [x] New catalog tests (43 tests) all green
- [x] Drift test confirms all 29 display strings present in docs
- [x] Existing keyboard shortcut tests unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)