### PR TITLE
feat(#144): crash-safe three-phase commit for path-keyed sidecar migrations

### DIFF
--- a/src-tauri/src/commands/watcher.rs
+++ b/src-tauri/src/commands/watcher.rs
@@ -324,11 +324,12 @@ pub(crate) fn process_watcher_events(
         };
 
         for path in &event.paths {
-            // Skip .git/ internals and .DS_Store.
+            // Skip .git/ internals, .DS_Store, and rename-txn/ staging directories.
             let path_str = path.to_string_lossy();
             if path_str.contains("/.git/")
                 || path_str.ends_with("/.git")
                 || path_str.ends_with("/.DS_Store")
+                || path_str.contains("/.notesage/rename-txn/")
             {
                 continue;
             }
@@ -514,5 +515,60 @@ mod tests {
             result.file_changes.is_empty(),
             "file-changed batch must be empty when all events are rename-both"
         );
+    }
+
+    #[test]
+    fn process_watcher_events_excludes_rename_txn_staging_paths() {
+        // Simulate a modify event for a file inside the rename-txn staging dir.
+        // It must be silently dropped from both file_changes and not interfere with
+        // the reindex entries intended for the frontend batch.
+        let mut self_writes: HashMap<PathBuf, Instant> = HashMap::new();
+        let staging_path = PathBuf::from(
+            "/Users/test/Notesage/.notesage/rename-txn/txn-123/entry-0.json",
+        );
+        let normal_path = PathBuf::from("/Users/test/Notesage/doc.md");
+
+        let events = vec![
+            DebouncedEvent::new(
+                notify::Event {
+                    kind: notify::EventKind::Modify(notify::event::ModifyKind::Data(
+                        notify::event::DataChange::Content,
+                    )),
+                    paths: vec![staging_path.clone()],
+                    attrs: Default::default(),
+                },
+                Instant::now(),
+            ),
+            DebouncedEvent::new(
+                notify::Event {
+                    kind: notify::EventKind::Modify(notify::event::ModifyKind::Data(
+                        notify::event::DataChange::Content,
+                    )),
+                    paths: vec![normal_path.clone()],
+                    attrs: Default::default(),
+                },
+                Instant::now(),
+            ),
+        ];
+
+        let result = process_watcher_events(events, &mut self_writes);
+
+        // Only the normal path should appear in file_changes; the staging path must be excluded.
+        let staging_str = staging_path.to_string_lossy();
+        let staging_in_changes = result.file_changes.iter().any(|e| e.path == staging_str);
+        assert!(
+            !staging_in_changes,
+            "rename-txn staging files must not appear in file-changed-batch"
+        );
+
+        // The normal doc.md event must still pass through.
+        let normal_str = normal_path.to_string_lossy();
+        // On systems where the file doesn't exist the effective_kind becomes Delete;
+        // we just check the path appears in either reindex_entries (always) or file_changes.
+        let in_reindex = result
+            .reindex_entries
+            .iter()
+            .any(|(p, _)| p == normal_str.as_ref());
+        assert!(in_reindex, "normal file must appear in reindex entries");
     }
 }

--- a/src/hooks/__tests__/useFileRenameSync.test.ts
+++ b/src/hooks/__tests__/useFileRenameSync.test.ts
@@ -555,7 +555,12 @@ describe('useFileRenameSync — folder rename: closed-tab sidecar reverse-lookup
       }
       return [];
     });
-    setMockInvokeHandler('path_exists', () => false);
+    setMockInvokeHandler('path_exists', (args) => {
+      const { path } = args as { path: string };
+      // old sidecar exists (so executeRenameTransaction proceeds with migration)
+      // new sidecar does NOT exist (so collectClosedTabMigrationInputs includes it as not-yet-migrated)
+      return path === oldSidecarFilePath;
+    });
     setMockInvokeHandler('read_file', (args) => {
       if ((args as { path: string }).path === oldSidecarFilePath) return existingSidecar;
       return '[]';

--- a/src/hooks/useAppLifecycle.ts
+++ b/src/hooks/useAppLifecycle.ts
@@ -10,6 +10,7 @@ import { getFileType, isBinaryFileType } from "@/lib/file-utils";
 import { setBinaryData } from "@/lib/binary-cache";
 import { refreshNotesTree } from "@/lib/refresh-notes-tree";
 import { backfillSidecarOriginalPaths } from "@/lib/backfill-sidecar-paths";
+import { recoverIncompleteTransactions } from "@/lib/rename-transaction";
 import { migrateV1AISettings } from "@/lib/ai/migration";
 import { scanICloudForProjects } from "@/lib/scan-icloud-projects";
 import { log, setLogLevel } from "@/lib/logger";
@@ -484,6 +485,22 @@ export async function reloadTrees() {
         (p) => p.endsWith(".md") && !Array.from(projectRoots).some((pr) => p.startsWith(pr + "/")),
       );
       void backfillSidecarOriginalPaths(notesRoot!, mdFilePaths).catch(() => {});
+    }
+  }
+
+  // Recover any incomplete rename transactions left by a previous crash.
+  // Must run after the notes root is validated and the notes tree is loaded,
+  // but before setting startupReady (so the watcher does not start emitting
+  // events for staging files that are still being cleaned up).
+  {
+    const notesRoot = useSettingsStore.getState().notesRootPath;
+    const isValidNotesRoot = notesRoot != null && notesRoot.length > 0 && !notesRoot.startsWith("~");
+    if (isValidNotesRoot) {
+      try {
+        await recoverIncompleteTransactions(notesRoot!);
+      } catch (err) {
+        log.warn("startup", `rename transaction recovery failed: ${err}`);
+      }
     }
   }
 

--- a/src/hooks/useFileRenameSync.ts
+++ b/src/hooks/useFileRenameSync.ts
@@ -6,9 +6,10 @@ import { useSettingsStore } from "@/stores/settings-store";
 import { useFileOperations } from "@/hooks/useFileOperations";
 import { isSelfRename, consumeSelfRename } from "@/lib/self-rename-filter";
 import { toastExternalRename } from "@/lib/notifications";
-import { tauriApi } from "@/lib/tauri";
 import { log } from "@/lib/logger";
-import { commentSidecarPath, parseSidecar, serializeSidecar } from "@/lib/comment-storage";
+import { commentSidecarPath, parseSidecar } from "@/lib/comment-storage";
+import { executeRenameTransaction, type SidecarMigrationInput } from "@/lib/rename-transaction";
+import { tauriApi } from "@/lib/tauri";
 
 interface FileRenamedPayload {
   old_path: string;
@@ -16,45 +17,32 @@ interface FileRenamedPayload {
   is_directory: boolean;
 }
 
-/** Migrate a single non-project file's path-keyed sidecar on rename. */
-async function migrateFileSidecar(
-  oldFilePath: string,
-  newFilePath: string,
-  notesRootPath: string
-): Promise<void> {
-  const oldSidecar = commentSidecarPath(notesRootPath, oldFilePath);
-  const newSidecar = commentSidecarPath(notesRootPath, newFilePath);
-  try {
-    const exists = await tauriApi.pathExists(oldSidecar);
-    if (!exists) return;
-    const content = await tauriApi.readFile(oldSidecar);
-    await tauriApi.writeFile(newSidecar, content);
-    await tauriApi.deletePath(oldSidecar);
-  } catch (err) {
-    log.warn("useFileRenameSync", `sidecar migration failed ${oldSidecar} → ${newSidecar}: ${err}`);
-  }
-}
-
 /**
  * Reverse-lookup pass for closed-tab non-project files on folder rename.
  *
- * Lists all path-keyed sidecars in the comments directory and migrates any
- * whose `originalPath` falls inside the renamed folder. Sidecars already
- * migrated by the open-tab pass are skipped (their new hash path exists).
+ * Lists all path-keyed sidecars in the comments directory and collects
+ * migration inputs for any whose `originalPath` falls inside the renamed
+ * folder. Returns the inputs so the caller can run them through
+ * `executeRenameTransaction` as part of a single crash-safe transaction.
+ *
+ * Sidecars already migrated by the open-tab pass (new hash path exists) are
+ * skipped.
  */
-async function migrateClosedTabSidecars(
+async function collectClosedTabMigrationInputs(
   oldFolderPath: string,
   newFolderPath: string,
   notesRootPath: string,
   projectRoots: string[],
-): Promise<void> {
+): Promise<SidecarMigrationInput[]> {
   const commentsDir = `${notesRootPath}/.notesage/comments`;
   let entries: Awaited<ReturnType<typeof tauriApi.listDirectory>>;
   try {
     entries = await tauriApi.listDirectory(commentsDir);
   } catch {
-    return; // comments directory does not exist yet
+    return []; // comments directory does not exist yet
   }
+
+  const inputs: SidecarMigrationInput[] = [];
 
   for (const entry of entries) {
     if (entry.is_directory || !entry.name.endsWith(".json") || !entry.name.startsWith("path-")) {
@@ -89,13 +77,10 @@ async function migrateClosedTabSidecars(
       // proceed
     }
 
-    try {
-      await tauriApi.writeFile(newSidecar, serializeSidecar(data.comments, newFilePath));
-      await tauriApi.deletePath(entry.path);
-    } catch (err) {
-      log.warn("useFileRenameSync", `closed-tab sidecar migration failed ${entry.path}: ${err}`);
-    }
+    inputs.push({ oldSidecar: entry.path, newSidecar, newFilePath });
   }
+
+  return inputs;
 }
 
 /**
@@ -164,30 +149,51 @@ export function useFileRenameSync(): void {
           // Single file rename: migrate sidecar if not inside a project.
           const isProjectFile = projects.some((p) => old_path.startsWith(p.path + "/"));
           if (!isProjectFile) {
-            void migrateFileSidecar(old_path, new_path, notesRootPath!).catch(() => {});
+            const oldSidecar = commentSidecarPath(notesRootPath!, old_path);
+            const newSidecar = commentSidecarPath(notesRootPath!, new_path);
+            void executeRenameTransaction(notesRootPath!, [
+              { oldSidecar, newSidecar, newFilePath: new_path },
+            ]).catch(() => {});
           }
         } else {
-          // Folder rename: fast path for open tabs (synchronous iteration),
-          // then reverse-lookup pass for closed-tab files via originalPath.
+          // Folder rename: collect all migration inputs (open-tab fast path +
+          // closed-tab reverse-lookup pass), then run them through a single
+          // crash-safe transaction.
           const descendantTabs = openDocs.filter((tab) =>
             tab.filePath.startsWith(new_path + "/")
           );
+          const openTabInputs: SidecarMigrationInput[] = [];
           for (const tab of descendantTabs) {
             const isProjectFile = projects.some((p) => tab.filePath.startsWith(p.path + "/"));
             if (!isProjectFile) {
-              // Reconstruct the old file path: replace the new prefix with the old one.
               const oldFilePath = old_path + tab.filePath.slice(new_path.length);
-              void migrateFileSidecar(oldFilePath, tab.filePath, notesRootPath!).catch(() => {});
+              openTabInputs.push({
+                oldSidecar: commentSidecarPath(notesRootPath!, oldFilePath),
+                newSidecar: commentSidecarPath(notesRootPath!, tab.filePath),
+                newFilePath: tab.filePath,
+              });
             }
           }
+
+          // Run open-tab migrations first in their own transaction so they are
+          // available to the closed-tab dedup check (alreadyMigrated check uses
+          // pathExists on the new sidecar path).
+          if (openTabInputs.length > 0) {
+            void executeRenameTransaction(notesRootPath!, openTabInputs).catch(() => {});
+          }
+
           // Reverse-lookup: migrate sidecars for closed-tab files whose
           // originalPath was inside the renamed folder.
-          void migrateClosedTabSidecars(
+          void collectClosedTabMigrationInputs(
             old_path,
             new_path,
             notesRootPath!,
             projects.map((p) => p.path),
-          ).catch(() => {});
+          ).then((closedInputs) => {
+            if (closedInputs.length > 0) {
+              return executeRenameTransaction(notesRootPath!, closedInputs);
+            }
+          }).catch(() => {});
         }
       }
 

--- a/src/lib/__tests__/rename-transaction.test.ts
+++ b/src/lib/__tests__/rename-transaction.test.ts
@@ -1,0 +1,453 @@
+/**
+ * RED tests for the crash-safe rename transaction manager (issue #144).
+ *
+ * Tests cover the three commit phases (prepare, committing, committed) and
+ * the startup recovery path for incomplete transactions.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const mockWriteFile = vi.fn().mockResolvedValue(undefined);
+const mockReadFile = vi.fn().mockResolvedValue('{}');
+const mockPathExists = vi.fn().mockResolvedValue(false);
+const mockDeletePath = vi.fn().mockResolvedValue(undefined);
+const mockCreateDirectory = vi.fn().mockResolvedValue(undefined);
+const mockListDirectory = vi.fn().mockResolvedValue([]);
+
+vi.mock('@/lib/tauri', () => ({
+  tauriApi: {
+    writeFile: (...args: unknown[]) => mockWriteFile(...args),
+    readFile: (...args: unknown[]) => mockReadFile(...args),
+    pathExists: (...args: unknown[]) => mockPathExists(...args),
+    deletePath: (...args: unknown[]) => mockDeletePath(...args),
+    createDirectory: (...args: unknown[]) => mockCreateDirectory(...args),
+    listDirectory: (...args: unknown[]) => mockListDirectory(...args),
+  },
+}));
+
+import {
+  executeRenameTransaction,
+  recoverIncompleteTransactions,
+  RENAME_TXN_DIR,
+  type RenameTransactionManifest,
+  type TransactionPhase,
+} from '../rename-transaction';
+
+const NOTES_ROOT = '/Users/test/Notesage';
+const TXN_BASE = `${NOTES_ROOT}/.notesage/${RENAME_TXN_DIR}`;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPathExists.mockResolvedValue(false);
+  mockListDirectory.mockResolvedValue([]);
+  mockReadFile.mockResolvedValue('{}');
+  mockWriteFile.mockResolvedValue(undefined);
+  mockDeletePath.mockResolvedValue(undefined);
+  mockCreateDirectory.mockResolvedValue(undefined);
+});
+
+// ---------------------------------------------------------------------------
+// Phase tests: prepare → committing → committed
+// ---------------------------------------------------------------------------
+
+describe('executeRenameTransaction — happy path (prepare → committing → committed)', () => {
+  it('writes staging copies during prepare phase', async () => {
+    const oldSidecar = `${NOTES_ROOT}/.notesage/comments/path-old.json`;
+    const newSidecar = `${NOTES_ROOT}/.notesage/comments/path-new.json`;
+    const content = JSON.stringify({ originalPath: '/notes/old.md', comments: [] });
+
+    // old sidecar exists
+    mockPathExists.mockImplementation(async (p: string) => p === oldSidecar);
+    mockReadFile.mockImplementation(async (p: string) => {
+      if (p === oldSidecar) return content;
+      return '{}';
+    });
+
+    const writtenFiles: Array<{ path: string; content: string }> = [];
+    mockWriteFile.mockImplementation(async (p: string, c: string) => {
+      writtenFiles.push({ path: p, content: c });
+    });
+
+    await executeRenameTransaction(NOTES_ROOT, [
+      { oldSidecar, newSidecar, newFilePath: '/notes/new.md' },
+    ]);
+
+    // Staging copies should have been written during prepare
+    const stagingWrites = writtenFiles.filter((w) => w.path.includes(RENAME_TXN_DIR));
+    expect(stagingWrites.length).toBeGreaterThan(0);
+  });
+
+  it('marks manifest as "committing" before applying destination writes', async () => {
+    const oldSidecar = `${NOTES_ROOT}/.notesage/comments/path-old.json`;
+    const newSidecar = `${NOTES_ROOT}/.notesage/comments/path-new.json`;
+    const content = JSON.stringify({ originalPath: '/notes/old.md', comments: [] });
+
+    mockPathExists.mockImplementation(async (p: string) => p === oldSidecar);
+    mockReadFile.mockImplementation(async (p: string) => {
+      if (p === oldSidecar) return content;
+      return '{}';
+    });
+
+    const manifestWrites: Array<{ path: string; content: string }> = [];
+    mockWriteFile.mockImplementation(async (p: string, c: string) => {
+      if (p.endsWith('manifest.json')) {
+        manifestWrites.push({ path: p, content: c });
+      }
+    });
+
+    await executeRenameTransaction(NOTES_ROOT, [
+      { oldSidecar, newSidecar, newFilePath: '/notes/new.md' },
+    ]);
+
+    // Should have written manifest with "committing" phase at some point
+    const committingWrite = manifestWrites.find((w) => {
+      try {
+        const m = JSON.parse(w.content) as RenameTransactionManifest;
+        return m.phase === 'committing';
+      } catch {
+        return false;
+      }
+    });
+    expect(committingWrite).toBeDefined();
+  });
+
+  it('writes the new sidecar to the destination path during commit', async () => {
+    const oldSidecar = `${NOTES_ROOT}/.notesage/comments/path-old.json`;
+    const newSidecar = `${NOTES_ROOT}/.notesage/comments/path-new.json`;
+    const content = JSON.stringify({ originalPath: '/notes/old.md', comments: [{ id: 'c1' }] });
+
+    mockPathExists.mockImplementation(async (p: string) => p === oldSidecar);
+    mockReadFile.mockImplementation(async (p: string) => {
+      if (p === oldSidecar) return content;
+      // staging files also return the same content
+      if (p.includes(RENAME_TXN_DIR)) return content;
+      return '{}';
+    });
+
+    const writtenFiles: Array<{ path: string; content: string }> = [];
+    mockWriteFile.mockImplementation(async (p: string, c: string) => {
+      writtenFiles.push({ path: p, content: c });
+    });
+
+    await executeRenameTransaction(NOTES_ROOT, [
+      { oldSidecar, newSidecar, newFilePath: '/notes/new.md' },
+    ]);
+
+    // The new sidecar destination must be written
+    const destWrite = writtenFiles.find((w) => w.path === newSidecar);
+    expect(destWrite).toBeDefined();
+  });
+
+  it('deletes the old sidecar after writing the new one', async () => {
+    const oldSidecar = `${NOTES_ROOT}/.notesage/comments/path-old.json`;
+    const newSidecar = `${NOTES_ROOT}/.notesage/comments/path-new.json`;
+    const content = JSON.stringify({ originalPath: '/notes/old.md', comments: [] });
+
+    mockPathExists.mockImplementation(async (p: string) => p === oldSidecar);
+    mockReadFile.mockImplementation(async (p: string) => {
+      if (p === oldSidecar || p.includes(RENAME_TXN_DIR)) return content;
+      return '{}';
+    });
+
+    const deletedPaths: string[] = [];
+    mockDeletePath.mockImplementation(async (p: string) => {
+      deletedPaths.push(p);
+    });
+
+    await executeRenameTransaction(NOTES_ROOT, [
+      { oldSidecar, newSidecar, newFilePath: '/notes/new.md' },
+    ]);
+
+    expect(deletedPaths).toContain(oldSidecar);
+  });
+
+  it('cleans up the staging directory after committed phase', async () => {
+    const oldSidecar = `${NOTES_ROOT}/.notesage/comments/path-old.json`;
+    const newSidecar = `${NOTES_ROOT}/.notesage/comments/path-new.json`;
+    const content = JSON.stringify({ originalPath: '/notes/old.md', comments: [] });
+
+    mockPathExists.mockImplementation(async (p: string) => p === oldSidecar || p.includes(RENAME_TXN_DIR));
+    mockReadFile.mockImplementation(async (p: string) => {
+      if (p === oldSidecar || p.includes(RENAME_TXN_DIR)) return content;
+      return '{}';
+    });
+
+    const deletedPaths: string[] = [];
+    mockDeletePath.mockImplementation(async (p: string) => {
+      deletedPaths.push(p);
+    });
+
+    await executeRenameTransaction(NOTES_ROOT, [
+      { oldSidecar, newSidecar, newFilePath: '/notes/new.md' },
+    ]);
+
+    // The staging directory for this transaction must be cleaned up
+    const txnDirCleanup = deletedPaths.some((p) => p.includes(RENAME_TXN_DIR));
+    expect(txnDirCleanup).toBe(true);
+  });
+
+  it('is a no-op when the old sidecar does not exist', async () => {
+    const oldSidecar = `${NOTES_ROOT}/.notesage/comments/path-nosidecar.json`;
+    const newSidecar = `${NOTES_ROOT}/.notesage/comments/path-new.json`;
+
+    mockPathExists.mockResolvedValue(false);
+
+    const writtenFiles: string[] = [];
+    mockWriteFile.mockImplementation(async (p: string) => { writtenFiles.push(p); });
+
+    await executeRenameTransaction(NOTES_ROOT, [
+      { oldSidecar, newSidecar, newFilePath: '/notes/new.md' },
+    ]);
+
+    // No destination write should happen if source doesn't exist
+    expect(writtenFiles.filter((p) => p === newSidecar)).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Crash recovery: crash before commit marked (rollback)
+// ---------------------------------------------------------------------------
+
+describe('recoverIncompleteTransactions — crash during prepare (rollback)', () => {
+  it('cleans up staging dir and leaves old sidecars untouched when crashed before committing', async () => {
+    const txnId = 'txn-prepare-crash';
+    const txnDir = `${TXN_BASE}/${txnId}`;
+    const manifestPath = `${txnDir}/manifest.json`;
+    const oldSidecar = `${NOTES_ROOT}/.notesage/comments/path-old.json`;
+    const newSidecar = `${NOTES_ROOT}/.notesage/comments/path-new.json`;
+    const stagingFile = `${txnDir}/entry-0.json`;
+
+    const manifest: RenameTransactionManifest = {
+      txnId,
+      phase: 'prepare', // crashed before reaching "committing"
+      entries: [{ oldSidecar, newSidecar, stagingFile }],
+      createdAt: Date.now() - 60_000, // 1 minute ago
+    };
+
+    // The txn dir and staging file exist
+    mockListDirectory.mockImplementation(async (p: string) => {
+      if (p === TXN_BASE) {
+        return [{ name: txnId, path: txnDir, is_directory: true, hidden: false }];
+      }
+      return [];
+    });
+    mockPathExists.mockImplementation(async (p: string) =>
+      p === txnDir || p === manifestPath || p === stagingFile
+    );
+    mockReadFile.mockImplementation(async (p: string) => {
+      if (p === manifestPath) return JSON.stringify(manifest);
+      return '{}';
+    });
+
+    const deletedPaths: string[] = [];
+    mockDeletePath.mockImplementation(async (p: string) => { deletedPaths.push(p); });
+    const writtenFiles: string[] = [];
+    mockWriteFile.mockImplementation(async (p: string) => { writtenFiles.push(p); });
+
+    await recoverIncompleteTransactions(NOTES_ROOT);
+
+    // The new destination sidecar must NOT have been written (rollback, not commit)
+    expect(writtenFiles).not.toContain(newSidecar);
+    // The staging directory should be cleaned up
+    const txnDirDeleted = deletedPaths.some((p) => p.includes(txnId));
+    expect(txnDirDeleted).toBe(true);
+  });
+
+  it('does not delete the old sidecar when rolling back a prepare-phase crash', async () => {
+    const txnId = 'txn-rollback-test';
+    const txnDir = `${TXN_BASE}/${txnId}`;
+    const manifestPath = `${txnDir}/manifest.json`;
+    const oldSidecar = `${NOTES_ROOT}/.notesage/comments/path-still-here.json`;
+    const newSidecar = `${NOTES_ROOT}/.notesage/comments/path-new.json`;
+    const stagingFile = `${txnDir}/entry-0.json`;
+
+    const manifest: RenameTransactionManifest = {
+      txnId,
+      phase: 'prepare',
+      entries: [{ oldSidecar, newSidecar, stagingFile }],
+      createdAt: Date.now() - 5_000,
+    };
+
+    mockListDirectory.mockImplementation(async (p: string) => {
+      if (p === TXN_BASE) {
+        return [{ name: txnId, path: txnDir, is_directory: true, hidden: false }];
+      }
+      return [];
+    });
+    mockPathExists.mockResolvedValue(true);
+    mockReadFile.mockImplementation(async (p: string) => {
+      if (p === manifestPath) return JSON.stringify(manifest);
+      return '{}';
+    });
+
+    const deletedPaths: string[] = [];
+    mockDeletePath.mockImplementation(async (p: string) => { deletedPaths.push(p); });
+
+    await recoverIncompleteTransactions(NOTES_ROOT);
+
+    // Old sidecar must NOT be deleted during rollback
+    expect(deletedPaths).not.toContain(oldSidecar);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Crash recovery: crash after "committing" is marked (resume / apply)
+// ---------------------------------------------------------------------------
+
+describe('recoverIncompleteTransactions — crash after committing marked (resume)', () => {
+  it('applies the migration (write new + delete old) when crashed after committing', async () => {
+    const txnId = 'txn-committing-crash';
+    const txnDir = `${TXN_BASE}/${txnId}`;
+    const manifestPath = `${txnDir}/manifest.json`;
+    const oldSidecar = `${NOTES_ROOT}/.notesage/comments/path-old.json`;
+    const newSidecar = `${NOTES_ROOT}/.notesage/comments/path-new.json`;
+    const stagingFile = `${txnDir}/entry-0.json`;
+    const sidecarContent = JSON.stringify({ originalPath: '/notes/old.md', comments: [{ id: 'c1' }] });
+
+    const manifest: RenameTransactionManifest = {
+      txnId,
+      phase: 'committing', // crashed after being marked committing
+      entries: [{ oldSidecar, newSidecar, stagingFile }],
+      createdAt: Date.now() - 30_000,
+    };
+
+    mockListDirectory.mockImplementation(async (p: string) => {
+      if (p === TXN_BASE) {
+        return [{ name: txnId, path: txnDir, is_directory: true, hidden: false }];
+      }
+      return [];
+    });
+    mockPathExists.mockImplementation(async (p: string) =>
+      p === txnDir || p === manifestPath || p === stagingFile
+    );
+    mockReadFile.mockImplementation(async (p: string) => {
+      if (p === manifestPath) return JSON.stringify(manifest);
+      if (p === stagingFile) return sidecarContent;
+      return '{}';
+    });
+
+    const writtenFiles: Array<{ path: string; content: string }> = [];
+    mockWriteFile.mockImplementation(async (p: string, c: string) => {
+      writtenFiles.push({ path: p, content: c });
+    });
+    const deletedPaths: string[] = [];
+    mockDeletePath.mockImplementation(async (p: string) => { deletedPaths.push(p); });
+
+    await recoverIncompleteTransactions(NOTES_ROOT);
+
+    // The new sidecar must be written during recovery
+    const destWrite = writtenFiles.find((w) => w.path === newSidecar);
+    expect(destWrite).toBeDefined();
+    expect(JSON.parse(destWrite!.content)).toMatchObject({ comments: [{ id: 'c1' }] });
+
+    // The old sidecar must be deleted (only if it exists on disk, which it does here
+    // because oldSidecar is not in our mockPathExists, but the recovery should
+    // attempt it unconditionally and handle errors gracefully)
+    // Staging cleanup must also occur
+    const txnCleanup = deletedPaths.some((p) => p.includes(txnId));
+    expect(txnCleanup).toBe(true);
+  });
+
+  it('completes recovery for all entries when a transaction has multiple sidecars', async () => {
+    const txnId = 'txn-multi-entry';
+    const txnDir = `${TXN_BASE}/${txnId}`;
+    const manifestPath = `${txnDir}/manifest.json`;
+
+    const entries = [
+      {
+        oldSidecar: `${NOTES_ROOT}/.notesage/comments/path-a.json`,
+        newSidecar: `${NOTES_ROOT}/.notesage/comments/path-aa.json`,
+        stagingFile: `${txnDir}/entry-0.json`,
+      },
+      {
+        oldSidecar: `${NOTES_ROOT}/.notesage/comments/path-b.json`,
+        newSidecar: `${NOTES_ROOT}/.notesage/comments/path-bb.json`,
+        stagingFile: `${txnDir}/entry-1.json`,
+      },
+    ];
+
+    const manifest: RenameTransactionManifest = {
+      txnId,
+      phase: 'committing',
+      entries,
+      createdAt: Date.now() - 10_000,
+    };
+
+    mockListDirectory.mockImplementation(async (p: string) => {
+      if (p === TXN_BASE) {
+        return [{ name: txnId, path: txnDir, is_directory: true, hidden: false }];
+      }
+      return [];
+    });
+    mockPathExists.mockImplementation(async (p: string) =>
+      p === txnDir || p === manifestPath || p.includes(txnDir)
+    );
+    mockReadFile.mockImplementation(async (p: string) => {
+      if (p === manifestPath) return JSON.stringify(manifest);
+      // All staging files return valid content
+      if (p.includes(txnDir)) return JSON.stringify({ originalPath: '/notes/x.md', comments: [] });
+      return '{}';
+    });
+
+    const writtenFiles: string[] = [];
+    mockWriteFile.mockImplementation(async (p: string) => { writtenFiles.push(p); });
+
+    await recoverIncompleteTransactions(NOTES_ROOT);
+
+    // Both new sidecars must be written
+    expect(writtenFiles).toContain(entries[0].newSidecar);
+    expect(writtenFiles).toContain(entries[1].newSidecar);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// No-op when txn dir does not exist
+// ---------------------------------------------------------------------------
+
+describe('recoverIncompleteTransactions — no-op when no transactions pending', () => {
+  it('returns without error when the rename-txn directory does not exist', async () => {
+    mockPathExists.mockResolvedValue(false);
+    mockListDirectory.mockRejectedValue(new Error('ENOENT'));
+
+    await expect(recoverIncompleteTransactions(NOTES_ROOT)).resolves.not.toThrow();
+  });
+
+  it('returns without error when rename-txn directory is empty', async () => {
+    mockPathExists.mockImplementation(async (p: string) => p === TXN_BASE);
+    mockListDirectory.mockResolvedValue([]);
+
+    await expect(recoverIncompleteTransactions(NOTES_ROOT)).resolves.not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RENAME_TXN_DIR constant must be set correctly for watcher exclusion
+// ---------------------------------------------------------------------------
+
+describe('RENAME_TXN_DIR constant', () => {
+  it('is the expected directory name used in watcher exclusion', () => {
+    expect(RENAME_TXN_DIR).toBe('rename-txn');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TransactionPhase type check
+// ---------------------------------------------------------------------------
+
+describe('TransactionPhase values', () => {
+  it('covers prepare, committing, and committed', () => {
+    const phases: TransactionPhase[] = ['prepare', 'committing', 'committed'];
+    expect(phases).toHaveLength(3);
+    expect(phases).toContain('prepare');
+    expect(phases).toContain('committing');
+    expect(phases).toContain('committed');
+  });
+});

--- a/src/lib/rename-transaction.ts
+++ b/src/lib/rename-transaction.ts
@@ -1,0 +1,382 @@
+/**
+ * Crash-safe three-phase commit for path-keyed sidecar file migration.
+ *
+ * When a folder rename touches N path-keyed sidecar files sequentially, a
+ * process kill mid-migration can leave sidecars in an inconsistent state.
+ * This module wraps the migration in a transaction with staging so that:
+ *
+ *   - A crash during **prepare** (before "committing" is written) triggers a
+ *     rollback on the next app start — old sidecars are left intact.
+ *   - A crash during or after **committing** is detected on the next app start
+ *     and the migration is resumed from the staging copies.
+ *
+ * Transaction directory layout:
+ *
+ *   <notesRoot>/.notesage/rename-txn/<txnId>/
+ *     manifest.json          — phase + entry list
+ *     entry-0.json           — staging copy of entry 0's sidecar content
+ *     entry-1.json           — staging copy of entry 1's sidecar content
+ *     ...
+ *
+ * The three phases:
+ *   1. **prepare**    — create txn dir, copy sidecars to staging, write manifest
+ *   2. **committing** — update manifest phase, apply destination writes + deletes
+ *   3. **committed**  — remove the txn dir (cleanup)
+ *
+ * The watcher excludes `rename-txn/` by name so staging writes never trigger
+ * spurious `file-changed-batch` events. See `watcher.rs` for the exclusion.
+ */
+
+import { tauriApi } from '@/lib/tauri';
+import { log } from '@/lib/logger';
+
+/** Name of the staging directory under `.notesage/`. Also used by the watcher for exclusion. */
+export const RENAME_TXN_DIR = 'rename-txn';
+
+/** The three commit phases of a rename transaction. */
+export type TransactionPhase = 'prepare' | 'committing' | 'committed';
+
+/** A single sidecar entry inside a transaction. */
+export interface RenameTransactionEntry {
+  /** Absolute path to the old (source) sidecar. */
+  oldSidecar: string;
+  /** Absolute path to the new (destination) sidecar. */
+  newSidecar: string;
+  /** Absolute path to the staging copy inside the txn directory. */
+  stagingFile: string;
+}
+
+/** The manifest written to `<txnDir>/manifest.json`. */
+export interface RenameTransactionManifest {
+  txnId: string;
+  phase: TransactionPhase;
+  entries: RenameTransactionEntry[];
+  /** Unix ms timestamp for debugging / stale-txn detection. */
+  createdAt: number;
+}
+
+/** Input descriptor for a single sidecar migration. */
+export interface SidecarMigrationInput {
+  /** Absolute path to the old sidecar. */
+  oldSidecar: string;
+  /** Absolute path to the destination sidecar. */
+  newSidecar: string;
+  /** The new document path (used to update `originalPath` in the sidecar envelope). */
+  newFilePath: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function txnBasePath(notesRootPath: string): string {
+  return `${notesRootPath}/.notesage/${RENAME_TXN_DIR}`;
+}
+
+function txnDirPath(notesRootPath: string, txnId: string): string {
+  return `${txnBasePath(notesRootPath)}/${txnId}`;
+}
+
+function manifestPath(txnDir: string): string {
+  return `${txnDir}/manifest.json`;
+}
+
+function generateTxnId(): string {
+  return `txn-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function writeManifest(txnDir: string, manifest: RenameTransactionManifest): Promise<void> {
+  await tauriApi.writeFile(manifestPath(txnDir), JSON.stringify(manifest, null, 2));
+}
+
+/** Best-effort cleanup of a transaction directory. Never throws. */
+async function cleanupTxnDir(txnDir: string): Promise<void> {
+  try {
+    await tauriApi.deletePath(txnDir);
+  } catch (err) {
+    log.warn('rename-transaction', `cleanup failed for ${txnDir}: ${err}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// executeRenameTransaction
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute a crash-safe rename of zero or more path-keyed sidecar files.
+ *
+ * Entries whose `oldSidecar` does not exist on disk are silently skipped.
+ * The caller is responsible for determining which sidecars need migration.
+ */
+export async function executeRenameTransaction(
+  notesRootPath: string,
+  inputs: SidecarMigrationInput[],
+): Promise<void> {
+  if (inputs.length === 0) return;
+
+  // Filter to entries where the old sidecar actually exists
+  const existingInputs: SidecarMigrationInput[] = [];
+  for (const input of inputs) {
+    try {
+      const exists = await tauriApi.pathExists(input.oldSidecar);
+      if (exists) {
+        existingInputs.push(input);
+      }
+    } catch {
+      // path check failed — skip this entry
+    }
+  }
+
+  if (existingInputs.length === 0) return;
+
+  const txnId = generateTxnId();
+  const txnDir = txnDirPath(notesRootPath, txnId);
+
+  // -------------------------------------------------------------------------
+  // PHASE 1: prepare
+  // -------------------------------------------------------------------------
+
+  try {
+    await tauriApi.createDirectory(txnDir);
+  } catch (err) {
+    log.warn('rename-transaction', `failed to create txn dir ${txnDir}: ${err}`);
+    // If we cannot create the txn dir, fall back to direct migration (unsafe but better than nothing)
+    await directMigrate(existingInputs);
+    return;
+  }
+
+  const entries: RenameTransactionEntry[] = [];
+  const readContents: string[] = [];
+
+  for (let i = 0; i < existingInputs.length; i++) {
+    const input = existingInputs[i];
+    const stagingFile = `${txnDir}/entry-${i}.json`;
+
+    let content: string;
+    try {
+      content = await tauriApi.readFile(input.oldSidecar);
+    } catch (err) {
+      log.warn('rename-transaction', `failed to read ${input.oldSidecar}: ${err}`);
+      continue;
+    }
+
+    // Update originalPath in the sidecar envelope if present
+    let updatedContent = content;
+    try {
+      const parsed = JSON.parse(content) as { originalPath?: string; comments?: unknown[] };
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        parsed.originalPath = input.newFilePath;
+        updatedContent = JSON.stringify(parsed, null, 2);
+      }
+    } catch {
+      // not a parseable envelope — use raw content as-is
+    }
+
+    try {
+      await tauriApi.writeFile(stagingFile, updatedContent);
+    } catch (err) {
+      log.warn('rename-transaction', `failed to write staging ${stagingFile}: ${err}`);
+      await cleanupTxnDir(txnDir);
+      return;
+    }
+
+    entries.push({ oldSidecar: input.oldSidecar, newSidecar: input.newSidecar, stagingFile });
+    readContents.push(updatedContent);
+  }
+
+  if (entries.length === 0) {
+    await cleanupTxnDir(txnDir);
+    return;
+  }
+
+  const manifest: RenameTransactionManifest = {
+    txnId,
+    phase: 'prepare',
+    entries,
+    createdAt: Date.now(),
+  };
+
+  try {
+    await writeManifest(txnDir, manifest);
+  } catch (err) {
+    log.warn('rename-transaction', `failed to write manifest for ${txnId}: ${err}`);
+    await cleanupTxnDir(txnDir);
+    return;
+  }
+
+  // -------------------------------------------------------------------------
+  // PHASE 2: committing — mark manifest, then apply
+  // -------------------------------------------------------------------------
+
+  manifest.phase = 'committing';
+  try {
+    await writeManifest(txnDir, manifest);
+  } catch (err) {
+    log.warn('rename-transaction', `failed to mark committing for ${txnId}: ${err}`);
+    await cleanupTxnDir(txnDir);
+    return;
+  }
+
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i];
+    const content = readContents[i];
+
+    try {
+      await tauriApi.writeFile(entry.newSidecar, content);
+    } catch (err) {
+      log.warn('rename-transaction', `failed to write dest ${entry.newSidecar}: ${err}`);
+      // Continue — will be retried via recovery on next launch
+      continue;
+    }
+
+    try {
+      await tauriApi.deletePath(entry.oldSidecar);
+    } catch (err) {
+      log.warn('rename-transaction', `failed to delete old ${entry.oldSidecar}: ${err}`);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // PHASE 3: committed — cleanup staging dir
+  // -------------------------------------------------------------------------
+
+  await cleanupTxnDir(txnDir);
+}
+
+// ---------------------------------------------------------------------------
+// recoverIncompleteTransactions (startup recovery scan)
+// ---------------------------------------------------------------------------
+
+/**
+ * Scan `<notesRoot>/.notesage/rename-txn/` for incomplete transactions and
+ * recover them:
+ *
+ * - **phase === "prepare"**: process was killed before committing. Rollback:
+ *   delete the staging dir. Old sidecars were never touched, so no data loss.
+ *
+ * - **phase === "committing"**: process was killed mid-commit. Resume: re-apply
+ *   the destination writes from staging, delete old sidecars, then cleanup.
+ *
+ * - **phase === "committed"**: process was killed during cleanup. Just delete the
+ *   staging dir.
+ *
+ * Silently swallows per-transaction errors so a corrupted manifest cannot block
+ * startup.
+ */
+export async function recoverIncompleteTransactions(notesRootPath: string): Promise<void> {
+  const basePath = txnBasePath(notesRootPath);
+
+  let txnDirs: Awaited<ReturnType<typeof tauriApi.listDirectory>>;
+  try {
+    txnDirs = await tauriApi.listDirectory(basePath);
+  } catch {
+    // The rename-txn dir doesn't exist yet — nothing to recover
+    return;
+  }
+
+  for (const entry of txnDirs) {
+    if (!entry.is_directory) continue;
+    await recoverSingleTransaction(entry.path).catch((err) => {
+      log.warn('rename-transaction', `recovery failed for ${entry.path}: ${err}`);
+    });
+  }
+}
+
+async function recoverSingleTransaction(txnDir: string): Promise<void> {
+  const mPath = manifestPath(txnDir);
+
+  let raw: string;
+  try {
+    raw = await tauriApi.readFile(mPath);
+  } catch {
+    // No manifest — corrupted txn dir, clean up
+    await cleanupTxnDir(txnDir);
+    return;
+  }
+
+  let manifest: RenameTransactionManifest;
+  try {
+    manifest = JSON.parse(raw) as RenameTransactionManifest;
+  } catch {
+    await cleanupTxnDir(txnDir);
+    return;
+  }
+
+  log.info(
+    'rename-transaction',
+    `recovering txn ${manifest.txnId} phase=${manifest.phase} entries=${manifest.entries.length}`,
+  );
+
+  switch (manifest.phase) {
+    case 'prepare':
+      // Crashed before committing — rollback by just cleaning up staging.
+      // Old sidecars were never modified.
+      await cleanupTxnDir(txnDir);
+      break;
+
+    case 'committing':
+      // Crashed mid-commit — resume from staging files.
+      for (const entry of manifest.entries) {
+        try {
+          let content: string;
+          try {
+            content = await tauriApi.readFile(entry.stagingFile);
+          } catch {
+            // Staging file is missing — skip this entry
+            continue;
+          }
+
+          await tauriApi.writeFile(entry.newSidecar, content);
+
+          // Delete old sidecar if it still exists (idempotent)
+          try {
+            const oldExists = await tauriApi.pathExists(entry.oldSidecar);
+            if (oldExists) {
+              await tauriApi.deletePath(entry.oldSidecar);
+            }
+          } catch {
+            // best-effort
+          }
+        } catch (err) {
+          log.warn('rename-transaction', `recovery entry failed ${entry.newSidecar}: ${err}`);
+        }
+      }
+      await cleanupTxnDir(txnDir);
+      break;
+
+    case 'committed':
+      // Committed but cleanup didn't finish — just delete the staging dir.
+      await cleanupTxnDir(txnDir);
+      break;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// directMigrate — fallback (no staging available)
+// ---------------------------------------------------------------------------
+
+/** Non-transactional fallback for when the txn dir cannot be created. */
+async function directMigrate(inputs: SidecarMigrationInput[]): Promise<void> {
+  for (const input of inputs) {
+    try {
+      const content = await tauriApi.readFile(input.oldSidecar);
+
+      // Update originalPath if present
+      let updatedContent = content;
+      try {
+        const parsed = JSON.parse(content) as { originalPath?: string; comments?: unknown[] };
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+          parsed.originalPath = input.newFilePath;
+          updatedContent = JSON.stringify(parsed, null, 2);
+        }
+      } catch {
+        // raw content
+      }
+
+      await tauriApi.writeFile(input.newSidecar, updatedContent);
+      await tauriApi.deletePath(input.oldSidecar);
+    } catch (err) {
+      log.warn('rename-transaction', `direct migrate failed ${input.oldSidecar}: ${err}`);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Introduces `src/lib/rename-transaction.ts` — a three-phase commit transaction module for crash-safe path-keyed sidecar file migration. Phases: **prepare** (copy sidecars to staging + write manifest) → **committing** (mark manifest, apply destination writes + delete sources) → **committed** (cleanup staging dir).
- Updates `useFileRenameSync` to route all path-keyed sidecar migrations through `executeRenameTransaction` instead of direct sequential read/write/delete, closing the data-loss window on mid-flight process kill during folder renames.
- Adds `recoverIncompleteTransactions` startup scan in `useAppLifecycle` — rolls back `prepare`-phase transactions (no data touched) and resumes `committing`-phase transactions from staging copies.
- Adds `rename-txn/` path exclusion to the Rust watcher's `process_watcher_events` so staging writes never produce spurious `file-changed-batch` events.

## Test plan

- [ ] All 14 tests in `src/lib/__tests__/rename-transaction.test.ts` pass — cover happy path, crash-during-prepare rollback, crash-after-committing resume, multiple entries, no-op when source missing, empty/missing txn dir
- [ ] All 19 tests in `src/hooks/__tests__/useFileRenameSync.test.ts` pass — include closed-tab reverse-lookup migration, project file skip, unrelated folder skip, and existing single-file + open-tab folder migration tests
- [ ] Full `pnpm test` (255 test files, 4671 tests) passes
- [ ] `pnpm typecheck` passes with no errors
- [ ] Rust watcher test `process_watcher_events_excludes_rename_txn_staging_paths` verifies the exclusion (requires Rust toolchain with glib-2.0 available)

Resolves #144