### PR TITLE
chore(rust): clean up two unused-* warnings

### DIFF
--- a/src-tauri/src/commands/skills.rs
+++ b/src-tauri/src/commands/skills.rs
@@ -969,7 +969,7 @@ mod tests {
     #[test]
     fn parse_usage_real_save_research() {
         let script = "#!/usr/bin/env node\n// save.mjs — Save research\n// Usage: node save.mjs <content_or_path> <output_dir> [--title \"...\"] [--tags \"tag1,tag2\"] [--url \"...\"] [--author \"...\"] [--force]\n";
-        let (schema, mappings) = parse_usage_comment(script).unwrap();
+        let (schema, _mappings) = parse_usage_comment(script).unwrap();
         let props = schema["properties"].as_object().unwrap();
         assert_eq!(props.len(), 7);
         assert_eq!(props["content_or_path"]["type"], "string");

--- a/src-tauri/src/export/integration_tests.rs
+++ b/src-tauri/src/export/integration_tests.rs
@@ -1,6 +1,6 @@
 use super::markdown_to_pptx::markdown_to_pptx;
 use super::markdown_to_typst::markdown_to_typst;
-use super::templates::{apply_template, PageSize, PptxTemplate, Template, TemplateOptions};
+use super::templates::{apply_template, PageSize, Template, TemplateOptions};
 use super::typst_world::NotesageWorld;
 use std::time::Instant;
 


### PR DESCRIPTION
## Summary

Two pre-existing `#[warn(unused)]` warnings were surfacing on every Rust CI run. Cleaning them up so future runs are quiet by default.

## Diff

| File | Warning | Fix |
| --- | --- | --- |
| `src-tauri/src/export/integration_tests.rs:3` | `unused import: PptxTemplate` | Drop from the import list |
| `src-tauri/src/commands/skills.rs:972` | `unused variable: mappings` (in destructure) | Prefix with `_mappings` |

## Verification

- [x] `cargo test --no-run` produces zero warnings on this branch (verified locally on `src-tauri/`)
- [x] No behavior change — both fixes are non-functional cleanups
- [x] Diff scoped to two single-line edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)