### PR TITLE
chore(sidebar): remove 'Expand in sidebar' from FolderPeek popover

### DIFF
--- a/src/components/sidebar/quiet/FolderPeek.tsx
+++ b/src/components/sidebar/quiet/FolderPeek.tsx
@@ -406,18 +406,6 @@ export function FolderPeek({
     [projectPath],
   );
 
-  // The footer "Expand in sidebar" button targets the project root —
-  // useful when the user wants to surface every direct child without
-  // committing to a specific subfolder yet.
-  const handleExpandInSidebar = useCallback(() => {
-    setIsOpen(false);
-    emitSidebarEvent({
-      type: "expand-path",
-      projectPath,
-      targetPath: projectPath,
-    });
-  }, [projectPath]);
-
   const handleItemKeyDown = useCallback(
     (event: KeyboardEvent<HTMLButtonElement>, action: () => void) => {
       if (event.key === "Enter" || event.key === " ") {
@@ -658,29 +646,6 @@ export function FolderPeek({
                   )}
                 </>
               )}
-              <div className="my-1 h-px bg-border/60" aria-hidden="true" />
-              {/*
-                Sidebar-simplification task #6 — was "See full tree"
-                that opened TreeOverlay. Now dispatches an
-                `expand-path` event for the project root so the parent
-                ProjectsSection inline-expands the project. The chord
-                hint (⌘⇧E) was dropped because it'll rebind to Open
-                Export in #22 (TreeOverlay deletion + ⌘⇧E reclaim).
-              */}
-              <button
-                type="button"
-                tabIndex={0}
-                onClick={handleExpandInSidebar}
-                onKeyDown={(e) => handleItemKeyDown(e, handleExpandInSidebar)}
-                className={cn(
-                  "h-7 px-2 flex items-center justify-between gap-2 rounded-sm text-xs w-full",
-                  "text-muted-foreground text-left",
-                  "hover:bg-muted/50 hover:text-foreground transition-colors duration-150",
-                  "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--accent,var(--primary))]",
-                )}
-              >
-                <span className="truncate">Expand in sidebar</span>
-              </button>
             </div>,
             document.body,
           )

--- a/src/components/sidebar/quiet/__tests__/FolderPeek.test.tsx
+++ b/src/components/sidebar/quiet/__tests__/FolderPeek.test.tsx
@@ -13,7 +13,7 @@
  *  - hidden / .DS_Store filtering
  *  - file-click opens a tab via `read_file`
  *  - folder-row click dispatches `expand-path` with the folder's path
- *  - footer "Expand in sidebar" button dispatches with project root
+ *  - footer "Expand in sidebar" button is absent (removed — inline row-click supersedes it)
  *  - reduced motion: animation classes omitted
  */
 
@@ -184,12 +184,8 @@ describe("FolderPeek (#36)", () => {
       (el) => el.textContent?.trim()
     );
     // Folders first: alpha-dir, Beta. Files second: alpha.md, zeta.md.
-    // Footer "Expand in sidebar" is last (renamed from "See full tree"
-    // by sidebar-simplification task #6).
-    const folderAndFileItems = items.filter(
-      (t) => t && !t.startsWith("Expand in sidebar")
-    );
-    expect(folderAndFileItems).toEqual([
+    // No footer button — "Expand in sidebar" was removed (issue #157).
+    expect(items).toEqual([
       "alpha-dir",
       "Beta",
       "alpha.md",
@@ -352,15 +348,7 @@ describe("FolderPeek (#36)", () => {
     unsub();
   });
 
-  it("'Expand in sidebar' footer button dispatches expand-path with project root as target", async () => {
-    const { subscribeToSidebarEvents } = await import("@/lib/sidebar-events");
-    const events: Array<{
-      type: string;
-      projectPath: string;
-      targetPath: string;
-    }> = [];
-    const unsub = subscribeToSidebarEvents((ev) => events.push(ev));
-
+  it("does NOT render an 'Expand in sidebar' button in the popover (removed — inline row-click supersedes it)", () => {
     renderWithProviders(
       <FolderPeek
         projectPath="/p/alpha"
@@ -374,19 +362,11 @@ describe("FolderPeek (#36)", () => {
       vi.advanceTimersByTime(HOVER_DELAY + 1);
     });
 
-    const footerBtn = screen.getByRole("button", { name: /expand in sidebar/i });
-    expect(footerBtn.hasAttribute("disabled")).toBe(false); // never disabled now
-    fireEvent.click(footerBtn);
-
-    expect(events).toEqual([
-      {
-        type: "expand-path",
-        projectPath: "/p/alpha",
-        targetPath: "/p/alpha", // project root, no specific child
-      },
-    ]);
-
-    unsub();
+    // The "Expand in sidebar" button must be absent now that inline
+    // folder expansion via row-click covers the same affordance.
+    expect(
+      screen.queryByRole("button", { name: /expand in sidebar/i })
+    ).toBeNull();
   });
 
   it("omits animation classes when reduced motion is preferred", () => {


### PR DESCRIPTION
Resolves #157

## Summary

Removes the redundant "Expand in sidebar" footer button from the `FolderPeek` hover popover. The button was originally added when the popover was the only affordance for expanding a folder in the sidebar. Since inline expansion via folder row-click landed (sidebar-simplification task #6), the footer button duplicates an existing affordance and adds visual clutter with no capability gain.

Also removes the now-dead `handleExpandInSidebar` callback that was only called from the deleted button.

## Red tests added

- `src/components/sidebar/quiet/__tests__/FolderPeek.test.tsx::does NOT render an 'Expand in sidebar' button in the popover` — asserts `queryByRole("button", { name: /expand in sidebar/i })` returns null
- `src/components/sidebar/quiet/__tests__/FolderPeek.test.tsx::renders folders before files, both alphabetical and case-insensitive` — updated to assert the popover contains exactly the 4 folder/file buttons (no longer needs to filter out the footer button)

## Green implementation

- `src/components/sidebar/quiet/FolderPeek.tsx`: removed the `<button>` rendering "Expand in sidebar" and the preceding `<div>` separator (lines ~661–683)
- `src/components/sidebar/quiet/FolderPeek.tsx`: removed the unused `handleExpandInSidebar` useCallback

## Refactor

Deleted the dead `handleExpandInSidebar` callback — it was only ever called from the removed button.

## Decisions made

- The `emitSidebarEvent` + `handleExpandInSidebar` plumbing was removed entirely since no other surface calls it. The `emitSidebarEvent` import remains because `handleFolderClick` (folder row click) still uses it for the `expand-path` event.

## Verification

- [x] Red tests were red before implementation
- [x] All red tests now green
- [x] `pnpm test` passes (full suite — 4774 tests across 262 files)
- [x] `pnpm typecheck` clean
- [x] No unrelated files modified

## Notes for reviewer

The inline row-click expansion (dispatching `notesage:sidebar-expand-path` via `handleFolderClick`) is entirely unchanged — clicking a folder row in the peek still expands it in the sidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the `aw-tdd` skill.