### PR TITLE
feat: Cmd+/Cmd-/Cmd+0 keyboard shortcuts to adjust editor font size

### DIFF
--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -54,6 +54,9 @@ All shortcuts use Cmd (⌘) on macOS. Glyph notation: ⌘ Command · ⌥ Option 
 | --- | --- | --- |
 | Toggle theme | `⌘T` | Switch between light and dark mode |
 | Open settings | `⌘,` | Open settings dialog |
+| Increase font size | `⌘+` / `⌘=` | Increase editor font size by 1pt (clamped to 24pt). Both Cmd-Shift-Equal (`+`) and Cmd-Equal (`=`) fire, plus the physical `Equal` key for non-US layouts. |
+| Decrease font size | `⌘-` | Decrease editor font size by 1pt (clamped to 10pt). Also fires via `event.code === "Minus"` for non-US layouts. |
+| Reset font size | `⌘0` | Reset editor font size to the application default (16pt). |
 
 ## AI Features
 

--- a/src/hooks/__tests__/useKeyboardShortcuts.test.tsx
+++ b/src/hooks/__tests__/useKeyboardShortcuts.test.tsx
@@ -91,6 +91,28 @@ vi.mock("@/stores/editor-store", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Editor-styles-store mock. Exposes adjustFontSize and resetFontSize so the
+// keyboard shortcut wiring tests can verify the font-size chords call through
+// without actually running the store logic.
+// ---------------------------------------------------------------------------
+
+const mockEditorStylesState: {
+  adjustFontSize: ReturnType<typeof vi.fn>;
+  resetFontSize: ReturnType<typeof vi.fn>;
+} = {
+  adjustFontSize: vi.fn(),
+  resetFontSize: vi.fn(),
+};
+
+vi.mock("@/stores/editor-styles-store", () => {
+  const useEditorStylesStore = Object.assign(
+    vi.fn(() => mockEditorStylesState),
+    { getState: () => mockEditorStylesState },
+  );
+  return { useEditorStylesStore };
+});
+
+// ---------------------------------------------------------------------------
 // Import the hook AFTER the mocks above.
 // ---------------------------------------------------------------------------
 
@@ -169,6 +191,10 @@ beforeEach(() => {
   mockEditorState.activeTabId = null;
   mockEditorState.closeTab.mockReset();
   mockEditorState.setPendingCloseTabId.mockReset();
+
+  // Reset editor-styles-store state.
+  mockEditorStylesState.adjustFontSize.mockReset();
+  mockEditorStylesState.resetFontSize.mockReset();
 
   capturedBarEvents = [];
   unsubscribeBar = subscribeToCmdBarEvents((e) => {
@@ -553,6 +579,75 @@ describe("useKeyboardShortcuts (scaffold bindings)", () => {
     } finally {
       window.removeEventListener(REVEAL_IN_FINDER_EVENT, listener);
     }
+  });
+});
+
+// ===========================================================================
+// Font-size keyboard shortcuts — ⌘+ / ⌘- / ⌘0
+// ===========================================================================
+
+describe("useKeyboardShortcuts (font-size chords)", () => {
+  it.each<UiPreview>(["legacy", "quiet-composer"])(
+    "⌘= (Cmd-Equal) increases font size by 1pt under uiPreview=%s",
+    (preview) => {
+      mockSettings.uiPreview = preview;
+      const callbacks = makeCallbacks();
+      renderHook(() => useKeyboardShortcuts(callbacks));
+
+      // US layout: Cmd+= (no shift) — both key and code
+      dispatchKey("=", { code: "Equal", metaKey: true });
+
+      expect(mockEditorStylesState.adjustFontSize).toHaveBeenCalledWith(1);
+    },
+  );
+
+  it.each<UiPreview>(["legacy", "quiet-composer"])(
+    "⌘+ (Cmd-Shift-Equal) increases font size by 1pt under uiPreview=%s",
+    (preview) => {
+      mockSettings.uiPreview = preview;
+      const callbacks = makeCallbacks();
+      renderHook(() => useKeyboardShortcuts(callbacks));
+
+      // US layout: Cmd+Shift+= produces "+"
+      dispatchKey("+", { code: "Equal", metaKey: true, shiftKey: true });
+
+      expect(mockEditorStylesState.adjustFontSize).toHaveBeenCalledWith(1);
+    },
+  );
+
+  it.each<UiPreview>(["legacy", "quiet-composer"])(
+    "⌘- (Cmd-Minus) decreases font size by 1pt under uiPreview=%s",
+    (preview) => {
+      mockSettings.uiPreview = preview;
+      const callbacks = makeCallbacks();
+      renderHook(() => useKeyboardShortcuts(callbacks));
+
+      dispatchKey("-", { code: "Minus", metaKey: true });
+
+      expect(mockEditorStylesState.adjustFontSize).toHaveBeenCalledWith(-1);
+    },
+  );
+
+  it.each<UiPreview>(["legacy", "quiet-composer"])(
+    "⌘0 (Cmd-Zero) resets font size to default under uiPreview=%s",
+    (preview) => {
+      mockSettings.uiPreview = preview;
+      const callbacks = makeCallbacks();
+      renderHook(() => useKeyboardShortcuts(callbacks));
+
+      dispatchKey("0", { code: "Digit0", metaKey: true });
+
+      expect(mockEditorStylesState.resetFontSize).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("⌘= does NOT open the legacy palette (font-size chord takes priority)", () => {
+    const callbacks = makeCallbacks();
+    renderHook(() => useKeyboardShortcuts(callbacks));
+
+    dispatchKey("=", { code: "Equal", metaKey: true });
+
+    expect(callbacks.onPaletteOpen).not.toHaveBeenCalled();
   });
 });
 

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -33,6 +33,7 @@ import { useEffect } from "react";
 import { toast } from "sonner";
 import { useEditorStore } from "@/stores/editor-store";
 import { useSettingsStore } from "@/stores/settings-store";
+import { useEditorStylesStore } from "@/stores/editor-styles-store";
 import { emitCmdBarEvent } from "@/lib/cmd-bar-events";
 import { emitAgentOrbEvent } from "@/lib/agent-orb-events";
 import { useCommandBarShortcuts } from "@/hooks/useCommandBarShortcuts";
@@ -235,6 +236,40 @@ export function useKeyboardShortcuts(callbacks: KeyboardShortcutCallbacks) {
         e.preventDefault();
         const settings = useSettingsStore.getState();
         settings.setTheme(settings.theme === "dark" ? "light" : "dark");
+        return;
+      }
+
+      // ------------------------------------------------------------------
+      // Font-size keyboard shortcuts: ⌘+ / ⌘= (increase), ⌘- (decrease),
+      // ⌘0 (reset to default).
+      //
+      // Cross-keyboard-layout safety:
+      //   ⌘+  — US: Cmd+Shift+Equal (key "+" or "="); non-US layouts fire
+      //         via event.code === "Equal" regardless of shift/modifier.
+      //   ⌘-  — US: Cmd+Minus (key "-"); non-US via code === "Minus".
+      //   ⌘0  — universal; code === "Digit0" for defence in depth.
+      //
+      // No altKey guard needed — alt is never involved for these chords.
+      // ------------------------------------------------------------------
+
+      // ⌘= or ⌘+ (Cmd-Equal or Cmd-Shift-Equal) — increase font size
+      if (isMod && !e.altKey && (key === "=" || key === "+" || e.code === "Equal")) {
+        e.preventDefault();
+        useEditorStylesStore.getState().adjustFontSize(1);
+        return;
+      }
+
+      // ⌘- — decrease font size
+      if (isMod && !e.shiftKey && !e.altKey && (key === "-" || e.code === "Minus")) {
+        e.preventDefault();
+        useEditorStylesStore.getState().adjustFontSize(-1);
+        return;
+      }
+
+      // ⌘0 — reset font size to default
+      if (isMod && !e.shiftKey && !e.altKey && (key === "0" || e.code === "Digit0")) {
+        e.preventDefault();
+        useEditorStylesStore.getState().resetFontSize();
         return;
       }
 

--- a/src/stores/__tests__/editor-styles-store.test.ts
+++ b/src/stores/__tests__/editor-styles-store.test.ts
@@ -379,3 +379,65 @@ describe('resetToDefaults', () => {
     expect(state.presets.heading1).toEqual(DEFAULT_PRESETS.heading1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Font-size keyboard shortcut helpers — adjustFontSize / resetFontSize
+// ---------------------------------------------------------------------------
+
+describe('adjustFontSize', () => {
+  it('increases font size by 1pt', () => {
+    useEditorStylesStore.getState().setFontSize(16);
+    useEditorStylesStore.getState().adjustFontSize(1);
+    expect(useEditorStylesStore.getState().fontSize).toBe(17);
+  });
+
+  it('decreases font size by 1pt', () => {
+    useEditorStylesStore.getState().setFontSize(16);
+    useEditorStylesStore.getState().adjustFontSize(-1);
+    expect(useEditorStylesStore.getState().fontSize).toBe(15);
+  });
+
+  it('clamps at max 24pt', () => {
+    useEditorStylesStore.getState().setFontSize(24);
+    useEditorStylesStore.getState().adjustFontSize(1);
+    expect(useEditorStylesStore.getState().fontSize).toBe(24);
+  });
+
+  it('clamps at min 10pt', () => {
+    useEditorStylesStore.getState().setFontSize(10);
+    useEditorStylesStore.getState().adjustFontSize(-1);
+    expect(useEditorStylesStore.getState().fontSize).toBe(10);
+  });
+
+  it('does not go below 10pt from an already-low value', () => {
+    useEditorStylesStore.getState().setFontSize(11);
+    useEditorStylesStore.getState().adjustFontSize(-5);
+    expect(useEditorStylesStore.getState().fontSize).toBe(10);
+  });
+
+  it('does not go above 24pt from an already-high value', () => {
+    useEditorStylesStore.getState().setFontSize(22);
+    useEditorStylesStore.getState().adjustFontSize(5);
+    expect(useEditorStylesStore.getState().fontSize).toBe(24);
+  });
+
+  it('keeps paragraph preset in sync', () => {
+    useEditorStylesStore.getState().setFontSize(16);
+    useEditorStylesStore.getState().adjustFontSize(2);
+    expect(useEditorStylesStore.getState().presets.paragraph.fontSize).toBe(18);
+  });
+});
+
+describe('resetFontSize', () => {
+  it('resets font size to the application default (16pt)', () => {
+    useEditorStylesStore.getState().setFontSize(22);
+    useEditorStylesStore.getState().resetFontSize();
+    expect(useEditorStylesStore.getState().fontSize).toBe(EDITOR_STYLES_DEFAULTS.fontSize);
+  });
+
+  it('keeps paragraph preset in sync after reset', () => {
+    useEditorStylesStore.getState().setFontSize(22);
+    useEditorStylesStore.getState().resetFontSize();
+    expect(useEditorStylesStore.getState().presets.paragraph.fontSize).toBe(EDITOR_STYLES_DEFAULTS.fontSize);
+  });
+});

--- a/src/stores/editor-styles-store.ts
+++ b/src/stores/editor-styles-store.ts
@@ -61,6 +61,15 @@ export function fontFamilyCSS(key: string): string {
 }
 
 // ---------------------------------------------------------------------------
+// Font-size keyboard shortcut constants
+// ---------------------------------------------------------------------------
+
+/** Minimum editor font size (pt), enforced by the keyboard shortcuts. */
+export const FONT_SIZE_MIN = 10;
+/** Maximum editor font size (pt), enforced by the keyboard shortcuts. */
+export const FONT_SIZE_MAX = 24;
+
+// ---------------------------------------------------------------------------
 // Legacy flat interface (kept for backwards compatibility)
 // ---------------------------------------------------------------------------
 
@@ -115,6 +124,10 @@ interface EditorStylesStore extends EditorStyles {
   setLineHeight: (height: number) => void;
   setParagraphSpacing: (spacing: number) => void;
   resetToDefaults: () => void;
+  /** Increase or decrease the paragraph font size by `delta` pt, clamped to [FONT_SIZE_MIN, FONT_SIZE_MAX]. */
+  adjustFontSize: (delta: number) => void;
+  /** Reset the paragraph font size to the application default. */
+  resetFontSize: () => void;
 }
 
 /** Derive legacy flat fields from presets for backwards compatibility. */
@@ -255,5 +268,15 @@ export const useEditorStylesStore = create<EditorStylesStore>()((set, get) => ({
 
   resetToDefaults: () => {
     set({ presets: { ...DEFAULT_PRESETS }, ...EDITOR_STYLES_DEFAULTS });
+  },
+
+  adjustFontSize: (delta) => {
+    const current = get().fontSize;
+    const next = Math.min(FONT_SIZE_MAX, Math.max(FONT_SIZE_MIN, current + delta));
+    get().setFontSize(next);
+  },
+
+  resetFontSize: () => {
+    get().setFontSize(EDITOR_STYLES_DEFAULTS.fontSize);
   },
 }));


### PR DESCRIPTION
Resolves #162

## Summary

Wires three new keyboard shortcuts — `⌘+`/`⌘=` (increase), `⌘-` (decrease), and `⌘0` (reset) — to adjust the global editor font size on the fly, without opening the typography popover. Adds `adjustFontSize(delta)` and `resetFontSize()` to `editor-styles-store` with bounds clamped to 10–24pt, then invokes them from `useKeyboardShortcuts.ts`. Both Classic Layout and Quiet Composer Layout are covered since `useKeyboardShortcuts` is mounted at the app root. Docs updated.

## Red tests added

- `src/stores/__tests__/editor-styles-store.test.ts::adjustFontSize > increases font size by 1pt` — delta +1 increments fontSize
- `src/stores/__tests__/editor-styles-store.test.ts::adjustFontSize > decreases font size by 1pt` — delta -1 decrements fontSize
- `src/stores/__tests__/editor-styles-store.test.ts::adjustFontSize > clamps at max 24pt` — hard ceiling at 24
- `src/stores/__tests__/editor-styles-store.test.ts::adjustFontSize > clamps at min 10pt` — hard floor at 10
- `src/stores/__tests__/editor-styles-store.test.ts::adjustFontSize > does not go below 10pt from an already-low value` — multi-pt delta clamped
- `src/stores/__tests__/editor-styles-store.test.ts::adjustFontSize > does not go above 24pt from an already-high value` — multi-pt delta clamped
- `src/stores/__tests__/editor-styles-store.test.ts::adjustFontSize > keeps paragraph preset in sync` — preset mirror
- `src/stores/__tests__/editor-styles-store.test.ts::resetFontSize > resets font size to the application default (16pt)` — back to default
- `src/stores/__tests__/editor-styles-store.test.ts::resetFontSize > keeps paragraph preset in sync after reset` — preset mirror
- `src/hooks/__tests__/useKeyboardShortcuts.test.tsx::useKeyboardShortcuts (font-size chords) > ⌘= increases font size by 1pt under uiPreview=legacy` — shortcut wiring (legacy)
- `src/hooks/__tests__/useKeyboardShortcuts.test.tsx::useKeyboardShortcuts (font-size chords) > ⌘= increases font size by 1pt under uiPreview=quiet-composer` — shortcut wiring (quiet)
- `src/hooks/__tests__/useKeyboardShortcuts.test.tsx::useKeyboardShortcuts (font-size chords) > ⌘+ increases font size by 1pt under both layouts` — shift-equal variant
- `src/hooks/__tests__/useKeyboardShortcuts.test.tsx::useKeyboardShortcuts (font-size chords) > ⌘- decreases font size by 1pt under both layouts` — minus chord
- `src/hooks/__tests__/useKeyboardShortcuts.test.tsx::useKeyboardShortcuts (font-size chords) > ⌘0 resets font size under both layouts` — zero chord
- `src/hooks/__tests__/useKeyboardShortcuts.test.tsx::useKeyboardShortcuts (font-size chords) > ⌘= does NOT open the legacy palette` — no palette conflict

## Green implementation

- `src/stores/editor-styles-store.ts` — Added `FONT_SIZE_MIN = 10` / `FONT_SIZE_MAX = 24` constants; added `adjustFontSize(delta)` and `resetFontSize()` methods to the store interface and implementation. Both delegate to the existing `setFontSize` → `updatePreset` pipeline so all consumers update immediately.
- `src/hooks/useKeyboardShortcuts.ts` — Imported `useEditorStylesStore`; added three keyboard handlers (`⌘=`/`⌘+`, `⌘-`, `⌘0`) in the uiPreview-agnostic section following the existing `event.code` fallback pattern for cross-keyboard-layout safety.
- `docs/keyboard-shortcuts.md` — Added three rows to the App Settings table documenting the new chords.

## Refactor

Skipped — implementation already minimal; the `adjustFontSize` method is a clean single-expression clamp.

## Decisions made

- **Step size: 1pt** | Chosen | Matches assumption in issue body; consistent with browser and VS Code behaviour.
- **Bounds: 10–24pt** | Chosen | Matches assumption in issue body; keeps document readable at both extremes.
- **`⌘0` is included** | Chosen | Matches assumption; no browser-zoom conflict in a native Tauri WebView.
- **`src/shared/appCommandManifest.json`** | Does not exist | Confirmed by filesystem search; wired through `useKeyboardShortcuts.ts` only, as assumed.
- **Placement in handler** | After `⌘T` in uiPreview-agnostic section | Both layouts should respond to font-size shortcuts; placing in the agnostic section avoids duplicating the logic for legacy vs quiet paths.
- **`⌘=` and `⌘+` both increase** | Both handled | `⌘+` on US is `Shift+Equal` (key `+`), `⌘=` is without Shift (key `=`). Both fire the same action. The `event.code === "Equal"` fallback covers non-US layouts where the physical Equal key may produce a different character.

## Verification

- [x] Red tests were red before implementation
- [x] All red tests now green
- [x] `pnpm test` passes (full suite — 262 files, 4792 tests)
- [x] `pnpm typecheck` clean
- [x] No unrelated files modified

## Notes for reviewer

- The `⌘-` handler has a `!e.shiftKey` guard to avoid conflicts with hypothetical future `⌘_` chords; `⌘+` (shift-equal) is handled together with `⌘=` (no-shift) in the increase handler.
- Font size change is reflected immediately because `setFontSize` → `updatePreset` updates Zustand state which drives the CSS variable in `ThemeProvider` / `EditorStylesProvider` — no editor reload required.
- The mock for `useEditorStylesStore` in the keyboard shortcut test is minimal: it only exposes `adjustFontSize` and `resetFontSize` as `vi.fn()` stubs, consistent with the pattern used for other store mocks in that test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the `aw-tdd` skill.