### PR TITLE
feat(viewer): open HTML files in rendered sandboxed iframe with source toggle

### DIFF
--- a/src/components/editor/viewers/HtmlViewer.tsx
+++ b/src/components/editor/viewers/HtmlViewer.tsx
@@ -1,0 +1,212 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import { Code } from "lucide-react";
+import { highlightDomMatches, clearDomHighlights } from "@/lib/dom-search";
+import { FindBar } from "@/components/editor/FindBar";
+import { CodeEditor } from "./CodeEditor";
+
+interface HtmlViewerProps {
+  content: string;
+  fileName: string;
+  filePath: string;
+  tabId: string;
+  isDirty: boolean;
+  updateTabContent: (content: string) => void;
+  saveFileWithContent: (content: string) => void;
+}
+
+export function HtmlViewer({
+  content,
+  fileName,
+  filePath,
+  tabId,
+  isDirty,
+  updateTabContent,
+  saveFileWithContent,
+}: HtmlViewerProps) {
+  const [sourceMode, setSourceMode] = useState(false);
+  const [findBarOpen, setFindBarOpen] = useState(false);
+  const [searchMatches, setSearchMatches] = useState<HTMLElement[]>([]);
+  const [searchCurrentIndex, setSearchCurrentIndex] = useState(-1);
+
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const searchMatchesRef = useRef<HTMLElement[]>([]);
+
+  // Write HTML into the sandboxed iframe when content or mode changes
+  useEffect(() => {
+    if (sourceMode) return;
+    const iframe = iframeRef.current;
+    if (!iframe) return;
+    const doc = iframe.contentDocument;
+    if (!doc) return;
+    doc.open();
+    doc.write(content);
+    doc.close();
+  }, [content, sourceMode]);
+
+  // Reset search state when switching modes or content changes
+  useEffect(() => {
+    setFindBarOpen(false);
+    setSearchMatches([]);
+    searchMatchesRef.current = [];
+    setSearchCurrentIndex(-1);
+  }, [sourceMode, content]);
+
+  // Listen for Cmd+F / notesage:find-open — only active in rendered mode
+  useEffect(() => {
+    if (sourceMode) return;
+    const handleFindOpen = () => setFindBarOpen(true);
+    window.addEventListener("notesage:find-open", handleFindOpen);
+    return () => window.removeEventListener("notesage:find-open", handleFindOpen);
+  }, [sourceMode]);
+
+  const getSearchContainer = useCallback((): HTMLElement | null => {
+    return iframeRef.current?.contentDocument?.body ?? null;
+  }, []);
+
+  const handleSearch = useCallback(
+    (query: string) => {
+      const container = getSearchContainer();
+      if (!container) return;
+      clearDomHighlights(container);
+      if (!query) {
+        setSearchMatches([]);
+        searchMatchesRef.current = [];
+        setSearchCurrentIndex(-1);
+        return;
+      }
+      const marks = highlightDomMatches(container, query);
+      setSearchMatches(marks);
+      searchMatchesRef.current = marks;
+      if (marks.length > 0) {
+        setSearchCurrentIndex(0);
+        requestAnimationFrame(() => {
+          marks[0].scrollIntoView({ behavior: "smooth", block: "center" });
+          marks[0].classList.add("dom-find-highlight-active");
+        });
+      } else {
+        setSearchCurrentIndex(-1);
+      }
+    },
+    [getSearchContainer],
+  );
+
+  const scrollToMatch = useCallback((index: number, marks: HTMLElement[]) => {
+    for (const m of marks) m.classList.remove("dom-find-highlight-active");
+    marks[index].classList.add("dom-find-highlight-active");
+    marks[index].scrollIntoView({ behavior: "smooth", block: "center" });
+  }, []);
+
+  const handleNext = useCallback(() => {
+    const marks = searchMatchesRef.current;
+    if (marks.length === 0) return;
+    setSearchCurrentIndex((prev) => {
+      const next = (prev + 1) % marks.length;
+      scrollToMatch(next, marks);
+      return next;
+    });
+  }, [scrollToMatch]);
+
+  const handlePrevious = useCallback(() => {
+    const marks = searchMatchesRef.current;
+    if (marks.length === 0) return;
+    setSearchCurrentIndex((prev) => {
+      const prevIdx = (prev - 1 + marks.length) % marks.length;
+      scrollToMatch(prevIdx, marks);
+      return prevIdx;
+    });
+  }, [scrollToMatch]);
+
+  const handleClose = useCallback(() => {
+    setFindBarOpen(false);
+    const container = getSearchContainer();
+    if (container) clearDomHighlights(container);
+    setSearchMatches([]);
+    searchMatchesRef.current = [];
+    setSearchCurrentIndex(-1);
+  }, [getSearchContainer]);
+
+  if (sourceMode) {
+    return (
+      <div className="h-full flex flex-col">
+        {/* Toolbar */}
+        <div className="h-9 border-b border-border px-3 flex items-center gap-2 shrink-0 bg-background">
+          <span className="text-xs text-muted-foreground truncate max-w-[200px]">
+            {fileName}
+          </span>
+          {isDirty && (
+            <span className="text-xs text-muted-foreground">●</span>
+          )}
+          <div className="ml-auto">
+            <button
+              type="button"
+              aria-label="Switch to rendered view"
+              onClick={() => setSourceMode(false)}
+              className="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+            >
+              <Code className="h-3.5 w-3.5" aria-hidden="true" />
+              Source
+            </button>
+          </div>
+        </div>
+        <div className="flex-1 min-h-0 overflow-hidden">
+          <CodeEditor
+            content={content}
+            fileName={fileName}
+            filePath={filePath}
+            tabId={tabId}
+            isDirty={isDirty}
+            updateTabContent={updateTabContent}
+            saveFileWithContent={saveFileWithContent}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full flex flex-col">
+      {/* Toolbar */}
+      <div className="h-9 border-b border-border px-3 flex items-center gap-2 shrink-0 bg-background">
+        <span className="text-xs text-muted-foreground truncate max-w-[200px]">
+          {fileName}
+        </span>
+        <div className="ml-auto">
+          <button
+            type="button"
+            aria-label="Switch to source view"
+            onClick={() => setSourceMode(true)}
+            className="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+          >
+            <Code className="h-3.5 w-3.5" aria-hidden="true" />
+            Source
+          </button>
+        </div>
+      </div>
+
+      {/* Content area with FindBar overlay */}
+      <div ref={scrollContainerRef} className="flex-1 overflow-hidden relative">
+        <FindBar
+          open={findBarOpen}
+          onClose={handleClose}
+          matchCount={searchMatches.length}
+          currentMatch={searchCurrentIndex}
+          onSearch={handleSearch}
+          onNext={handleNext}
+          onPrevious={handlePrevious}
+          replaceEnabled={false}
+          replaceExpanded={false}
+          onReplaceExpandedChange={() => {}}
+        />
+        {/* Sandboxed iframe — allow-same-origin for local asset loading, no allow-scripts */}
+        <iframe
+          ref={iframeRef}
+          title={fileName}
+          sandbox="allow-same-origin"
+          className="w-full h-full border-0 bg-white"
+          aria-label={`Rendered HTML: ${fileName}`}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/editor/viewers/PlainTextViewer.tsx
+++ b/src/components/editor/viewers/PlainTextViewer.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState, useRef, useCallback } from "react";
 import { highlightDomMatches, clearDomHighlights } from "@/lib/dom-search";
 import { FindBar } from "@/components/editor/FindBar";
-import { isCodeFile } from "@/lib/codemirror-languages";
+import { isCodeFile, isHtmlViewerFile } from "@/lib/codemirror-languages";
 import { CodeEditor } from "./CodeEditor";
+import { HtmlViewer } from "./HtmlViewer";
 
 interface PlainTextViewerProps {
   content: string;
@@ -24,6 +25,21 @@ export function PlainTextViewer({
   updateTabContent,
   saveFileWithContent,
 }: PlainTextViewerProps) {
+  // Route .html/.htm files to the HTML rendered viewer
+  if (isHtmlViewerFile(fileName) && filePath && tabId && updateTabContent && saveFileWithContent) {
+    return (
+      <HtmlViewer
+        content={content}
+        fileName={fileName}
+        filePath={filePath}
+        tabId={tabId}
+        isDirty={isDirty ?? false}
+        updateTabContent={updateTabContent}
+        saveFileWithContent={saveFileWithContent}
+      />
+    );
+  }
+
   // Route code files to the CodeEditor
   if (isCodeFile(fileName) && filePath && tabId && updateTabContent && saveFileWithContent) {
     return (

--- a/src/components/editor/viewers/__tests__/HtmlViewer.test.tsx
+++ b/src/components/editor/viewers/__tests__/HtmlViewer.test.tsx
@@ -1,0 +1,168 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { HtmlViewer } from "../HtmlViewer";
+import { PlainTextViewer } from "../PlainTextViewer";
+
+// Mock CodeEditor to avoid full CodeMirror setup in jsdom
+vi.mock("../CodeEditor", () => ({
+  CodeEditor: ({ fileName, content }: { fileName: string; content: string }) => (
+    <div data-testid="code-editor" data-filename={fileName}>
+      {content}
+    </div>
+  ),
+}));
+
+describe("HtmlViewer", () => {
+  const htmlContent = "<html><body><h1>Hello</h1></body></html>";
+  const filePath = "/path/to/page.html";
+  const fileName = "page.html";
+
+  it("renders an iframe in rendered mode by default", () => {
+    render(
+      <HtmlViewer
+        content={htmlContent}
+        fileName={fileName}
+        filePath={filePath}
+        tabId="tab-1"
+        isDirty={false}
+        updateTabContent={vi.fn()}
+        saveFileWithContent={vi.fn()}
+      />
+    );
+    // Should show an iframe for rendered mode
+    const iframe = document.querySelector("iframe");
+    expect(iframe).not.toBeNull();
+  });
+
+  it("iframe has sandbox='allow-same-origin' without allow-scripts", () => {
+    render(
+      <HtmlViewer
+        content={htmlContent}
+        fileName={fileName}
+        filePath={filePath}
+        tabId="tab-2"
+        isDirty={false}
+        updateTabContent={vi.fn()}
+        saveFileWithContent={vi.fn()}
+      />
+    );
+    const iframe = document.querySelector("iframe");
+    expect(iframe).not.toBeNull();
+    const sandbox = iframe!.getAttribute("sandbox");
+    expect(sandbox).toContain("allow-same-origin");
+    expect(sandbox).not.toContain("allow-scripts");
+  });
+
+  it("shows a toggle button to switch between rendered and source modes", () => {
+    render(
+      <HtmlViewer
+        content={htmlContent}
+        fileName={fileName}
+        filePath={filePath}
+        tabId="tab-3"
+        isDirty={false}
+        updateTabContent={vi.fn()}
+        saveFileWithContent={vi.fn()}
+      />
+    );
+    // There should be a toggle button
+    const toggleButton = screen.getByRole("button", { name: /source|rendered|code|preview/i });
+    expect(toggleButton).toBeTruthy();
+  });
+
+  it("clicking toggle switches to source (CodeEditor) mode", () => {
+    render(
+      <HtmlViewer
+        content={htmlContent}
+        fileName={fileName}
+        filePath={filePath}
+        tabId="tab-4"
+        isDirty={false}
+        updateTabContent={vi.fn()}
+        saveFileWithContent={vi.fn()}
+      />
+    );
+    // Initially in rendered mode — no code editor
+    expect(screen.queryByTestId("code-editor")).toBeNull();
+
+    // Click toggle to source mode
+    const toggleButton = screen.getByRole("button", { name: /source|rendered|code|preview/i });
+    fireEvent.click(toggleButton);
+
+    // Should now show CodeEditor
+    expect(screen.getByTestId("code-editor")).toBeTruthy();
+  });
+
+  it("clicking toggle again returns to rendered mode", () => {
+    render(
+      <HtmlViewer
+        content={htmlContent}
+        fileName={fileName}
+        filePath={filePath}
+        tabId="tab-5"
+        isDirty={false}
+        updateTabContent={vi.fn()}
+        saveFileWithContent={vi.fn()}
+      />
+    );
+    // Click to enter source mode
+    fireEvent.click(screen.getByRole("button", { name: /source|rendered|code|preview/i }));
+    expect(screen.getByTestId("code-editor")).toBeTruthy();
+    // Click again to return to rendered mode (re-query the new button)
+    fireEvent.click(screen.getByRole("button", { name: /source|rendered|code|preview/i }));
+    expect(screen.queryByTestId("code-editor")).toBeNull();
+    expect(document.querySelector("iframe")).not.toBeNull();
+  });
+});
+
+describe("PlainTextViewer routing for HTML files", () => {
+  it("routes .html files to HtmlViewer (shows iframe, not code-editor)", () => {
+    render(
+      <PlainTextViewer
+        content="<html><body>Hello</body></html>"
+        fileName="index.html"
+        filePath="/path/index.html"
+        tabId="tab-html"
+        isDirty={false}
+        updateTabContent={vi.fn()}
+        saveFileWithContent={vi.fn()}
+      />
+    );
+    // Should show iframe (HtmlViewer rendered mode), not CodeEditor
+    expect(document.querySelector("iframe")).not.toBeNull();
+    expect(screen.queryByTestId("code-editor")).toBeNull();
+  });
+
+  it("routes .htm files to HtmlViewer (shows iframe, not code-editor)", () => {
+    render(
+      <PlainTextViewer
+        content="<html><body>Hello</body></html>"
+        fileName="page.htm"
+        filePath="/path/page.htm"
+        tabId="tab-htm"
+        isDirty={false}
+        updateTabContent={vi.fn()}
+        saveFileWithContent={vi.fn()}
+      />
+    );
+    expect(document.querySelector("iframe")).not.toBeNull();
+    expect(screen.queryByTestId("code-editor")).toBeNull();
+  });
+
+  it("still routes .ts files to CodeEditor", () => {
+    render(
+      <PlainTextViewer
+        content="const x = 1;"
+        fileName="main.ts"
+        filePath="/path/main.ts"
+        tabId="tab-ts"
+        isDirty={false}
+        updateTabContent={vi.fn()}
+        saveFileWithContent={vi.fn()}
+      />
+    );
+    expect(screen.getByTestId("code-editor")).toBeTruthy();
+    expect(document.querySelector("iframe")).toBeNull();
+  });
+});

--- a/src/lib/__tests__/codemirror-languages.test.ts
+++ b/src/lib/__tests__/codemirror-languages.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { isCodeFile, getLanguageName, loadLanguage } from "../codemirror-languages";
+import { isCodeFile, isHtmlViewerFile, getLanguageName, loadLanguage } from "../codemirror-languages";
 
 describe("isCodeFile", () => {
   const supportedFiles = [
     "main.js", "app.jsx", "index.mjs", "main.ts", "App.tsx",
     "script.py", "lib.rs", "main.go", "App.java",
     "main.c", "utils.h", "main.cpp", "utils.hpp",
-    "index.html", "styles.css", "config.json",
+    "styles.css", "config.json",
     "config.yaml", "config.yml", "config.toml",
     "README.md", "script.sh", "script.bash", "script.zsh",
     "query.sql", "data.xml", "main.swift", "Main.kt",
@@ -26,6 +26,15 @@ describe("isCodeFile", () => {
     expect(isCodeFile(fileName)).toBe(false);
   });
 
+  it("returns false for .html files (routed to HtmlViewer)", () => {
+    expect(isCodeFile("index.html")).toBe(false);
+    expect(isCodeFile("page.HTML")).toBe(false);
+  });
+
+  it("returns false for .htm files (routed to HtmlViewer)", () => {
+    expect(isCodeFile("page.htm")).toBe(false);
+  });
+
   it("returns false for files with no extension", () => {
     expect(isCodeFile("Makefile")).toBe(false);
     expect(isCodeFile("LICENSE")).toBe(false);
@@ -35,6 +44,25 @@ describe("isCodeFile", () => {
     expect(isCodeFile("main.JS")).toBe(true);
     expect(isCodeFile("main.TS")).toBe(true);
     expect(isCodeFile("main.PY")).toBe(true);
+  });
+});
+
+describe("isHtmlViewerFile", () => {
+  it("returns true for .html files", () => {
+    expect(isHtmlViewerFile("index.html")).toBe(true);
+    expect(isHtmlViewerFile("page.HTML")).toBe(true);
+  });
+
+  it("returns true for .htm files", () => {
+    expect(isHtmlViewerFile("page.htm")).toBe(true);
+    expect(isHtmlViewerFile("old.HTM")).toBe(true);
+  });
+
+  it("returns false for non-HTML files", () => {
+    expect(isHtmlViewerFile("main.ts")).toBe(false);
+    expect(isHtmlViewerFile("styles.css")).toBe(false);
+    expect(isHtmlViewerFile("readme.txt")).toBe(false);
+    expect(isHtmlViewerFile("Makefile")).toBe(false);
   });
 });
 

--- a/src/lib/codemirror-languages.ts
+++ b/src/lib/codemirror-languages.ts
@@ -91,13 +91,24 @@ const LANGUAGE_NAMES: Record<string, string> = {
   php: "PHP",
 };
 
+/** Extensions that open in the HTML rendered viewer instead of CodeEditor. */
+const HTML_VIEWER_EXTENSIONS = new Set(["html", "htm"]);
+
+/**
+ * Check if a filename should open in the HtmlViewer (rendered iframe mode).
+ */
+export function isHtmlViewerFile(fileName: string): boolean {
+  return HTML_VIEWER_EXTENSIONS.has(getExtension(fileName));
+}
+
 /**
  * Check if a filename has a known code file extension.
  * Returns `true` for files that should open in the CodeEditor.
+ * Note: .html/.htm files are excluded — they open in HtmlViewer instead.
  */
 export function isCodeFile(fileName: string): boolean {
   const ext = getExtension(fileName);
-  return ext !== "" && ext in LANGUAGE_MAP;
+  return ext !== "" && ext in LANGUAGE_MAP && !HTML_VIEWER_EXTENSIONS.has(ext);
 }
 
 /**


### PR DESCRIPTION
Resolves #163

## Summary

Adds a new `HtmlViewer` component that opens `.html`/`.htm` files in a sandboxed iframe by default, with a toolbar button to toggle into source mode (CodeMirror 6). The iframe uses `sandbox="allow-same-origin"` so local assets (images, CSS in the same directory) can load via the Tauri asset protocol, while JavaScript execution and external network access are blocked. Cmd+F opens a DOM-based find bar in rendered mode; CodeMirror's native search panel handles Cmd+F in source mode. `isCodeFile()` is updated to exclude `.html`/`.htm` (they route through the new `isHtmlViewerFile()` path in `PlainTextViewer`).

## Red tests added

- `src/lib/__tests__/codemirror-languages.test.ts::isCodeFile > returns false for .html files` — isCodeFile must exclude html/htm
- `src/lib/__tests__/codemirror-languages.test.ts::isCodeFile > returns false for .htm files` — same for .htm
- `src/lib/__tests__/codemirror-languages.test.ts::isHtmlViewerFile > returns true for .html files` — new routing function
- `src/lib/__tests__/codemirror-languages.test.ts::isHtmlViewerFile > returns true for .htm files`
- `src/lib/__tests__/codemirror-languages.test.ts::isHtmlViewerFile > returns false for non-HTML files`
- `src/components/editor/viewers/__tests__/HtmlViewer.test.tsx::HtmlViewer > renders an iframe in rendered mode by default`
- `src/components/editor/viewers/__tests__/HtmlViewer.test.tsx::HtmlViewer > iframe has sandbox='allow-same-origin' without allow-scripts`
- `src/components/editor/viewers/__tests__/HtmlViewer.test.tsx::HtmlViewer > shows a toggle button to switch between rendered and source modes`
- `src/components/editor/viewers/__tests__/HtmlViewer.test.tsx::HtmlViewer > clicking toggle switches to source (CodeEditor) mode`
- `src/components/editor/viewers/__tests__/HtmlViewer.test.tsx::HtmlViewer > clicking toggle again returns to rendered mode`
- `src/components/editor/viewers/__tests__/HtmlViewer.test.tsx::PlainTextViewer routing > routes .html files to HtmlViewer`
- `src/components/editor/viewers/__tests__/HtmlViewer.test.tsx::PlainTextViewer routing > routes .htm files to HtmlViewer`
- `src/components/editor/viewers/__tests__/HtmlViewer.test.tsx::PlainTextViewer routing > still routes .ts files to CodeEditor` (regression guard)

## Green implementation

- `src/lib/codemirror-languages.ts` — added `HTML_VIEWER_EXTENSIONS` set, `isHtmlViewerFile()` export, modified `isCodeFile()` to exclude html/htm while keeping them in `LANGUAGE_MAP` for source-mode syntax loading
- `src/components/editor/viewers/HtmlViewer.tsx` — new component: sandboxed iframe in rendered mode, CodeEditor in source mode, FindBar with DOM-based search, toolbar toggle button
- `src/components/editor/viewers/PlainTextViewer.tsx` — route `.html`/`.htm` to `HtmlViewer` before the existing CodeEditor route

## Refactor

Skipped — implementation already minimal.

## Decisions made

- **Keep html/htm in LANGUAGE_MAP** | kept | `loadLanguage("html")` still works for CodeEditor source-mode syntax highlighting inside HtmlViewer; removing them would break the language pill
- **iframe `sandbox` value** | `allow-same-origin` only | The issue specifies no `allow-scripts`; `allow-same-origin` is the minimum needed for Tauri's `asset://` protocol to resolve relative paths correctly
- **Toggle button placement** | inline in the top toolbar | Consistent with other viewer controls; ViewerToolbarPill was considered but overkill for a single button with no scroll-fade behavior needed here
- **Source mode wraps CodeEditor without a second toolbar** | CodeEditor renders its own toolbar | Avoids doubling up on toolbar chrome; the outer wrapper's toolbar (with toggle) is still visible above CodeEditor's built-in toolbar
- **FindBar in rendered mode only** | DOM search on iframe.contentDocument.body | CodeMirror already handles Cmd+F in source mode; no duplication needed

## Verification

- [x] Red tests were red before implementation
- [x] All red tests now green
- [x] `pnpm test` passes (263 files, 4786 tests)
- [x] `pnpm typecheck` clean
- [x] No unrelated files modified

## Notes for reviewer

- The iframe `srcdoc` attribute was not used; instead `contentDocument.open/write/close` is called in a `useEffect` after mount. This approach works in jsdom (for tests) and in the Tauri WebView. `srcdoc` may be explored in a follow-up if the write approach shows timing issues in edge cases.
- The `allow-same-origin` sandbox attribute means the iframe page shares the parent window's origin, allowing Tauri's `asset://` protocol to resolve relative paths. This also means the iframe can read same-origin cookies/storage — that is acceptable for local HTML documents.
- External URLs inside the HTML (e.g. `<img src="https://...">`) will be blocked by Tauri's network sandboxing at the OS/CSP level, not by the sandbox attribute itself. This matches the acceptance criteria.
- The source mode toggle state is ephemeral (React state, not persisted) as specified in the Assumptions section.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the `aw-tdd` skill.