### PR TITLE
fix(editor): add 24px bottom padding to source-mode CodeMirror content

### DIFF
--- a/src/components/editor/__tests__/codemirror-theme.test.ts
+++ b/src/components/editor/__tests__/codemirror-theme.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Regression tests for the CodeMirror theme used in source mode.
+ *
+ * Issue #166: The source-mode (CodeMirror) editor cuts off the last few lines
+ * because the .cm-content element has no bottom padding, allowing fixed-position
+ * chrome (StatusBar) to overlap the scrollable content.
+ */
+import { describe, it, expect } from "vitest";
+
+// Import the theme to inspect its generated CSS text via CodeMirror's
+// StyleModule.getRules() method, which is accessible by walking the extension
+// data structure.
+import { notesageTheme } from "../codemirror-theme";
+
+/**
+ * Extract the generated CSS string from a CodeMirror Extension produced by
+ * EditorView.theme(). CodeMirror builds a StyleModule internally; the module
+ * exposes a getRules() method that returns the complete CSS text.
+ */
+function extractThemeCSS(extension: unknown): string {
+  const visited = new Set<unknown>();
+
+  function walk(node: unknown): string {
+    if (!node || typeof node !== "object") return "";
+    if (visited.has(node)) return "";
+    visited.add(node);
+
+    // StyleModule has a getRules() method
+    if (typeof (node as { getRules?: unknown }).getRules === "function") {
+      return (node as { getRules: () => string }).getRules();
+    }
+
+    if (Array.isArray(node)) {
+      return node.map(walk).join("\n");
+    }
+
+    return Object.values(node as Record<string, unknown>)
+      .map(walk)
+      .join("\n");
+  }
+
+  return walk(extension);
+}
+
+/**
+ * Parse a CSS length value like "16px", "0px", "0", "24px" → number (px).
+ * Returns 0 for bare "0" (valid CSS, means 0px).
+ */
+function parsePx(value: string): number {
+  if (value === "0") return 0;
+  const m = /^(\d+(?:\.\d+)?)px$/.exec(value.trim());
+  return m ? parseFloat(m[1]) : 0;
+}
+
+/**
+ * Extract the effective bottom padding (in px) from the CSS rules string for
+ * the .cm-content selector. Handles both explicit `padding-bottom` and
+ * 3/4-value `padding` shorthand (with or without trailing `px` on zero).
+ */
+function extractCmContentBottomPadding(css: string): number {
+  // Narrow to the .cm-content rule block if possible
+  const blockMatch = /\.cm-content\s*\{([^}]*)\}/.exec(css);
+  const block = blockMatch ? blockMatch[1] : css;
+
+  // Explicit padding-bottom property (wins over shorthand in CSS cascade, but
+  // here we just want whatever is declared):
+  const pbPropMatch = /padding-bottom\s*:\s*([^;]+);?/.exec(block);
+  if (pbPropMatch) {
+    return parsePx(pbPropMatch[1].trim());
+  }
+
+  // Shorthand: padding: <top> <right> <bottom> <left>
+  // Values may be "0" (no unit) or "Npx".
+  const pxOrZero = "(?:\\d+(?:\\.\\d+)?px|0)";
+  const shorthand4Re = new RegExp(
+    `padding\\s*:\\s*(${pxOrZero})\\s+(${pxOrZero})\\s+(${pxOrZero})\\s+(${pxOrZero})`,
+  );
+  const s4 = shorthand4Re.exec(block);
+  if (s4) return parsePx(s4[3]); // 3rd value = bottom
+
+  // Shorthand: padding: <top> <left-right> <bottom>
+  const shorthand3Re = new RegExp(
+    `padding\\s*:\\s*(${pxOrZero})\\s+(${pxOrZero})\\s+(${pxOrZero})(?:\\s|;|$)`,
+  );
+  const s3 = shorthand3Re.exec(block);
+  if (s3) return parsePx(s3[3]); // 3rd value = bottom
+
+  return 0;
+}
+
+/**
+ * Extract the effective top padding (in px) from the CSS rules string for
+ * the .cm-content selector.
+ */
+function extractCmContentTopPadding(css: string): number {
+  const blockMatch = /\.cm-content\s*\{([^}]*)\}/.exec(css);
+  const block = blockMatch ? blockMatch[1] : css;
+
+  const ptPropMatch = /padding-top\s*:\s*([^;]+);?/.exec(block);
+  if (ptPropMatch) {
+    return parsePx(ptPropMatch[1].trim());
+  }
+
+  const pxOrZero = "(?:\\d+(?:\\.\\d+)?px|0)";
+  const shorthand4Re = new RegExp(
+    `padding\\s*:\\s*(${pxOrZero})\\s+(${pxOrZero})\\s+(${pxOrZero})\\s+(${pxOrZero})`,
+  );
+  const s4 = shorthand4Re.exec(block);
+  if (s4) return parsePx(s4[1]); // 1st value = top
+
+  const shorthand3Re = new RegExp(
+    `padding\\s*:\\s*(${pxOrZero})\\s+(${pxOrZero})\\s+(${pxOrZero})(?:\\s|;|$)`,
+  );
+  const s3 = shorthand3Re.exec(block);
+  if (s3) return parsePx(s3[1]); // 1st value = top
+
+  return 0;
+}
+
+describe("notesageTheme — source mode bottom padding (#166)", () => {
+  it("the .cm-content rule defines a paddingBottom of at least 24px so the StatusBar cannot clip the last line", () => {
+    const css = extractThemeCSS(notesageTheme);
+    const bottom = extractCmContentBottomPadding(css);
+
+    expect(
+      bottom,
+      `Expected .cm-content bottom padding >= 24px so the last line is not hidden behind the StatusBar.\n` +
+        `Found: ${bottom}px.\n\n` +
+        `Current .cm-content rule:\n${(/\.cm-content\s*\{[^}]*\}/.exec(css) ?? ["(no block found)"])[0]}`,
+    ).toBeGreaterThanOrEqual(24);
+  });
+
+  it("the .cm-content rule retains the existing top padding of 16px (no regression)", () => {
+    const css = extractThemeCSS(notesageTheme);
+    const top = extractCmContentTopPadding(css);
+
+    expect(
+      top,
+      `Expected .cm-content top padding == 16px. Found: ${top}px.\n\n` +
+        `Current .cm-content rule:\n${(/\.cm-content\s*\{[^}]*\}/.exec(css) ?? ["(no block found)"])[0]}`,
+    ).toBe(16);
+  });
+});

--- a/src/components/editor/codemirror-theme.ts
+++ b/src/components/editor/codemirror-theme.ts
@@ -21,7 +21,13 @@ export const notesageTheme = EditorView.theme(
     ".cm-content": {
       caretColor: "var(--color-foreground)",
       lineHeight: "1.7",
-      padding: "16px 0 0 0",
+      // Top 16px: breathing room at the top of the document.
+      // Bottom 24px: ensures the last line is reachable when fixed-position
+      // chrome (StatusBar) overlaps the CodeMirror scroller. Without this
+      // the scroll range ends at the final line of text, which the StatusBar
+      // then hides — the user cannot see or position the cursor at the end
+      // of the document (issue #166).
+      padding: "16px 0 24px 0",
     },
     ".cm-cursor, .cm-dropCursor": {
       borderLeftColor: "var(--color-foreground)",


### PR DESCRIPTION
Fixes #166

## Summary

The CodeMirror `.cm-content` element in source mode had `padding: 16px 0 0 0` (top padding only). This meant the scroll range ended precisely at the last line of text, with no extra space below it. When the fixed-position `StatusBar` chrome overlapped the bottom of the editor viewport, the last few lines were hidden behind it and the user could not scroll to reach them — even though the scroll indicator showed content below.

The fix changes `.cm-content` padding to `16px 0 24px 0`, adding 24 px of bottom breathing room. This matches the WYSIWYG (Tiptap) editor's behaviour and ensures the final line clears the StatusBar overlay. WYSIWYG mode is untouched.

## Red tests added

- `src/components/editor/__tests__/codemirror-theme.test.ts::the .cm-content rule defines a paddingBottom of at least 24px so the StatusBar cannot clip the last line` — asserts the generated CSS for `.cm-content` has `padding-bottom >= 24px`
- `src/components/editor/__tests__/codemirror-theme.test.ts::the .cm-content rule retains the existing top padding of 16px (no regression)` — regression guard confirming the top padding is unchanged (was green before implementation, as expected for an existing-behaviour guard)

## Green implementation

- `src/components/editor/codemirror-theme.ts` — changed `.cm-content` padding from `"16px 0 0 0"` to `"16px 0 24px 0"` with a comment explaining the bottom padding rationale

## Refactor

Skipped — the implementation is already minimal (one value in one CSS declaration).

## Decisions made

- **Bottom padding value: 24px** | Chose 24px | The issue body's `## Assumptions` section accepts ">= 24px as the minimum, matching the WYSIWYG editor's breathing room." The aw-slice proposed answer also specifies 24px. No reason to deviate.
- **Fix location: codemirror-theme.ts .cm-content** | Chose `.cm-content` padding | The aw-slice proposed answer identifies this as the primary fix location. An alternative would be adding `paddingBottom` to the `SourceEditor`'s container div, but the theme-level approach is cleaner — it keeps all CodeMirror visual rules in one place and applies consistently to both the markdown source editor and the code file editor that also uses `notesageCodeExtensions`.

## Verification

- [x] Red tests were red before implementation
- [x] All red tests now green
- [x] `pnpm test` passes (full suite — 4776 tests)
- [x] `pnpm typecheck` clean
- [x] No unrelated files modified

## Notes for reviewer

The `notesageTheme` is shared between the markdown source editor (`notesageExtensions`) and the code file editor (`notesageCodeExtensions`). The 24px bottom padding benefits both surfaces — code files in the `CodeEditor` viewer also had the same hidden-last-line issue. This was intentional; both surfaces use the same fixed-chrome overlay and need the same breathing room.

The test inspects CodeMirror's internal `StyleModule.getRules()` output to get the actual generated CSS string without needing a real DOM. This is more reliable than mocking and matches the approach used by the existing `codemirror-languages.test.ts` which also imports the module directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the `aw-tdd` skill.