### PR TITLE
feat(editor): Cmd+/Cmd+- keyboard shortcuts for font size

### DIFF
--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -54,6 +54,9 @@ All shortcuts use Cmd (⌘) on macOS. Glyph notation: ⌘ Command · ⌥ Option 
 | --- | --- | --- |
 | Toggle theme | `⌘T` | Switch between light and dark mode |
 | Open settings | `⌘,` | Open settings dialog |
+| Increase font size | `⌘+` / `⌘=` | Increase editor font size by 1pt (clamped to 24pt). Both `⌘+` (Shift+Equal on US) and `⌘=` (Equal without Shift) work; cross-layout safe via `event.code === "Equal"`. |
+| Decrease font size | `⌘-` | Decrease editor font size by 1pt (clamped to 10pt). Cross-layout safe via `event.code === "Minus"`. |
+| Reset font size | `⌘0` | Reset editor font size to application default (16pt). |
 
 ## AI Features
 

--- a/src/hooks/__tests__/useKeyboardShortcuts.test.tsx
+++ b/src/hooks/__tests__/useKeyboardShortcuts.test.tsx
@@ -91,6 +91,33 @@ vi.mock("@/stores/editor-store", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Editor-styles-store mock.
+// ---------------------------------------------------------------------------
+
+const mockEditorStylesState: {
+  fontSize: number;
+  adjustFontSize: ReturnType<typeof vi.fn>;
+  setFontSize: ReturnType<typeof vi.fn>;
+} = {
+  fontSize: 16,
+  adjustFontSize: vi.fn(),
+  setFontSize: vi.fn(),
+};
+
+vi.mock("@/stores/editor-styles-store", () => {
+  const useEditorStylesStore = Object.assign(
+    vi.fn(() => mockEditorStylesState),
+    { getState: () => mockEditorStylesState },
+  );
+  return {
+    useEditorStylesStore,
+    EDITOR_STYLES_DEFAULTS: { fontSize: 16 },
+    FONT_SIZE_MIN: 10,
+    FONT_SIZE_MAX: 24,
+  };
+});
+
+// ---------------------------------------------------------------------------
 // Import the hook AFTER the mocks above.
 // ---------------------------------------------------------------------------
 
@@ -169,6 +196,11 @@ beforeEach(() => {
   mockEditorState.activeTabId = null;
   mockEditorState.closeTab.mockReset();
   mockEditorState.setPendingCloseTabId.mockReset();
+
+  // Reset editor styles state.
+  mockEditorStylesState.fontSize = 16;
+  mockEditorStylesState.adjustFontSize.mockReset();
+  mockEditorStylesState.setFontSize.mockReset();
 
   capturedBarEvents = [];
   unsubscribeBar = subscribeToCmdBarEvents((e) => {
@@ -554,6 +586,65 @@ describe("useKeyboardShortcuts (scaffold bindings)", () => {
       window.removeEventListener(REVEAL_IN_FINDER_EVENT, listener);
     }
   });
+});
+
+// ===========================================================================
+// Font size chords — Cmd++ / Cmd+= / Cmd+- / Cmd+0
+// ===========================================================================
+
+describe("useKeyboardShortcuts (font size chords)", () => {
+  it("Cmd++ (Shift+Equal) increases font size by 1pt", () => {
+    const callbacks = makeCallbacks();
+    renderHook(() => useKeyboardShortcuts(callbacks));
+
+    dispatchKey("+", { metaKey: true, shiftKey: true, code: "Equal" });
+
+    expect(mockEditorStylesState.adjustFontSize).toHaveBeenCalledWith(1);
+    expect(mockEditorStylesState.adjustFontSize).toHaveBeenCalledTimes(1);
+  });
+
+  it("Cmd+= (Equal without shift) also increases font size by 1pt", () => {
+    const callbacks = makeCallbacks();
+    renderHook(() => useKeyboardShortcuts(callbacks));
+
+    dispatchKey("=", { metaKey: true, code: "Equal" });
+
+    expect(mockEditorStylesState.adjustFontSize).toHaveBeenCalledWith(1);
+    expect(mockEditorStylesState.adjustFontSize).toHaveBeenCalledTimes(1);
+  });
+
+  it("Cmd+- (Minus) decreases font size by 1pt", () => {
+    const callbacks = makeCallbacks();
+    renderHook(() => useKeyboardShortcuts(callbacks));
+
+    dispatchKey("-", { metaKey: true, code: "Minus" });
+
+    expect(mockEditorStylesState.adjustFontSize).toHaveBeenCalledWith(-1);
+    expect(mockEditorStylesState.adjustFontSize).toHaveBeenCalledTimes(1);
+  });
+
+  it("Cmd+0 resets font size to the application default (16pt)", () => {
+    const callbacks = makeCallbacks();
+    renderHook(() => useKeyboardShortcuts(callbacks));
+
+    dispatchKey("0", { metaKey: true });
+
+    expect(mockEditorStylesState.setFontSize).toHaveBeenCalledWith(16);
+    expect(mockEditorStylesState.setFontSize).toHaveBeenCalledTimes(1);
+  });
+
+  it.each<UiPreview>(["legacy", "quiet-composer"])(
+    "font size chords work under uiPreview=%s",
+    (preview) => {
+      mockSettings.uiPreview = preview;
+      const callbacks = makeCallbacks();
+      renderHook(() => useKeyboardShortcuts(callbacks));
+
+      dispatchKey("+", { metaKey: true, shiftKey: true, code: "Equal" });
+
+      expect(mockEditorStylesState.adjustFontSize).toHaveBeenCalledWith(1);
+    },
+  );
 });
 
 // ===========================================================================

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -39,6 +39,7 @@ import { useCommandBarShortcuts } from "@/hooks/useCommandBarShortcuts";
 import { useDoubleTapCmd } from "@/hooks/useDoubleTapCmd";
 import { tauriApi } from "@/lib/tauri";
 import { copyToClipboard } from "@/components/sidebar/quiet/sidebar-clipboard";
+import { useEditorStylesStore, EDITOR_STYLES_DEFAULTS } from "@/stores/editor-styles-store";
 import type { PaletteMode } from "@/lib/command-palette";
 
 /**
@@ -235,6 +236,29 @@ export function useKeyboardShortcuts(callbacks: KeyboardShortcutCallbacks) {
         e.preventDefault();
         const settings = useSettingsStore.getState();
         settings.setTheme(settings.theme === "dark" ? "light" : "dark");
+        return;
+      }
+
+      // ⌘++ / ⌘+= — increase editor font size (cross-layout: key "+" or "="
+      // both use code "Equal", with or without Shift depending on layout).
+      if (isMod && !e.altKey && (e.key === "+" || e.key === "=" || e.code === "Equal")) {
+        e.preventDefault();
+        useEditorStylesStore.getState().adjustFontSize(1);
+        return;
+      }
+
+      // ⌘+- — decrease editor font size.
+      // Guard !shiftKey so ⌘+_ (Shift+Minus) does not fire.
+      if (isMod && !e.shiftKey && !e.altKey && (e.key === "-" || e.code === "Minus")) {
+        e.preventDefault();
+        useEditorStylesStore.getState().adjustFontSize(-1);
+        return;
+      }
+
+      // ⌘+0 — reset editor font size to application default.
+      if (isMod && !e.shiftKey && !e.altKey && e.key === "0") {
+        e.preventDefault();
+        useEditorStylesStore.getState().setFontSize(EDITOR_STYLES_DEFAULTS.fontSize);
         return;
       }
 

--- a/src/stores/__tests__/editor-styles-store.test.ts
+++ b/src/stores/__tests__/editor-styles-store.test.ts
@@ -7,7 +7,7 @@
  */
 import { describe, it, expect, beforeEach } from 'vitest';
 import { setMockInvokeHandler } from '@/test/tauri-mock';
-import { useEditorStylesStore, fontFamilyCSS, EDITOR_STYLES_DEFAULTS, FONT_PRESETS } from '../editor-styles-store';
+import { useEditorStylesStore, fontFamilyCSS, EDITOR_STYLES_DEFAULTS, FONT_PRESETS, FONT_SIZE_MIN, FONT_SIZE_MAX } from '../editor-styles-store';
 import { DEFAULT_PRESETS, TYPOGRAPHY_VERSION } from '@/lib/typography-presets';
 
 beforeEach(() => {
@@ -360,6 +360,40 @@ describe('system font persistence', () => {
     expect(fontFamilyCSS('system')).toContain('SF Pro');
     expect(fontFamilyCSS('georgia')).toContain('Georgia');
     expect(fontFamilyCSS('jetbrains-mono')).toContain('JetBrains Mono');
+  });
+});
+
+describe('adjustFontSize', () => {
+  it('increases font size by 1pt', () => {
+    useEditorStylesStore.getState().setFontSize(16);
+    useEditorStylesStore.getState().adjustFontSize(1);
+    expect(useEditorStylesStore.getState().fontSize).toBe(17);
+  });
+
+  it('decreases font size by 1pt', () => {
+    useEditorStylesStore.getState().setFontSize(16);
+    useEditorStylesStore.getState().adjustFontSize(-1);
+    expect(useEditorStylesStore.getState().fontSize).toBe(15);
+  });
+
+  it('clamps at FONT_SIZE_MAX (24pt) — does not exceed maximum', () => {
+    useEditorStylesStore.getState().setFontSize(FONT_SIZE_MAX);
+    useEditorStylesStore.getState().adjustFontSize(1);
+    expect(useEditorStylesStore.getState().fontSize).toBe(FONT_SIZE_MAX);
+  });
+
+  it('clamps at FONT_SIZE_MIN (10pt) — does not go below minimum', () => {
+    useEditorStylesStore.getState().setFontSize(FONT_SIZE_MIN);
+    useEditorStylesStore.getState().adjustFontSize(-1);
+    expect(useEditorStylesStore.getState().fontSize).toBe(FONT_SIZE_MIN);
+  });
+
+  it('FONT_SIZE_MIN is 10', () => {
+    expect(FONT_SIZE_MIN).toBe(10);
+  });
+
+  it('FONT_SIZE_MAX is 24', () => {
+    expect(FONT_SIZE_MAX).toBe(24);
   });
 });
 

--- a/src/stores/editor-styles-store.ts
+++ b/src/stores/editor-styles-store.ts
@@ -61,6 +61,13 @@ export function fontFamilyCSS(key: string): string {
 }
 
 // ---------------------------------------------------------------------------
+// Font size bounds for keyboard shortcuts (Cmd++ / Cmd+- / Cmd+0)
+// ---------------------------------------------------------------------------
+
+export const FONT_SIZE_MIN = 10;
+export const FONT_SIZE_MAX = 24;
+
+// ---------------------------------------------------------------------------
 // Legacy flat interface (kept for backwards compatibility)
 // ---------------------------------------------------------------------------
 
@@ -105,6 +112,9 @@ interface EditorStylesStore extends EditorStyles {
   setDocumentPresets: (presets: TypographyPresets | null) => void;
   /** Get the effective presets (documentPresets if set, otherwise global presets). */
   getEffectivePresets: () => TypographyPresets;
+
+  /** Adjust font size by delta, clamped to [FONT_SIZE_MIN, FONT_SIZE_MAX]. */
+  adjustFontSize: (delta: number) => void;
 
   // Legacy API (delegates to presets.paragraph)
   loadSettings: (notesagePath: string) => Promise<void>;
@@ -243,6 +253,12 @@ export const useEditorStylesStore = create<EditorStylesStore>()((set, get) => ({
 
   setFontSize: (size) => {
     get().updatePreset("paragraph", { fontSize: size });
+  },
+
+  adjustFontSize: (delta) => {
+    const current = get().fontSize;
+    const next = Math.min(FONT_SIZE_MAX, Math.max(FONT_SIZE_MIN, current + delta));
+    get().updatePreset("paragraph", { fontSize: next });
   },
 
   setLineHeight: (height) => {


### PR DESCRIPTION
Resolves #162

## Summary

Adds `Cmd++` / `Cmd+=` (increase), `Cmd+-` (decrease), and `Cmd+0` (reset to default) keyboard shortcuts that adjust the global editor font size in 1pt steps without requiring the user to open the typography popover. Font size is clamped between 10pt and 24pt. Both `Cmd++` (Shift+Equal on US keyboards) and `Cmd+=` (Equal without Shift) increase font size, supporting non-US keyboard layouts via `event.code === "Equal"`. The shortcuts work in both Classic Layout and Quiet Composer.

## Red tests added

- `src/stores/__tests__/editor-styles-store.test.ts::adjustFontSize > increases font size by 1pt` — delta +1 updates paragraph fontSize
- `src/stores/__tests__/editor-styles-store.test.ts::adjustFontSize > decreases font size by 1pt` — delta -1 updates paragraph fontSize
- `src/stores/__tests__/editor-styles-store.test.ts::adjustFontSize > clamps at FONT_SIZE_MAX (24pt)` — no increase beyond 24
- `src/stores/__tests__/editor-styles-store.test.ts::adjustFontSize > clamps at FONT_SIZE_MIN (10pt)` — no decrease below 10
- `src/stores/__tests__/editor-styles-store.test.ts::adjustFontSize > FONT_SIZE_MIN is 10` — constant value
- `src/stores/__tests__/editor-styles-store.test.ts::adjustFontSize > FONT_SIZE_MAX is 24` — constant value
- `src/hooks/__tests__/useKeyboardShortcuts.test.tsx::font size chords > Cmd++ increases font size` — hook calls adjustFontSize(1)
- `src/hooks/__tests__/useKeyboardShortcuts.test.tsx::font size chords > Cmd+= also increases font size` — hook calls adjustFontSize(1)
- `src/hooks/__tests__/useKeyboardShortcuts.test.tsx::font size chords > Cmd+- decreases font size` — hook calls adjustFontSize(-1)
- `src/hooks/__tests__/useKeyboardShortcuts.test.tsx::font size chords > Cmd+0 resets font size` — hook calls setFontSize(16)
- `src/hooks/__tests__/useKeyboardShortcuts.test.tsx::font size chords > works under uiPreview=legacy` — chord fires in legacy layout
- `src/hooks/__tests__/useKeyboardShortcuts.test.tsx::font size chords > works under uiPreview=quiet-composer` — chord fires in quiet composer

## Green implementation

- `src/stores/editor-styles-store.ts` — export `FONT_SIZE_MIN = 10`, `FONT_SIZE_MAX = 24`; add `adjustFontSize(delta: number)` method with `Math.min/max` clamping
- `src/hooks/useKeyboardShortcuts.ts` — import `useEditorStylesStore` and `EDITOR_STYLES_DEFAULTS`; add three chord handlers in the uiPreview-agnostic section
- `docs/keyboard-shortcuts.md` — document the three new chords under "App Settings"

## Refactor

Skipped — implementation is already minimal; the `adjustFontSize` is a one-liner and the chord handlers follow the existing pattern exactly.

## Decisions made

- **Step size 1pt**: issue assumption followed verbatim.
- **Bounds 10–24pt**: issue assumption followed verbatim; implemented as exported constants so tests and hook both reference the same values.
- **Chord placement in hook**: placed immediately after `Cmd+T` (theme toggle) in the uiPreview-agnostic section, so they work in both Classic and Quiet Composer without any branch logic.
- **`event.code` safety**: `"Equal"` covers both `+` (Shift+Equal) and `=` (Equal without Shift); `"Minus"` covers `-`; `e.key === "0"` needs no code fallback since the digit row is consistent across all layouts.
- **`Cmd+0` conflict**: no conflict in Tauri app (assumption from issue body confirmed — no browser-style zoom).

## Verification

- [x] Red tests were red before implementation
- [x] All red tests now green
- [x] `pnpm test` passes (4786 tests across 262 files)
- [x] `pnpm typecheck` clean
- [x] No unrelated files modified (5 files: store, store test, hook, hook test, docs)

## Notes for reviewer

- The `adjustFontSize` method reads `get().fontSize` (the legacy flat field mirrored from `presets.paragraph.fontSize`) and delegates the write to `updatePreset("paragraph", ...)`, keeping it consistent with `setFontSize`.
- `Cmd+0` uses `e.key === "0"` only (no `e.code` fallback) because digit keys are physically identical across all layouts — `0` always produces `"0"` regardless of modifier state.
- The mock for `useEditorStylesStore` in `useKeyboardShortcuts.test.tsx` exports `EDITOR_STYLES_DEFAULTS: { fontSize: 16 }` so the reset test verifies the literal default value without importing from the real store.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the `aw-tdd` skill.