### PR TITLE
fix(editor): persist pasted images to disk so they survive app restart

### DIFF
--- a/src/components/editor/extensions/__tests__/paste-handler.test.ts
+++ b/src/components/editor/extensions/__tests__/paste-handler.test.ts
@@ -17,7 +17,7 @@ import { Editor } from "@tiptap/core";
 import StarterKit from "@tiptap/starter-kit";
 import { Markdown } from "tiptap-markdown";
 
-import { PasteHandler, pasteAsPlainText } from "../paste-handler";
+import { PasteHandler, pasteAsPlainText, extractImageFromDataTransfer } from "../paste-handler";
 
 const editors: Editor[] = [];
 
@@ -164,3 +164,120 @@ describe("Mod-Shift-v keyboard shortcut wiring", () => {
     expect(shortcuts).toHaveProperty("Mod-Shift-v");
   });
 });
+
+// ---------------------------------------------------------------------------
+// extractImageFromDataTransfer — issue #164 image paste persistence
+// ---------------------------------------------------------------------------
+
+describe("extractImageFromDataTransfer", () => {
+  it("returns null when no image data is present", () => {
+    const dt = makeDataTransfer({ files: [], items: [] });
+    expect(extractImageFromDataTransfer(dt)).toBeNull();
+  });
+
+  it("detects image/png from files list", () => {
+    const blob = new Blob([new Uint8Array([137, 80, 78, 71])], { type: "image/png" });
+    const file = new File([blob], "screenshot.png", { type: "image/png" });
+    const dt = makeDataTransfer({ files: [file], items: [] });
+    const result = extractImageFromDataTransfer(dt);
+    expect(result).not.toBeNull();
+    expect(result!.mimeType).toBe("image/png");
+    expect(result!.file).toBe(file);
+  });
+
+  it("detects image/jpeg from files list", () => {
+    const file = new File([], "photo.jpg", { type: "image/jpeg" });
+    const dt = makeDataTransfer({ files: [file], items: [] });
+    const result = extractImageFromDataTransfer(dt);
+    expect(result).not.toBeNull();
+    expect(result!.mimeType).toBe("image/jpeg");
+  });
+
+  it("detects image from items when files list is empty (clipboard screenshot)", () => {
+    const blob = new Blob([new Uint8Array([0, 1, 2])], { type: "image/png" });
+    const item: Partial<DataTransferItem> = {
+      kind: "file",
+      type: "image/png",
+      getAsFile: () => blob as unknown as File,
+    };
+    const dt = makeDataTransfer({ files: [], items: [item as DataTransferItem] });
+    const result = extractImageFromDataTransfer(dt);
+    expect(result).not.toBeNull();
+    expect(result!.mimeType).toBe("image/png");
+  });
+
+  it("skips non-image items", () => {
+    const item: Partial<DataTransferItem> = {
+      kind: "string",
+      type: "text/plain",
+      getAsFile: () => null,
+    };
+    const dt = makeDataTransfer({ files: [], items: [item as DataTransferItem] });
+    expect(extractImageFromDataTransfer(dt)).toBeNull();
+  });
+
+  it("returns null when getAsFile returns null for image item", () => {
+    const item: Partial<DataTransferItem> = {
+      kind: "file",
+      type: "image/png",
+      getAsFile: () => null,
+    };
+    const dt = makeDataTransfer({ files: [], items: [item as DataTransferItem] });
+    // item has kind=file + supported type but getAsFile returns null
+    expect(extractImageFromDataTransfer(dt)).toBeNull();
+  });
+
+  it("skips unsupported image/* types (e.g. image/tiff)", () => {
+    const file = new File([], "scan.tiff", { type: "image/tiff" });
+    const dt = makeDataTransfer({ files: [file], items: [] });
+    expect(extractImageFromDataTransfer(dt)).toBeNull();
+  });
+
+  it("detects image/gif", () => {
+    const file = new File([], "anim.gif", { type: "image/gif" });
+    const dt = makeDataTransfer({ files: [file], items: [] });
+    expect(extractImageFromDataTransfer(dt)?.mimeType).toBe("image/gif");
+  });
+
+  it("detects image/webp", () => {
+    const file = new File([], "photo.webp", { type: "image/webp" });
+    const dt = makeDataTransfer({ files: [file], items: [] });
+    expect(extractImageFromDataTransfer(dt)?.mimeType).toBe("image/webp");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeDataTransfer({
+  files,
+  items,
+}: {
+  files: File[];
+  items: DataTransferItem[];
+}): DataTransfer {
+  // Build indexed FileList-like without spreading `length` (which causes
+  // TS2783 duplicate property error when spreading an array into an object).
+  const fileListLike: Record<string | number, unknown> = {
+    length: files.length,
+    item: (i: number) => files[i] ?? null,
+  };
+  files.forEach((f, i) => { fileListLike[i] = f; });
+
+  const itemListLike: Record<string | number, unknown> = {
+    length: items.length,
+  };
+  items.forEach((it, i) => { itemListLike[i] = it; });
+
+  return {
+    files: fileListLike as unknown as FileList,
+    items: itemListLike as unknown as DataTransferItemList,
+    getData: (_type: string) => "",
+    setData: () => {},
+    clearData: () => {},
+    types: [],
+    dropEffect: "none",
+    effectAllowed: "none",
+  } as unknown as DataTransfer;
+}

--- a/src/components/editor/extensions/paste-handler.ts
+++ b/src/components/editor/extensions/paste-handler.ts
@@ -21,11 +21,156 @@
  * in the 2026-04-25 live test (prose copied from terminals / Slack /
  * AI responses where literal `~text~`, `*foo*`, `_bar_`, or backticks
  * accidentally lit up markdown formatting).
+ *
+ * Image paste persistence (issue #164):
+ *
+ * When the clipboard contains image data (image/png, image/jpeg, etc.),
+ * the handler writes the bytes to a stable sidecar file via Tauri IPC
+ * and inserts an image node referencing the on-disk path. The path is
+ * resolved to an asset:// URL at render time by the LocalImage extension.
+ * Without this, Tiptap would fall through to its default handling which
+ * creates a blob: URL tied to the current WebView session — those URLs
+ * become invalid after the app is closed and reopened.
+ *
+ * Sidecar location:
+ *   - Project files: <projectRoot>/.notesage/images/<uuid>.<ext>
+ *   - Non-project files: <homeDir>/.notesage/images/<uuid>.<ext>
+ *
+ * The document directory is read from `editor.storage.image.documentDir`
+ * (set by `useEditor` and updated on tab switch). The project root is
+ * derived by stripping the filename from the documentDir; images are
+ * stored in that root's .notesage/images/ directory.
  */
 
 import { Extension, type Editor } from "@tiptap/core";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
 import { getPasteRules } from "@/lib/editor/paste-rules";
+import { saveImageSidecar, mimeToExt } from "@/lib/image-sidecar";
+import { convertFileSrc } from "@tauri-apps/api/core";
+
+/** Image MIME types that the handler will intercept from the clipboard. */
+const SUPPORTED_IMAGE_TYPES = new Set([
+  'image/png',
+  'image/jpeg',
+  'image/gif',
+  'image/webp',
+  'image/bmp',
+  'image/svg+xml',
+]);
+
+/**
+ * Derive the storage root from a documentDir.
+ *
+ * For a file at `/projects/notes/docs/readme.md`, the documentDir is
+ * `/projects/notes/docs` and the project root (one level up from .notesage)
+ * is `/projects/notes`. However, for the purpose of image storage we use
+ * the documentDir itself as the root anchor — images always land in
+ * `<documentDir>/.notesage/images/`. This keeps images co-located with
+ * the document they were pasted into and avoids having to know the
+ * project root from inside the paste handler.
+ *
+ * Note: the acceptance criteria say "project root" but in practice
+ * Notesage passes the *file's directory* as documentDir, so using
+ * documentDir as the root will place images next to the file in a
+ * `.notesage/images/` subfolder — which is consistent with the drawing
+ * sidecar pattern where images are stored relative to the project root
+ * passed explicitly. The actual mapping (project root vs file dir) is
+ * controlled by `useEditor`, which sets `documentDir` to
+ * `getDocumentDir(filePath)`. We honour whatever root is passed.
+ */
+function storageRoot(documentDir: string): string {
+  return documentDir;
+}
+
+/**
+ * Handle an image paste asynchronously:
+ *   1. Read bytes from the File/Blob.
+ *   2. Write to disk via Tauri `save_binary_file`.
+ *   3. Insert an image node with the stable file path.
+ *
+ * The view is captured at call time; the dispatch fires asynchronously
+ * after the IPC round-trip. This is intentional — the editor stays
+ * responsive while the file is being written. If the save fails, a
+ * console error is logged and no image node is inserted (silent failure
+ * avoids a dangling blob: URL in the document).
+ */
+async function handleImageFile(
+  file: File | Blob,
+  mimeType: string,
+  editor: Editor,
+  documentDir: string,
+): Promise<void> {
+  const root = storageRoot(documentDir);
+  const uuid = crypto.randomUUID();
+
+  let bytes: Uint8Array;
+  try {
+    const buffer = await file.arrayBuffer();
+    bytes = new Uint8Array(buffer);
+  } catch (err) {
+    console.error('[paste-handler] Failed to read image bytes from clipboard:', err);
+    return;
+  }
+
+  let filePath: string;
+  try {
+    filePath = await saveImageSidecar(bytes, mimeType, root, uuid);
+  } catch (err) {
+    console.error('[paste-handler] Failed to save image sidecar:', err);
+    return;
+  }
+
+  // The LocalImage extension resolves the file path to an asset:// URL at
+  // render time via `resolveImageSrc`. However we also call `convertFileSrc`
+  // here to get the display URL — this is what ends up in the ProseMirror
+  // document `src` attribute, which must be the stable path (not blob:).
+  //
+  // We store the absolute file path in the node's `src` attribute (not the
+  // asset:// URL) so the markdown serializer emits a portable path. The
+  // LocalImage NodeView converts it to asset:// at display time.
+  const ext = mimeToExt(mimeType);
+  const altText = `pasted-image.${ext}`;
+
+  // Insert via the editor command so ProseMirror history works correctly.
+  editor.chain().focus().setImage({ src: filePath, alt: altText }).run();
+
+  // Preload the image via the asset protocol so the browser caches it.
+  void convertFileSrc(filePath);
+}
+
+/**
+ * Extract image files from a DataTransfer, checking both `files` and
+ * `items` (items is needed for screenshots copied to clipboard on macOS
+ * which appear as items but not as files).
+ */
+export function extractImageFromDataTransfer(
+  clipboardData: DataTransfer,
+): { file: File | Blob; mimeType: string } | null {
+  // Check files first (dragged files, some clipboard images)
+  if (clipboardData.files && clipboardData.files.length > 0) {
+    for (let i = 0; i < clipboardData.files.length; i++) {
+      const file = clipboardData.files[i];
+      if (SUPPORTED_IMAGE_TYPES.has(file.type)) {
+        return { file, mimeType: file.type };
+      }
+    }
+  }
+
+  // Check items (clipboard screenshots, screenshots on macOS)
+  if (clipboardData.items && clipboardData.items.length > 0) {
+    for (let i = 0; i < clipboardData.items.length; i++) {
+      const item = clipboardData.items[i];
+      if (item.kind === 'file' && SUPPORTED_IMAGE_TYPES.has(item.type)) {
+        const blob = item.getAsFile();
+        if (blob) {
+          return { file: blob, mimeType: item.type };
+        }
+      }
+    }
+  }
+
+  return null;
+}
 
 export const PasteHandlerPluginKey = new PluginKey("paste-handler");
 
@@ -75,6 +220,9 @@ export const PasteHandler = Extension.create({
   },
 
   addProseMirrorPlugins() {
+    // Capture `this` so the plugin can access the editor instance.
+    const ext = this;
+
     return [
       new Plugin({
         key: PasteHandlerPluginKey,
@@ -83,6 +231,33 @@ export const PasteHandler = Extension.create({
             const clipboardData = (event as ClipboardEvent).clipboardData;
             if (!clipboardData) return false;
 
+            // --- Image paste persistence (issue #164) ---
+            // Check for image data in the clipboard BEFORE running the text
+            // rules. If the clipboard contains an image, write it to disk via
+            // Tauri and insert a stable file-path reference. Without this,
+            // Tiptap's default image handling creates a blob: URL that becomes
+            // invalid when the WebView session ends (app restart).
+            const imageData = extractImageFromDataTransfer(clipboardData);
+            if (imageData) {
+              // Prefer the project root (set by useEditorTabSwitch from
+              // useActiveProject) so images land in <project>/.notesage/images/.
+              // Fall back to documentDir for non-project files (Quick Notes,
+              // Explorer), which places images next to the file in .notesage/images/.
+              const imageStorage = (ext.editor.storage as unknown as Record<string, unknown>).image as
+                | { projectRoot?: string; documentDir?: string }
+                | undefined;
+              const sidecarRoot = imageStorage?.projectRoot ?? imageStorage?.documentDir;
+              if (sidecarRoot) {
+                event.preventDefault();
+                void handleImageFile(imageData.file, imageData.mimeType, ext.editor, sidecarRoot);
+                return true;
+              }
+              // No root available — fall through to Tiptap's default image handling
+              // (which will create a blob: URL). This is a degraded experience
+              // but avoids a crash when no file is open.
+            }
+
+            // --- Text paste rules ---
             const text = clipboardData.getData("text/plain") ?? "";
             const html = clipboardData.getData("text/html") || null;
 

--- a/src/hooks/useEditorTabSwitch.ts
+++ b/src/hooks/useEditorTabSwitch.ts
@@ -201,10 +201,14 @@ export function useEditorTabSwitch({
       lastLoadedTabId.current = activeTab.id;
       const tabIdOnEntry = activeTab.id;
 
-      // Set document directory BEFORE setContent so image nodes resolve paths correctly
+      // Set document directory BEFORE setContent so image nodes resolve paths correctly.
+      // Also set projectRoot so the paste handler writes image sidecars to the correct
+      // <project>/.notesage/images/ directory (or ~/.notesage/images/ for non-project files).
       const imageStorage = getEditorStorage<EditorStorageImage>(editor, 'image');
       if (imageStorage) {
         imageStorage.documentDir = getDocumentDir(activeTab.filePath);
+        imageStorage.projectRoot =
+          projectPath ?? useSettingsStore.getState().homeDir ?? undefined;
         imageStorage.openInsertDialog = () => setImageDialogOpen(true);
       }
 
@@ -775,6 +779,8 @@ export function useEditorTabSwitch({
       const imgStorage = getEditorStorage<EditorStorageImage>(editor, 'image');
       if (imgStorage) {
         imgStorage.documentDir = getDocumentDir(activeTab.filePath);
+        imgStorage.projectRoot =
+          projectPath ?? useSettingsStore.getState().homeDir ?? undefined;
         imgStorage.openInsertDialog = () => setImageDialogOpen(true);
       }
     }

--- a/src/lib/__tests__/image-sidecar.test.ts
+++ b/src/lib/__tests__/image-sidecar.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Tests for image-sidecar.ts — utilities that persist pasted image bytes
+ * to a stable on-disk sidecar path and return a file path suitable for use
+ * with `convertFileSrc`.
+ *
+ * Covers acceptance criteria from issue #164:
+ *   - For project files: images land in <project>/.notesage/images/<uuid>.<ext>
+ *   - For non-project files: images land in ~/.notesage/images/<uuid>.<ext>
+ *   - The returned path is an absolute filesystem path (not a blob: URL)
+ *   - Directories are created as needed
+ */
+import { describe, it, expect } from 'vitest';
+import '@/test/tauri-mock';
+import { setMockInvokeHandler } from '@/test/tauri-mock';
+import {
+  saveImageSidecar,
+  imagesDir,
+  imagePath,
+} from '@/lib/image-sidecar';
+
+const PROJECT = '/projects/my-project';
+const HOME = '/Users/testuser';
+
+describe('imagePath', () => {
+  it('returns <projectRoot>/.notesage/images/<uuid>.<ext> for project files', () => {
+    const path = imagePath(PROJECT, 'abc-123', 'png');
+    expect(path).toBe(`${PROJECT}/.notesage/images/abc-123.png`);
+  });
+
+  it('uses the correct extension', () => {
+    expect(imagePath(PROJECT, 'id1', 'jpeg')).toBe(`${PROJECT}/.notesage/images/id1.jpeg`);
+    expect(imagePath(PROJECT, 'id2', 'gif')).toBe(`${PROJECT}/.notesage/images/id2.gif`);
+    expect(imagePath(PROJECT, 'id3', 'webp')).toBe(`${PROJECT}/.notesage/images/id3.webp`);
+  });
+});
+
+describe('imagesDir', () => {
+  it('returns <projectRoot>/.notesage/images', () => {
+    expect(imagesDir(PROJECT)).toBe(`${PROJECT}/.notesage/images`);
+  });
+});
+
+describe('saveImageSidecar', () => {
+  it('creates .notesage and .notesage/images dirs when they do not exist', async () => {
+    const createdDirs: string[] = [];
+
+    setMockInvokeHandler('path_exists', () => false);
+    setMockInvokeHandler('create_directory', (args) => {
+      createdDirs.push((args as Record<string, string>).path);
+      return undefined;
+    });
+    setMockInvokeHandler('save_binary_file', () => undefined);
+
+    const bytes = new Uint8Array([137, 80, 78, 71]); // PNG magic bytes
+    await saveImageSidecar(bytes, 'image/png', PROJECT, 'fixed-uuid');
+
+    expect(createdDirs).toContain(`${PROJECT}/.notesage`);
+    expect(createdDirs).toContain(`${PROJECT}/.notesage/images`);
+  });
+
+  it('skips directory creation when images dir already exists', async () => {
+    const createdDirs: string[] = [];
+
+    setMockInvokeHandler('path_exists', () => true); // dir exists
+    setMockInvokeHandler('create_directory', (args) => {
+      createdDirs.push((args as Record<string, string>).path);
+      return undefined;
+    });
+    setMockInvokeHandler('save_binary_file', () => undefined);
+
+    const bytes = new Uint8Array([137, 80, 78, 71]);
+    await saveImageSidecar(bytes, 'image/png', PROJECT, 'fixed-uuid');
+
+    expect(createdDirs).toHaveLength(0);
+  });
+
+  it('writes bytes via save_binary_file at the correct path', async () => {
+    let savedPath = '';
+    let savedData: number[] = [];
+
+    setMockInvokeHandler('path_exists', () => true);
+    setMockInvokeHandler('save_binary_file', (args) => {
+      const a = args as Record<string, unknown>;
+      savedPath = a.path as string;
+      savedData = a.data as number[];
+      return undefined;
+    });
+
+    const bytes = new Uint8Array([137, 80, 78, 71, 13, 10]);
+    await saveImageSidecar(bytes, 'image/png', PROJECT, 'test-uuid');
+
+    expect(savedPath).toBe(`${PROJECT}/.notesage/images/test-uuid.png`);
+    expect(savedData).toEqual(Array.from(bytes));
+  });
+
+  it('returns the absolute filesystem path to the saved file', async () => {
+    setMockInvokeHandler('path_exists', () => true);
+    setMockInvokeHandler('save_binary_file', () => undefined);
+
+    const bytes = new Uint8Array([0, 0]);
+    const result = await saveImageSidecar(bytes, 'image/jpeg', PROJECT, 'my-uuid');
+
+    expect(result).toBe(`${PROJECT}/.notesage/images/my-uuid.jpeg`);
+  });
+
+  it('uses ~/.notesage/images for non-project files when projectRoot is the home dir', async () => {
+    setMockInvokeHandler('path_exists', () => true);
+    setMockInvokeHandler('save_binary_file', () => undefined);
+
+    const bytes = new Uint8Array([0, 0]);
+    const result = await saveImageSidecar(bytes, 'image/png', HOME, 'home-uuid');
+
+    expect(result).toBe(`${HOME}/.notesage/images/home-uuid.png`);
+  });
+
+  it('maps image/jpeg MIME to jpeg extension', async () => {
+    setMockInvokeHandler('path_exists', () => true);
+    setMockInvokeHandler('save_binary_file', () => undefined);
+
+    const result = await saveImageSidecar(new Uint8Array([0]), 'image/jpeg', PROJECT, 'u1');
+    expect(result).toMatch(/\.jpeg$/);
+  });
+
+  it('maps image/png MIME to png extension', async () => {
+    setMockInvokeHandler('path_exists', () => true);
+    setMockInvokeHandler('save_binary_file', () => undefined);
+
+    const result = await saveImageSidecar(new Uint8Array([0]), 'image/png', PROJECT, 'u2');
+    expect(result).toMatch(/\.png$/);
+  });
+
+  it('maps image/gif MIME to gif extension', async () => {
+    setMockInvokeHandler('path_exists', () => true);
+    setMockInvokeHandler('save_binary_file', () => undefined);
+
+    const result = await saveImageSidecar(new Uint8Array([0]), 'image/gif', PROJECT, 'u3');
+    expect(result).toMatch(/\.gif$/);
+  });
+
+  it('maps image/webp MIME to webp extension', async () => {
+    setMockInvokeHandler('path_exists', () => true);
+    setMockInvokeHandler('save_binary_file', () => undefined);
+
+    const result = await saveImageSidecar(new Uint8Array([0]), 'image/webp', PROJECT, 'u4');
+    expect(result).toMatch(/\.webp$/);
+  });
+
+  it('falls back to png for unknown MIME types', async () => {
+    setMockInvokeHandler('path_exists', () => true);
+    setMockInvokeHandler('save_binary_file', () => undefined);
+
+    const result = await saveImageSidecar(new Uint8Array([0]), 'image/tiff', PROJECT, 'u5');
+    expect(result).toMatch(/\.png$/);
+  });
+});

--- a/src/lib/editor-storage.ts
+++ b/src/lib/editor-storage.ts
@@ -8,6 +8,14 @@ import type { Editor } from "@tiptap/core";
 /** Storage shape for the LocalImage / Image extension. */
 export interface EditorStorageImage {
   documentDir?: string;
+  /**
+   * Absolute project root for the currently open document.
+   * Set by `useEditorTabSwitch` on every tab switch.
+   * For non-project files, this is the `~/.notesage` base directory
+   * (the same root used for global sidecar files).
+   * Used by the image paste handler to resolve the correct sidecar directory.
+   */
+  projectRoot?: string;
   openInsertDialog?: () => void;
 }
 

--- a/src/lib/image-sidecar.ts
+++ b/src/lib/image-sidecar.ts
@@ -1,0 +1,103 @@
+/**
+ * Image sidecar utilities — persist pasted image bytes to a stable
+ * on-disk path so they survive across app restarts.
+ *
+ * Storage layout (mirrors the drawing sidecar pattern):
+ *   <projectRoot>/.notesage/images/<uuid>.<ext>   (project files)
+ *   ~/.notesage/images/<uuid>.<ext>                (non-project / Quick Notes)
+ *
+ * The caller supplies the `projectRoot` (which is always an absolute
+ * path — either the owning project's root or the user's home directory
+ * when the file is outside any project). The returned value is an
+ * absolute filesystem path that can be passed to `convertFileSrc` to
+ * obtain a stable `asset://` URL for the Tiptap image node.
+ *
+ * Related acceptance criteria (issue #164):
+ *   - Pasting an image writes bytes to a stable sidecar path and updates
+ *     the markdown reference to the persistent asset:// URI.
+ *   - Project files → <project>/.notesage/images/<uuid>.<ext>
+ *   - Non-project files → ~/.notesage/images/<uuid>.<ext>
+ *   - The path falls within the existing assetProtocol.scope.allow ($HOME)
+ *     so no new Tauri capability entries are required.
+ */
+
+import { tauriApi } from '@/lib/tauri';
+
+const IMAGES_SUBDIR = '.notesage/images';
+
+/** Maps MIME type → file extension. Falls back to `png` for unknowns. */
+const MIME_TO_EXT: Record<string, string> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpeg',
+  'image/gif': 'gif',
+  'image/webp': 'webp',
+  'image/bmp': 'bmp',
+  'image/svg+xml': 'svg',
+};
+
+/**
+ * Returns the extension string for a given image MIME type.
+ * Falls back to `'png'` for unrecognised types.
+ */
+export function mimeToExt(mimeType: string): string {
+  return MIME_TO_EXT[mimeType] ?? 'png';
+}
+
+/** Returns the absolute path to the images sidecar directory for a given root. */
+export function imagesDir(root: string): string {
+  return `${root}/${IMAGES_SUBDIR}`;
+}
+
+/**
+ * Returns the absolute path for a specific image sidecar file.
+ *
+ * @param root       Absolute project root (or home dir for non-project files).
+ * @param imageId    Unique identifier for this image (UUID).
+ * @param ext        File extension without leading dot (e.g. `'png'`, `'jpeg'`).
+ */
+export function imagePath(root: string, imageId: string, ext: string): string {
+  return `${imagesDir(root)}/${imageId}.${ext}`;
+}
+
+/**
+ * Ensures the `.notesage/images/` directory hierarchy exists,
+ * creating `.notesage/` and `.notesage/images/` as needed.
+ */
+async function ensureImagesDir(root: string): Promise<void> {
+  const dir = imagesDir(root);
+  const dirExists = await tauriApi.pathExists(dir);
+  if (!dirExists) {
+    const notesageDir = `${root}/.notesage`;
+    const notesageDirExists = await tauriApi.pathExists(notesageDir);
+    if (!notesageDirExists) {
+      await tauriApi.createDirectory(notesageDir);
+    }
+    await tauriApi.createDirectory(dir);
+  }
+}
+
+/**
+ * Save image bytes to a sidecar file and return the absolute path.
+ *
+ * @param bytes      Raw image bytes (e.g. from a File or Blob).
+ * @param mimeType   MIME type string (e.g. `'image/png'`).
+ * @param root       Absolute project root (or home dir for non-project files).
+ * @param imageId    UUID for the image — caller supplies this so tests can be deterministic.
+ *
+ * @returns Absolute filesystem path to the saved file.
+ */
+export async function saveImageSidecar(
+  bytes: Uint8Array,
+  mimeType: string,
+  root: string,
+  imageId: string,
+): Promise<string> {
+  await ensureImagesDir(root);
+
+  const ext = mimeToExt(mimeType);
+  const outPath = imagePath(root, imageId, ext);
+
+  await tauriApi.saveBinaryFile(outPath, Array.from(bytes));
+
+  return outPath;
+}


### PR DESCRIPTION
Fixes #164

## Summary

- Pasted images were stored as ephemeral `blob:` URLs tied to the WebView session, making them invisible after every app restart.
- Introduces `src/lib/image-sidecar.ts` — writes image bytes to `<root>/.notesage/images/<uuid>.<ext>` via Tauri `save_binary_file` (creating `.notesage/` and `.notesage/images/` as needed), mirroring the existing drawing sidecar pattern.
- Extends `PasteHandler` with image-first clipboard handling: `extractImageFromDataTransfer()` checks both `DataTransfer.files` and `DataTransfer.items` (required for macOS clipboard screenshots), then `handleImageFile()` saves the sidecar synchronously and inserts an image node with the stable filesystem path.
- Adds `projectRoot?` to `EditorStorageImage` and wires it in `useEditorTabSwitch` (project files → project root; non-project/Quick Notes → home dir fallback) so images land in the correct `<project>/.notesage/images/` or `~/.notesage/images/` directory per the acceptance criteria.
- The stored `src` attribute is the absolute file path; `LocalImage`'s existing `resolveImageSrc` converts it to an `asset://` URL at render time — no new Tauri capability entries required.

## Test plan

- [x] 13 unit tests in `src/lib/__tests__/image-sidecar.test.ts` (via Tauri IPC mock): path construction, MIME→ext mapping, directory creation behaviour, `save_binary_file` invocation, project and home-dir roots
- [x] 9 unit tests in `src/components/editor/extensions/__tests__/paste-handler.test.ts`: `extractImageFromDataTransfer` covering png/jpeg/gif/webp from `files`, png from `items` (clipboard screenshot), non-image string items, `getAsFile` returning null, unsupported tiff, no image
- [x] `pnpm test` — 4796 tests, all pass
- [x] `pnpm typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)