### PR TITLE
chore(completions): remove 'Completions disabled for this file' toast

### DIFF
--- a/src/hooks/__tests__/useCopilotCompletion.test.ts
+++ b/src/hooks/__tests__/useCopilotCompletion.test.ts
@@ -3,6 +3,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import '@/test/tauri-mock';
 import { setMockInvokeHandler, emitMockEvent } from '@/test/tauri-mock';
+import { toast } from 'sonner';
 import { renderHook, act } from '@testing-library/react';
 import { invoke } from '@tauri-apps/api/core';
 import { useCopilotCompletion } from '@/hooks/useCopilotCompletion';
@@ -1587,6 +1588,98 @@ describe('useCopilotCompletion', () => {
       });
 
       expect(mockRequestCopilotCompletion).toHaveBeenCalled();
+    });
+  });
+
+  // =========================================================================
+  // Issue #178 — Remove the 'Completions disabled for this file' toast
+  //
+  // The per-tab/per-session toast fires on every app restart, every tab
+  // switch to an out-of-scope file, and every scope change. It is noise:
+  // the user already chose to disable completions (toggle) or the file is
+  // simply outside the selected project. The Status Bar's muted indicator
+  // is the passive hint that remains.
+  // =========================================================================
+
+  describe('issue #178 — no toast on out-of-scope tab activation', () => {
+    beforeEach(() => {
+      useSettingsStore.setState({
+        homeDir: '/Users/tester',
+        notesRootPath: '/Users/tester/Notesage',
+        completionsOnOutOfScope: false,
+      });
+      vi.mocked(toast.info).mockClear();
+    });
+
+    it('does NOT fire toast.info when activating an out-of-scope tab', async () => {
+      const conn = makeAgentManagedConnection();
+      setupWithConnection(conn);
+      useWorkspaceStore.setState({
+        projects: [{ path: '/workspace/project-A', fileTree: [] }],
+      });
+      setupConversation(['/workspace/project-A']);
+      // Tab is outside the selected project
+      setupWithTab(makeTab({ filePath: '/workspace/project-B/secret.md' }));
+
+      renderHook(() => useCopilotCompletion(makeMockEditor('content')));
+
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+
+      expect(toast.info).not.toHaveBeenCalled();
+    });
+
+    it('does NOT fire toast.info on repeated tab switches to out-of-scope files', async () => {
+      const conn = makeAgentManagedConnection();
+      setupWithConnection(conn);
+      useWorkspaceStore.setState({
+        projects: [
+          { path: '/workspace/project-A', fileTree: [] },
+          { path: '/workspace/project-B', fileTree: [] },
+        ],
+      });
+      setupConversation(['/workspace/project-A']);
+
+      const tabA = makeTab({ id: 'tab-A', filePath: '/workspace/project-A/file.md', fileName: 'file.md' });
+      const tabB = makeTab({ id: 'tab-B', filePath: '/workspace/project-B/secret.md', fileName: 'secret.md' });
+      useEditorStore.setState({ openDocuments: [tabA, tabB], activeTabId: 'tab-A' });
+
+      const editor = makeMockEditor('hello');
+      const { rerender } = renderHook(() => useCopilotCompletion(editor));
+
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+
+      vi.mocked(toast.info).mockClear();
+
+      // Switch to the out-of-scope tab
+      act(() => {
+        useEditorStore.setState({ activeTabId: 'tab-B' });
+      });
+      rerender();
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+
+      // Switch back to in-scope then out-of-scope again
+      act(() => {
+        useEditorStore.setState({ activeTabId: 'tab-A' });
+      });
+      rerender();
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+      act(() => {
+        useEditorStore.setState({ activeTabId: 'tab-B' });
+      });
+      rerender();
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+
+      expect(toast.info).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/hooks/useCopilotCompletion.ts
+++ b/src/hooks/useCopilotCompletion.ts
@@ -161,33 +161,6 @@ export function useCopilotCompletion(editor: Editor | null) {
   const uriAllowed = (uri: string): boolean =>
     completionsOnOutOfScope || isUriInScope(uri, scope);
 
-  // Once-per-session toast suppression. Live-test 2026-04-26 — the previous
-  // per-tab Set was too chatty: every restored tab on cold start, every
-  // tab-switch back to an out-of-scope file, and every reload re-fired the
-  // toast. The user's complaint is the WITHIN-SESSION repeat, so we collapse
-  // the dedup to a single boolean and re-arm only when the relevant inputs
-  // change (scope or the `completionsOnOutOfScope` setting). A stable sonner
-  // id is preserved as belt-and-suspenders so any race that bypasses the
-  // dedup still collapses visually.
-  const hasShownOutOfScopeToast = useRef(false);
-
-  const notifyOutOfScope = useCallback(() => {
-    if (hasShownOutOfScopeToast.current) return;
-    hasShownOutOfScopeToast.current = true;
-    toast.info('Completions disabled for this file — outside selected project scope', {
-      id: 'copilot-scope-out-of-scope',
-    });
-  }, []);
-
-  // Re-arm the once-per-session toast when the inputs that determine scope
-  // change. A user who flips `completionsOnOutOfScope` or changes the
-  // selected project paths in the chat footer should see the toast again
-  // the next time they activate an out-of-scope tab — the new scope is a
-  // fresh decision worth surfacing once.
-  useEffect(() => {
-    hasShownOutOfScopeToast.current = false;
-  }, [completionsOnOutOfScope, selectedProjectPaths, resolvedNotesRoot]);
-
   const isSourceMode = activeTab?.viewMode === 'source';
 
   useEffect(() => {
@@ -217,8 +190,7 @@ export function useCopilotCompletion(editor: Editor | null) {
     // Task #17 — the `completionsOnOutOfScope` setting bypasses this gate
     // (legacy behaviour). Gate short-circuits via `uriAllowed`.
     if (!uriAllowed(uri)) {
-      notifyOutOfScope();
-      // Also clear any stale ghost text — a leftover decoration from a
+      // Clear any stale ghost text — a leftover decoration from a
       // previous in-scope tab must not linger on the blocked one.
       if (editor && hasActiveGhostText(editor)) {
         clearGhostText(editor);


### PR DESCRIPTION
Resolves #178

## Summary

Removes the `toast.info('Completions disabled for this file — outside selected project scope', ...)` call from `useCopilotCompletion.ts`. The toast fired on every app restart, every tab-switch to an out-of-scope file, and every scope change — pure noise for a silent, automatic decision. The Status Bar's muted "Completions: off" indicator remains as a passive hint. The crash-loop and restart toasts in the same hook are untouched (actionable errors).

No equivalent toast existed in `useLocalCompletion.ts`.

## Red tests added

- `src/hooks/__tests__/useCopilotCompletion.test.ts::issue #178 — no toast on out-of-scope tab activation::does NOT fire toast.info when activating an out-of-scope tab` — verifies `toast.info` is never called when an out-of-scope tab becomes active
- `src/hooks/__tests__/useCopilotCompletion.test.ts::issue #178 — no toast on out-of-scope tab activation::does NOT fire toast.info on repeated tab switches to out-of-scope files` — verifies no toast after multiple tab-switches between in-scope and out-of-scope files

## Green implementation

- `src/hooks/useCopilotCompletion.ts` — removed `hasShownOutOfScopeToast` ref, `notifyOutOfScope` callback, re-arm `useEffect`, and the `notifyOutOfScope()` call in the scope gate. The `toast` import is kept because the crash-loop and restart toasts below still use it.

## Refactor

Skipped — implementation is already minimal after the deletion.

## Decisions made

- Keep the `toast` import: the crash-loop (`toast.error(...)`) and restart (`toast.warning(...)`) toasts lower in the same file are out of scope for this issue and remain.
- No change to `useLocalCompletion.ts`: a grep confirmed it never had the out-of-scope toast.
- No change to `StatusBar.tsx`: the muted "Completions: off" hint stays per the issue spec.

## Verification

- [x] Red tests were red before implementation
- [x] All red tests now green (41/41 in the test file)
- [x] `pnpm test` passes (4776 tests, full suite)
- [x] `pnpm typecheck` clean
- [x] No unrelated files modified

## Notes for reviewer

The only meaningful diff in `useCopilotCompletion.ts` is the removal of ~29 lines: the `useRef`, `useCallback`, `useEffect`, and one function call. Nothing else changed. The 2 new tests import `toast` from `sonner` (which `tauri-mock.ts` already mocks as a `vi.fn()`) and assert `toast.info` is not called when an out-of-scope tab activates.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the `aw-tdd` skill.