### PR TITLE
fix(status-tray): derive completion picker from connections store capability

### DIFF
--- a/src/components/editor/StatusTray.tsx
+++ b/src/components/editor/StatusTray.tsx
@@ -60,20 +60,6 @@ function InlineCompletionIcon({ className }: { className?: string }) {
 // Completion provider picker
 // ---------------------------------------------------------------------------
 
-type CompletionOption = "off" | "copilot" | "local_ai" | "ollama";
-
-interface CompletionOptionMeta {
-  value: CompletionOption;
-  label: string;
-}
-
-const COMPLETION_OPTIONS: CompletionOptionMeta[] = [
-  { value: "off", label: "Off" },
-  { value: "copilot", label: "Copilot" },
-  { value: "local_ai", label: "Local AI" },
-  { value: "ollama", label: "Ollama" },
-];
-
 // ---------------------------------------------------------------------------
 // Props
 // ---------------------------------------------------------------------------
@@ -244,53 +230,27 @@ function CompletionsGroup() {
   const setRouting = useRoutingStore((s) => s.setRouting);
   const connections = useConnectionsStore((s) => s.connections);
 
-  // Look up completion-capable connections by provider/flavor.
-  const copilotConn = useMemo(
-    () =>
-      connections.find(
-        (c) => c.provider === "github" && c.authMethod === "agent_managed",
-      ),
-    [connections],
-  );
-  const localAiConn = useMemo(
-    () => connections.find((c) => c.authMethod === "local_bundled"),
-    [connections],
-  );
-  const ollamaConn = useMemo(
-    () => connections.find((c) => c.provider === "ollama"),
+  // Only show connections that advertise the inline_completion capability —
+  // mirrors the filter in UseCaseRoutingSettings so the two surfaces stay consistent.
+  const compatibleConnections = useMemo(
+    () => connections.filter((c) => c.capabilities.includes("inline_completion")),
     [connections],
   );
 
   const currentConnectionId = routing.inline_completion?.connectionId ?? null;
 
-  const activeOption: CompletionOption = (() => {
-    if (inlineCompletionsDisabled) return "off";
-    if (!currentConnectionId) return "off";
-    if (copilotConn && currentConnectionId === copilotConn.id) return "copilot";
-    if (localAiConn && currentConnectionId === localAiConn.id) return "local_ai";
-    if (ollamaConn && currentConnectionId === ollamaConn.id) return "ollama";
-    return "off";
-  })();
+  const isOff =
+    inlineCompletionsDisabled ||
+    !currentConnectionId ||
+    !compatibleConnections.some((c) => c.id === currentConnectionId);
 
-  const isDisabled = (opt: CompletionOption) => {
-    if (opt === "off") return false;
-    if (opt === "copilot") return !copilotConn;
-    if (opt === "local_ai") return !localAiConn;
-    if (opt === "ollama") return !ollamaConn;
-    return true;
+  const handleSelectOff = () => {
+    setInlineCompletionsDisabled(true);
   };
 
-  const handleSelect = (opt: CompletionOption) => {
-    if (isDisabled(opt)) return;
-    if (opt === "off") {
-      setInlineCompletionsDisabled(true);
-      return;
-    }
-    const conn =
-      opt === "copilot" ? copilotConn : opt === "local_ai" ? localAiConn : ollamaConn;
-    if (!conn) return;
+  const handleSelectConnection = (connId: string) => {
     setInlineCompletionsDisabled(false);
-    setRouting("inline_completion", conn.id);
+    setRouting("inline_completion", connId);
   };
 
   return (
@@ -304,38 +264,77 @@ function CompletionsGroup() {
         aria-label="Completion provider"
         className="flex items-center gap-1 rounded-md border border-border p-0.5 bg-muted/30"
       >
-        {COMPLETION_OPTIONS.map((opt) => {
-          const active = opt.value === activeOption;
-          const disabled = isDisabled(opt.value);
+        {/* Always-present Off option */}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              role="radio"
+              aria-checked={isOff}
+              aria-label="Off"
+              onClick={handleSelectOff}
+              className={cn(
+                "flex-1 text-[10px] h-6 px-2 rounded-sm transition-colors",
+                "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+                isOff
+                  ? "bg-[var(--color-accent-primary)] text-[oklch(100%_0_0)] shadow-sm"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              Off
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="top" className="text-xs max-w-[220px]">
+            Off
+          </TooltipContent>
+        </Tooltip>
+
+        {/* One button per configured inline_completion-capable connection */}
+        {compatibleConnections.map((conn) => {
+          const active = !isOff && conn.id === currentConnectionId;
           return (
-            <Tooltip key={opt.value}>
+            <Tooltip key={conn.id}>
               <TooltipTrigger asChild>
                 <button
                   type="button"
                   role="radio"
                   aria-checked={active}
-                  aria-label={opt.label}
-                  disabled={disabled}
-                  onClick={() => handleSelect(opt.value)}
+                  aria-label={conn.label}
+                  onClick={() => handleSelectConnection(conn.id)}
                   className={cn(
                     "flex-1 text-[10px] h-6 px-2 rounded-sm transition-colors",
                     "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
                     active
                       ? "bg-[var(--color-accent-primary)] text-[oklch(100%_0_0)] shadow-sm"
                       : "text-muted-foreground hover:text-foreground",
-                    disabled && "opacity-40 cursor-not-allowed hover:text-muted-foreground",
                   )}
                 >
-                  {opt.label}
+                  {conn.label}
                 </button>
               </TooltipTrigger>
               <TooltipContent side="top" className="text-xs max-w-[220px]">
-                {disabled ? `${opt.label} — not configured` : opt.label}
+                {conn.label}
               </TooltipContent>
             </Tooltip>
           );
         })}
       </div>
+
+      {/* Empty state: no compatible connections configured */}
+      {compatibleConnections.length === 0 && (
+        <p className="text-[10px] text-muted-foreground/60 leading-tight px-2">
+          No inline completion provider configured.{" "}
+          <button
+            type="button"
+            onClick={() =>
+              window.dispatchEvent(new CustomEvent("notesage:open-settings"))
+            }
+            className="underline hover:text-foreground transition-colors"
+          >
+            Configure in Settings…
+          </button>
+        </p>
+      )}
     </section>
   );
 }

--- a/src/components/editor/__tests__/StatusTray.test.tsx
+++ b/src/components/editor/__tests__/StatusTray.test.tsx
@@ -120,28 +120,28 @@ describe('StatusTray — task #53', () => {
     expect(text).not.toContain('Session');
   });
 
-  it('renders the completion picker with all four options', () => {
+  it('renders the completion picker with only "Off" when no inline_completion connections exist', () => {
+    // With no connections seeded, the picker shows only the static "Off" option
+    // and the empty-state hint. Previously this test expected 4 hardcoded options
+    // (Off, Copilot, Local AI, Ollama); after #179 the list is dynamic.
     renderWithProviders(<TrayHost open={true} onOpenChange={() => {}} />);
     const group = document.querySelector('[role="radiogroup"]');
     expect(group).toBeTruthy();
     const options = group?.querySelectorAll('[role="radio"]');
-    expect(options?.length).toBe(4);
+    expect(options?.length).toBe(1);
     const labels = Array.from(options ?? []).map((b) => b.getAttribute('aria-label'));
-    expect(labels).toEqual(['Off', 'Copilot', 'Local AI', 'Ollama']);
+    expect(labels).toEqual(['Off']);
   });
 
-  it('disables options whose connections are not configured', () => {
+  it('shows only "Off" (active) and no other radio buttons when no connections are configured', () => {
+    // After #179: absent connections are simply absent from the picker — there are
+    // no disabled placeholder buttons for Copilot / Local AI / Ollama.
     renderWithProviders(<TrayHost open={true} onOpenChange={() => {}} />);
     const radios = document.querySelectorAll('[role="radio"]');
-    const byLabel: Record<string, HTMLElement> = {};
-    radios.forEach((r) => {
-      byLabel[r.getAttribute('aria-label') ?? ''] = r as HTMLElement;
-    });
-    // With no connections, Off is enabled, others are disabled.
-    expect((byLabel['Off'] as HTMLButtonElement).disabled).toBe(false);
-    expect((byLabel['Copilot'] as HTMLButtonElement).disabled).toBe(true);
-    expect((byLabel['Local AI'] as HTMLButtonElement).disabled).toBe(true);
-    expect((byLabel['Ollama'] as HTMLButtonElement).disabled).toBe(true);
+    expect(radios.length).toBe(1);
+    const offButton = radios[0] as HTMLButtonElement;
+    expect(offButton.getAttribute('aria-label')).toBe('Off');
+    expect(offButton.getAttribute('aria-checked')).toBe('true');
   });
 
   it('marks "Off" as active when completions are disabled globally', () => {
@@ -846,6 +846,143 @@ describe('StatusTray — task #53', () => {
       expect(button).toBeTruthy();
       // Without `onOpenActions` threaded in, the button shouldn't fire.
       expect(button!.hasAttribute('disabled')).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // CompletionsGroup — issue #179: dynamic picker from connections-store
+  // -------------------------------------------------------------------------
+
+  describe('CompletionsGroup — dynamic connections (issue #179)', () => {
+    it('shows only inline_completion-capable connections, not hardcoded options', () => {
+      // Add one Anthropic connection with inline_completion capability.
+      addConnection({
+        id: 'c-anthropic',
+        provider: 'anthropic',
+        authMethod: 'api_key',
+        label: 'My Claude',
+        capabilities: ['interactive', 'inline_completion'],
+      });
+      renderWithProviders(<TrayHost open={true} onOpenChange={() => {}} />);
+      const group = document.querySelector('[role="radiogroup"]');
+      const options = group?.querySelectorAll('[role="radio"]');
+      const labels = Array.from(options ?? []).map((b) => b.getAttribute('aria-label'));
+      // Should show Off + connection label, NOT hardcoded provider names.
+      expect(labels).toContain('Off');
+      expect(labels).toContain('My Claude');
+      expect(labels).not.toContain('Copilot');
+      expect(labels).not.toContain('Local AI');
+      expect(labels).not.toContain('Ollama');
+    });
+
+    it('omits connections that lack inline_completion capability', () => {
+      // Add a connection that only has interactive capability.
+      addConnection({
+        id: 'c-interactive-only',
+        provider: 'anthropic',
+        authMethod: 'api_key',
+        label: 'Chat Only',
+        capabilities: ['interactive'],
+      });
+      renderWithProviders(<TrayHost open={true} onOpenChange={() => {}} />);
+      const group = document.querySelector('[role="radiogroup"]');
+      const options = group?.querySelectorAll('[role="radio"]');
+      const labels = Array.from(options ?? []).map((b) => b.getAttribute('aria-label'));
+      // Connection without inline_completion must not appear.
+      expect(labels).not.toContain('Chat Only');
+      // Only "Off" visible.
+      expect(labels).toEqual(['Off']);
+    });
+
+    it('shows "Configure in Settings" empty-state when no inline_completion connections exist', () => {
+      // No connections added — default from resetStores().
+      renderWithProviders(<TrayHost open={true} onOpenChange={() => {}} />);
+      const text = document.body.textContent ?? '';
+      expect(text).toContain('Configure in Settings');
+    });
+
+    it('does not show hardcoded Copilot/Local AI/Ollama when no matching connections', () => {
+      // With no connections the old code showed three disabled hardcoded buttons.
+      renderWithProviders(<TrayHost open={true} onOpenChange={() => {}} />);
+      const text = document.body.textContent ?? '';
+      expect(text).not.toContain('Copilot');
+      expect(text).not.toContain('Local AI');
+      expect(text).not.toContain('Ollama');
+    });
+
+    it('picking a connection writes its ID to routing-store inline_completion', () => {
+      addConnection({
+        id: 'c-custom-123',
+        provider: 'ollama',
+        authMethod: 'local',
+        label: 'My Ollama',
+        capabilities: ['inline_completion'],
+      });
+      renderWithProviders(<TrayHost open={true} onOpenChange={() => {}} />);
+      const button = Array.from(document.querySelectorAll('[role="radio"]')).find(
+        (b) => b.getAttribute('aria-label') === 'My Ollama',
+      ) as HTMLButtonElement;
+      expect(button).toBeTruthy();
+      fireEvent.click(button);
+      expect(useRoutingStore.getState().routing.inline_completion.connectionId).toBe('c-custom-123');
+      expect(useSettingsStore.getState().inlineCompletionsDisabled).toBe(false);
+    });
+
+    it('active state reflects the routing-store inline_completion connection ID', () => {
+      addConnection({
+        id: 'c-1',
+        provider: 'ollama',
+        authMethod: 'local',
+        label: 'Ollama',
+        capabilities: ['inline_completion'],
+      });
+      addConnection({
+        id: 'c-2',
+        provider: 'anthropic',
+        authMethod: 'api_key',
+        label: 'Claude',
+        capabilities: ['inline_completion'],
+      });
+      useRoutingStore.setState({
+        routing: {
+          interactive: { connectionId: null },
+          agent_tasks: { connectionId: null },
+          inline_completion: { connectionId: 'c-2' },
+        },
+      });
+      renderWithProviders(<TrayHost open={true} onOpenChange={() => {}} />);
+      const byLabel: Record<string, Element> = {};
+      document.querySelectorAll('[role="radio"]').forEach((b) => {
+        byLabel[b.getAttribute('aria-label') ?? ''] = b;
+      });
+      expect(byLabel['Claude']?.getAttribute('aria-checked')).toBe('true');
+      expect(byLabel['Ollama']?.getAttribute('aria-checked')).toBe('false');
+      expect(byLabel['Off']?.getAttribute('aria-checked')).toBe('false');
+    });
+
+    it('Off is active when inlineCompletionsDisabled=true regardless of routing', () => {
+      addConnection({
+        id: 'c-oll',
+        provider: 'ollama',
+        authMethod: 'local',
+        label: 'Ollama',
+        capabilities: ['inline_completion'],
+      });
+      useRoutingStore.setState({
+        routing: {
+          interactive: { connectionId: null },
+          agent_tasks: { connectionId: null },
+          inline_completion: { connectionId: 'c-oll' },
+        },
+      });
+      useSettingsStore.setState({ inlineCompletionsDisabled: true });
+      renderWithProviders(<TrayHost open={true} onOpenChange={() => {}} />);
+      const byLabel: Record<string, Element> = {};
+      document.querySelectorAll('[role="radio"]').forEach((b) => {
+        byLabel[b.getAttribute('aria-label') ?? ''] = b;
+      });
+      expect(byLabel['Off']?.getAttribute('aria-checked')).toBe('true');
+      expect(byLabel['Ollama']?.getAttribute('aria-checked')).toBe('false');
     });
   });
 });


### PR DESCRIPTION
Fixes #179

## Summary

Replaces the hardcoded four-option picker (Off / Copilot / Local AI / Ollama) in the StatusTray `CompletionsGroup` with a dynamic list derived from `connections.filter(c => c.capabilities.includes('inline_completion'))`. This mirrors the approach used by `UseCaseRoutingSettings.tsx`, which is the source of truth for the inline-completion slot.

Each connection with the `inline_completion` capability gets one radio button keyed by `conn.id` and labelled by `conn.label`. A static "Off" button is always present. When no compatible connection is configured, an empty-state hint with a "Configure in Settings…" link is shown.

## Red tests added

- `src/components/editor/__tests__/StatusTray.test.tsx::shows only inline_completion-capable connections, not hardcoded options` — connection with custom label appears; hardcoded names do not
- `src/components/editor/__tests__/StatusTray.test.tsx::omits connections that lack inline_completion capability` — `['interactive']`-only connection is excluded
- `src/components/editor/__tests__/StatusTray.test.tsx::shows "Configure in Settings" empty-state when no inline_completion connections exist` — empty-state text present when no connections
- `src/components/editor/__tests__/StatusTray.test.tsx::does not show hardcoded Copilot/Local AI/Ollama when no matching connections` — regression guard for hardcoded labels
- `src/components/editor/__tests__/StatusTray.test.tsx::picking a connection writes its ID to routing-store inline_completion` — click routes `routing.inline_completion.connectionId`
- `src/components/editor/__tests__/StatusTray.test.tsx::active state reflects the routing-store inline_completion connection ID` — `aria-checked` mirrors store state
- `src/components/editor/__tests__/StatusTray.test.tsx::Off is active when inlineCompletionsDisabled=true regardless of routing` — regression guard for master toggle

## Green implementation

- `src/components/editor/StatusTray.tsx` — removed `COMPLETION_OPTIONS`, `CompletionOption` type, `CompletionOptionMeta` interface; removed `copilotConn`/`localAiConn`/`ollamaConn` provider/authMethod lookups; added `compatibleConnections` memo using capability filter; rewrote picker render loop; added empty-state paragraph; updated `isOff` logic to cover orphaned routing (connection removed while routed)
- `src/components/editor/__tests__/StatusTray.test.tsx` — updated two old tests (`renders the completion picker with all four options` → reflects single "Off" when no connections; `disables options whose connections are not configured` → replaced disabled-button check with absent-button check)

## Refactor

Skipped — the implementation is already minimal and the removed code was all replaced.

## Decisions made

- **Empty state dispatches `notesage:open-settings` CustomEvent** rather than accepting a settings-open callback through the component tree. The `StatusTray` is rendered from `StatusBar` which has no settings-open handler; threading one would require adding a prop to two layers. The CustomEvent matches the pattern used in other parts of the codebase and is captured by `useKeyboardShortcuts`. — Chosen for minimal diff scope.
- **`isOff` covers orphaned routing** (connection removed from store while still set as the routing target) by checking `compatibleConnections.some(c => c.id === currentConnectionId)`. This ensures the picker shows "Off" active rather than a ghost active state when routing points to a deleted connection.

## Verification

- [x] Red tests were red before implementation
- [x] All red tests now green
- [x] `pnpm test` passes (262 files, 4781 tests)
- [x] `pnpm typecheck` clean
- [x] No unrelated files modified

## Notes for reviewer

The perf test (`src/perf/status-tray.perf.test.ts`) seeds an Ollama connection with label "Ollama" and searches for `aria-label="Ollama"` — this continues to work because the dynamic picker uses `conn.label` as the aria-label, and the perf test seeds a connection whose label is "Ollama".

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the `aw-tdd` skill.