### PR TITLE
fix(editor): prevent floating cmd bar from hiding cursor row during typing

### DIFF
--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -2,6 +2,7 @@ import { useEffect, useCallback, useRef, useState, useMemo, lazy, Suspense } fro
 import { createPortal } from "react-dom";
 import { useScrollPersistence } from "@/hooks/useScrollPersistence";
 import { useEditorResize } from "@/hooks/useEditorResize";
+import { useCursorScrollGuard } from "@/hooks/useCursorScrollGuard";
 import { EditorContent } from "@tiptap/react";
 import type { EditorState } from "@tiptap/pm/state";
 import { useEditorStore } from "@/stores/editor-store";
@@ -234,6 +235,8 @@ export function Editor({ onNewNote, onNewProject, onOpenFolder, onOpenProject, o
     activeTabId,
     activeTabFilePath: activeTab?.filePath,
   });
+
+  useCursorScrollGuard(scrollAreaRef);
 
   const { renderedWidth } = useEditorResize({
     contentRef,

--- a/src/hooks/__tests__/useCursorScrollGuard.test.ts
+++ b/src/hooks/__tests__/useCursorScrollGuard.test.ts
@@ -1,0 +1,314 @@
+// @vitest-environment jsdom
+
+/**
+ * Unit tests for useCursorScrollGuard.
+ *
+ * The hook listens for keydown events, reads the cursor's screen position via
+ * window.getSelection(), compares it to the floating command bar's top edge,
+ * and scrolls the editor container up if the cursor row would be hidden.
+ *
+ * jsdom does not implement layout (getBoundingClientRect always returns zeros),
+ * so we mock the relevant APIs on a test-by-test basis.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+// ---------------------------------------------------------------------------
+// Settings-store mock — controls `cmdBarPinned`
+// ---------------------------------------------------------------------------
+
+const mockSettings: { cmdBarPinned: boolean } = { cmdBarPinned: false };
+
+vi.mock('@/stores/settings-store', () => ({
+  useSettingsStore: Object.assign(
+    vi.fn((selector: (s: typeof mockSettings) => unknown) => selector(mockSettings)),
+    { getState: () => mockSettings },
+  ),
+}));
+
+import { useCursorScrollGuard } from '../useCursorScrollGuard';
+
+// ---------------------------------------------------------------------------
+// DOM helpers
+// ---------------------------------------------------------------------------
+
+/** Create a scroll container with a mocked scrollBy and attach it to body. */
+function mountScrollContainer(): { el: HTMLElement; scrollBy: ReturnType<typeof vi.fn> } {
+  const el = document.createElement('div');
+  document.body.appendChild(el);
+  const scrollBy = vi.fn();
+  el.scrollBy = scrollBy;
+  return { el, scrollBy };
+}
+
+/** Mount a floating (non-pinned) command bar and give it a fixed top edge. */
+function mountCmdBar(topEdge: number): HTMLElement {
+  const bar = document.createElement('div');
+  bar.setAttribute('data-cmd-bar', '');
+  bar.setAttribute('data-cmd-bar-pinned', 'false');
+  bar.getBoundingClientRect = vi.fn(() => ({
+    top: topEdge,
+    bottom: topEdge + 480,
+    left: 0,
+    right: 640,
+    width: 640,
+    height: 480,
+    x: 0,
+    y: topEdge,
+    toJSON: () => ({}),
+  }));
+  document.body.appendChild(bar);
+  return bar;
+}
+
+/** Mount a command bar with pinned="true". */
+function mountPinnedCmdBar(): HTMLElement {
+  const bar = document.createElement('div');
+  bar.setAttribute('data-cmd-bar', '');
+  bar.setAttribute('data-cmd-bar-pinned', 'true');
+  document.body.appendChild(bar);
+  return bar;
+}
+
+/** Mock window.getSelection to return a cursor whose bottom edge is at `cursorBottom`. */
+function mockCursorAt(cursorBottom: number): void {
+  const range = {
+    collapse: vi.fn(),
+    getBoundingClientRect: vi.fn(() => ({
+      top: cursorBottom - 20,
+      bottom: cursorBottom,
+      height: 20,
+      width: 2,
+      left: 100,
+      right: 102,
+      x: 100,
+      y: cursorBottom - 20,
+      toJSON: () => ({}),
+    })),
+  };
+  const selection = {
+    rangeCount: 1,
+    getRangeAt: vi.fn(() => range),
+  };
+  vi.spyOn(window, 'getSelection').mockReturnValue(selection as unknown as Selection);
+}
+
+/** Mock window.getSelection to return no selection. */
+function mockNoSelection(): void {
+  vi.spyOn(window, 'getSelection').mockReturnValue(null);
+}
+
+/** Dispatch a keydown event on the document. */
+function fireKeydown(): void {
+  document.dispatchEvent(
+    new KeyboardEvent('keydown', { key: 'a', bubbles: true, cancelable: true }),
+  );
+}
+
+// ---------------------------------------------------------------------------
+
+describe('useCursorScrollGuard', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    mockSettings.cmdBarPinned = false;
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Core scroll behavior
+  // -------------------------------------------------------------------------
+
+  it('scrolls the container by the overlap amount when cursor bottom is below the safe zone', () => {
+    const { el, scrollBy } = mountScrollContainer();
+    const cmdBarTopEdge = 500;
+    mountCmdBar(cmdBarTopEdge);
+    // Cursor bottom at 480 — safe zone bottom is 500 - 60 = 440, so overlap = 40
+    mockCursorAt(480);
+
+    const scrollContainerRef = { current: el };
+    renderHook(() => useCursorScrollGuard(scrollContainerRef));
+
+    act(() => { fireKeydown(); });
+
+    expect(scrollBy).toHaveBeenCalledTimes(1);
+    expect(scrollBy).toHaveBeenCalledWith(
+      expect.objectContaining({ top: 40 }),
+    );
+  });
+
+  it('does not scroll when cursor is already above the safe zone', () => {
+    const { el, scrollBy } = mountScrollContainer();
+    const cmdBarTopEdge = 600;
+    mountCmdBar(cmdBarTopEdge);
+    // Cursor bottom at 400 — safe zone bottom is 600 - 60 = 540, no overlap
+    mockCursorAt(400);
+
+    const scrollContainerRef = { current: el };
+    renderHook(() => useCursorScrollGuard(scrollContainerRef));
+
+    act(() => { fireKeydown(); });
+
+    expect(scrollBy).not.toHaveBeenCalled();
+  });
+
+  it('does not scroll when cursor bottom exactly equals the safe zone boundary', () => {
+    const { el, scrollBy } = mountScrollContainer();
+    const cmdBarTopEdge = 500;
+    mountCmdBar(cmdBarTopEdge);
+    // Safe zone bottom = 500 - 60 = 440. Cursor bottom = 440 (equal, not below)
+    mockCursorAt(440);
+
+    const scrollContainerRef = { current: el };
+    renderHook(() => useCursorScrollGuard(scrollContainerRef));
+
+    act(() => { fireKeydown(); });
+
+    expect(scrollBy).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // Pinned mode — no effect
+  // -------------------------------------------------------------------------
+
+  it('does nothing when cmdBarPinned is true in the settings store', () => {
+    mockSettings.cmdBarPinned = true;
+    const { el, scrollBy } = mountScrollContainer();
+    mountCmdBar(500);
+    mockCursorAt(480);
+
+    const scrollContainerRef = { current: el };
+    renderHook(() => useCursorScrollGuard(scrollContainerRef));
+
+    act(() => { fireKeydown(); });
+
+    expect(scrollBy).not.toHaveBeenCalled();
+  });
+
+  it('does not scroll when the cmd bar DOM element has data-cmd-bar-pinned="true"', () => {
+    const { el, scrollBy } = mountScrollContainer();
+    mountPinnedCmdBar();
+    mockCursorAt(480);
+
+    const scrollContainerRef = { current: el };
+    renderHook(() => useCursorScrollGuard(scrollContainerRef));
+
+    act(() => { fireKeydown(); });
+
+    expect(scrollBy).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // Missing elements — graceful no-op
+  // -------------------------------------------------------------------------
+
+  it('is a no-op when no [data-cmd-bar] element is in the DOM', () => {
+    const { el, scrollBy } = mountScrollContainer();
+    // No cmd bar mounted
+    mockCursorAt(480);
+
+    const scrollContainerRef = { current: el };
+    renderHook(() => useCursorScrollGuard(scrollContainerRef));
+
+    act(() => { fireKeydown(); });
+
+    expect(scrollBy).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when window.getSelection returns null', () => {
+    const { el, scrollBy } = mountScrollContainer();
+    mountCmdBar(500);
+    mockNoSelection();
+
+    const scrollContainerRef = { current: el };
+    renderHook(() => useCursorScrollGuard(scrollContainerRef));
+
+    act(() => { fireKeydown(); });
+
+    expect(scrollBy).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when the scrollContainerRef is null', () => {
+    mountCmdBar(500);
+    mockCursorAt(480);
+
+    const scrollContainerRef = { current: null };
+    // Should not throw
+    expect(() => {
+      renderHook(() => useCursorScrollGuard(scrollContainerRef));
+      act(() => { fireKeydown(); });
+    }).not.toThrow();
+  });
+
+  // -------------------------------------------------------------------------
+  // Throttling
+  // -------------------------------------------------------------------------
+
+  it('throttles scroll calls so rapid keydowns within 16 ms fire at most once', () => {
+    vi.useFakeTimers();
+    const { el, scrollBy } = mountScrollContainer();
+    mountCmdBar(500);
+    mockCursorAt(480);
+
+    const scrollContainerRef = { current: el };
+    renderHook(() => useCursorScrollGuard(scrollContainerRef));
+
+    act(() => {
+      fireKeydown();
+      fireKeydown();
+      fireKeydown();
+    });
+
+    // Only one scroll should fire despite three rapid keydowns
+    expect(scrollBy).toHaveBeenCalledTimes(1);
+
+    vi.useRealTimers();
+  });
+
+  it('fires again after the throttle window has elapsed', () => {
+    vi.useFakeTimers();
+    const { el, scrollBy } = mountScrollContainer();
+    mountCmdBar(500);
+    mockCursorAt(480);
+
+    const scrollContainerRef = { current: el };
+    renderHook(() => useCursorScrollGuard(scrollContainerRef));
+
+    act(() => { fireKeydown(); });
+    expect(scrollBy).toHaveBeenCalledTimes(1);
+
+    // Advance past the 16 ms throttle window
+    act(() => { vi.advanceTimersByTime(20); });
+    act(() => { fireKeydown(); });
+    expect(scrollBy).toHaveBeenCalledTimes(2);
+
+    vi.useRealTimers();
+  });
+
+  // -------------------------------------------------------------------------
+  // Cleanup
+  // -------------------------------------------------------------------------
+
+  it('removes the keydown listener on unmount and stops scrolling', () => {
+    const { el, scrollBy } = mountScrollContainer();
+    mountCmdBar(500);
+    mockCursorAt(480);
+
+    const scrollContainerRef = { current: el };
+    const { unmount } = renderHook(() => useCursorScrollGuard(scrollContainerRef));
+
+    act(() => { fireKeydown(); });
+    expect(scrollBy).toHaveBeenCalledTimes(1);
+
+    unmount();
+    scrollBy.mockClear();
+
+    act(() => { fireKeydown(); });
+    expect(scrollBy).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useCursorScrollGuard.ts
+++ b/src/hooks/useCursorScrollGuard.ts
@@ -1,0 +1,70 @@
+import { useCallback, useEffect, useRef } from "react";
+import type { RefObject } from "react";
+import { useSettingsStore } from "@/stores/settings-store";
+
+/** Breathing room in px between the cursor row bottom and the cmd bar top edge. */
+const BREATHING_ROOM_PX = 60;
+
+/** Minimum ms between consecutive scroll corrections to avoid animation fights. */
+const THROTTLE_MS = 16;
+
+/**
+ * Prevents the floating command bar from hiding the cursor row during typing.
+ *
+ * On each keydown event the hook:
+ * 1. Reads the cursor's screen coordinates via `window.getSelection()`.
+ * 2. Reads the floating cmd bar's top edge via `getBoundingClientRect()`.
+ * 3. If the cursor bottom is within BREATHING_ROOM_PX of the cmd bar top,
+ *    smoothly scrolls the editor container upward by the overlap amount.
+ *
+ * Only active in Quiet Composer floating mode (`cmdBarPinned === false`).
+ * Skips if the DOM cmd bar element itself reports `data-cmd-bar-pinned="true"`
+ * (defence-in-depth against stale store state during transitions).
+ */
+export function useCursorScrollGuard(
+  scrollContainerRef: RefObject<HTMLElement | null>,
+): void {
+  const cmdBarPinned = useSettingsStore((s) => s.cmdBarPinned);
+  const lastFireTime = useRef(0);
+
+  const guardScroll = useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    const cmdBar = document.querySelector<HTMLElement>("[data-cmd-bar]");
+    if (!cmdBar) return;
+    if (cmdBar.getAttribute("data-cmd-bar-pinned") === "true") return;
+
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0) return;
+
+    const range = selection.getRangeAt(0);
+    const cursorRect = range.getBoundingClientRect();
+    if (!cursorRect || cursorRect.height === 0) return;
+
+    const safeBottom = cmdBar.getBoundingClientRect().top - BREATHING_ROOM_PX;
+
+    if (cursorRect.bottom > safeBottom) {
+      container.scrollBy({
+        top: cursorRect.bottom - safeBottom,
+        behavior: "smooth",
+      });
+    }
+  }, [scrollContainerRef]);
+
+  useEffect(() => {
+    if (cmdBarPinned) return;
+
+    const onKeydown = () => {
+      const now = Date.now();
+      if (now - lastFireTime.current < THROTTLE_MS) return;
+      lastFireTime.current = now;
+      guardScroll();
+    };
+
+    document.addEventListener("keydown", onKeydown, { capture: true });
+    return () => {
+      document.removeEventListener("keydown", onKeydown, { capture: true });
+    };
+  }, [cmdBarPinned, guardScroll]);
+}


### PR DESCRIPTION
Fixes #177

## Summary

Adds `useCursorScrollGuard` — a lightweight hook that fires on every `keydown` event and prevents the Quiet Composer's floating command bar from hiding the line currently being typed. On each keystroke the hook reads the cursor's screen position via `window.getSelection()`, computes the cmd bar's top edge via `getBoundingClientRect()`, and if the cursor bottom is within 60 px of the bar's top edge it smoothly scrolls the editor container upward by exactly the overlap amount. The hook is throttled to one correction per 16 ms to avoid fighting CSS scroll animations, and is a strict no-op when the cmd bar is in pinned side-panel mode or when the Classic Layout is active.

## Red tests added

- `useCursorScrollGuard.test.ts::scrolls the container by the overlap amount when cursor bottom is below the safe zone` — core scroll math
- `useCursorScrollGuard.test.ts::does not scroll when cursor is already above the safe zone` — no false scrolls
- `useCursorScrollGuard.test.ts::does not scroll when cursor bottom exactly equals the safe zone boundary` — boundary condition
- `useCursorScrollGuard.test.ts::does nothing when cmdBarPinned is true in the settings store` — pinned-mode guard
- `useCursorScrollGuard.test.ts::does not scroll when the cmd bar DOM element has data-cmd-bar-pinned="true"` — defence-in-depth DOM guard
- `useCursorScrollGuard.test.ts::is a no-op when no [data-cmd-bar] element is in the DOM` — missing element graceful no-op
- `useCursorScrollGuard.test.ts::is a no-op when window.getSelection returns null` — no selection graceful no-op
- `useCursorScrollGuard.test.ts::is a no-op when the scrollContainerRef is null` — null ref safe
- `useCursorScrollGuard.test.ts::throttles scroll calls so rapid keydowns within 16 ms fire at most once` — throttle correctness
- `useCursorScrollGuard.test.ts::fires again after the throttle window has elapsed` — throttle resets
- `useCursorScrollGuard.test.ts::removes the keydown listener on unmount and stops scrolling` — cleanup

## Green implementation

- `src/hooks/useCursorScrollGuard.ts` — new hook: keydown listener, `window.getSelection()` cursor read, `getBoundingClientRect()` on `[data-cmd-bar]`, throttled `container.scrollBy({ behavior: 'smooth' })`
- `src/hooks/__tests__/useCursorScrollGuard.test.ts` — 11 unit tests covering all acceptance criteria
- `src/components/editor/Editor.tsx` — import + one-line call `useCursorScrollGuard(scrollAreaRef)` after the existing `useScrollPersistence` call

## Refactor

Skipped — implementation is already minimal (55 lines of hook code).

## Decisions made

- **Cursor detection via `window.getSelection()`** | Used `getSelection()` + `getRangeAt(0).getBoundingClientRect()` instead of Tiptap's `view.coordsAtPos()` | Works for all three editor surfaces (markdown WYSIWYG, source mode CodeMirror, code file editor) without needing a Tiptap editor ref; the issue explicitly asked for "applies to whichever editor surface has focus".
- **Keydown event on `document` (capture phase)** | Chosen over `input` event | Fires before the browser scrolls the contenteditable, giving the guard first chance to adjust. The capture flag avoids interference from Tiptap's own key handlers.
- **Breathing room = 60 px (constant)** | Implements the 60 px default from the issue's Assumptions section | Exposed as `BREATHING_ROOM_PX` at module top for easy tuning.
- **Throttle = 16 ms (one animation frame)** | Matches the Assumptions section recommendation | Keeps the scroll correction frame-budget friendly without dropping keystrokes.
- **`data-cmd-bar-pinned` double-check** | Store check (`cmdBarPinned`) already gates the effect, but the DOM attribute is re-checked inside `guardScroll` as defence-in-depth during expand/collapse transitions when the store and DOM might transiently disagree.

## Verification

- [x] Red tests were red before implementation (import error — hook file did not exist)
- [x] All 11 red tests now green
- [x] `pnpm test` passes (263 files, 4785 tests)
- [x] `pnpm typecheck` clean
- [x] No unrelated files modified (only `Editor.tsx` + the two new files)

## Notes for reviewer

The fix targets the scroll container (`scrollAreaRef`) that already exists in `Editor.tsx` — it does not add any new DOM nodes or CSS. The `behavior: 'smooth'` scroll works in the Tauri WebView (WKWebView on macOS) which respects the CSSOM scroll-behavior API. If WKWebView ever drops smooth scroll support, the fallback is instant (`scrollTop += delta`) which would still keep the cursor visible — just without the animation.

The hook deliberately does NOT guard against `prefers-reduced-motion` because the scroll is a functional correction, not a decorative animation. If a user has reduced motion enabled, the smooth scroll degrades to an instant jump (browsers treat `behavior: 'smooth'` as a hint, not a requirement, when `prefers-reduced-motion: reduce` is set).

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the `aw-tdd` skill.