### PR TITLE
chore(aw): every stage reads human comments since its trigger marker

### DIFF
--- a/.claude/skills/aw-refine/SKILL.md
+++ b/.claude/skills/aw-refine/SKILL.md
@@ -14,10 +14,19 @@ Rewrite a single GitHub issue body into the outcome-oriented template. The issue
 
 ## Process
 
-1. **Read the issue.**
-   - `gh issue view $ISSUE_NUMBER --json title,body,labels`
+1. **Read the issue, including comments.**
+   - `gh issue view $ISSUE_NUMBER --json title,body,labels,comments`
    - Verify exactly one of `bug` / `enhancement` / `chore` is present AND `refine` is present. If not, post a clarification comment and stop.
    - If `refined` is already present, exit silently (idempotent).
+
+1.5. **Read human comments since the trigger marker** — authoritative override material.
+
+   When the user resets a refined issue to `refine` (via `aw-feedback`'s "Redo refined scope" / assumption-override path, or by manual label flip), they almost always leave a comment explaining what was wrong with the previous refine. **That comment is the most important input to this run.** Without reading it, this skill re-runs against the same body and predictably re-produces the same wrong refinement.
+
+   - Filter the `comments` array to skip bot comments (any comment whose author is `github-actions[bot]`, `claude[bot]`, `app/claude`, or contains a `> *Refined automatically by the` / `> *Read by` marker line at the start).
+   - Of the remaining human comments, focus on those posted after the issue's most recent state-change event. If the issue currently carries `refine` (was reset from `refined`), the relevant comments are everything posted after the most recent `refined` label was added to the issue (use `gh issue view` event history if needed, or simply: any human comment posted after the latest bot `Refined automatically` marker).
+   - Treat each such human comment as **authoritative**. What the human explicitly stated outweighs any conflicting interpretation you would otherwise derive from the issue body alone. Fold the corrections into the rewritten body's `## Assumptions` section AND into the outcome / acceptance-criteria sections as needed — not just a passing mention, but a structural rewrite that makes the corrected scope impossible to re-derive wrong.
+   - If a human comment includes "Files explicitly NOT touched" / "DO NOT" / "Wrong path" sections, mirror them in the rewritten body so `aw-tdd` can't miss them.
 
 2. **Pick the matching template** (see Templates below) based on the category.
 
@@ -26,6 +35,8 @@ Rewrite a single GitHub issue body into the outcome-oriented template. The issue
    Preserve verbatim: reproduction steps, error messages, code blocks, environment / version, user-provided technical context, original outcome if already clear.
 
    Improve: outcome focus, scope (in / out / non-goals), acceptance criteria (testable, observable). When you make assumptions because the original was silent or ambiguous, record them under `## Assumptions` in the rewritten body — they're override-able by comment.
+
+   **When step 1.5 found human override comments**, the rewritten body is structurally different from the previous body, not a near-copy. Test: read the new body cold without seeing the comment, and ask "could I derive the override from this alone?" If no, expand the body until yes. The comment was a one-time correction; the body is the durable spec.
 
 4. **Update the body** via `gh issue edit $ISSUE_NUMBER --body-file <(...)`.
 

--- a/.claude/skills/aw-slice/SKILL.md
+++ b/.claude/skills/aw-slice/SKILL.md
@@ -14,12 +14,24 @@ Decide how a refined GitHub issue should be implemented: as one PR (the common c
 
 ## Process
 
-1. **Read the issue.**
+1. **Read the issue, including comments.**
    - `gh issue view $ISSUE_NUMBER --json title,body,labels,comments`
    - Verify it has `refined` AND `slice` AND one of `bug` / `enhancement` / `chore`.
    - Verify it does NOT have `sliced` or `awaiting-research`. If it does, exit silently (idempotent).
    - The `slice` action label is the explicit gate. Set by `aw-refine` after a successful clarification, or by a human after a research peer closes (`awaiting-research` → `slice`). Bare `refined` alone is NOT a trigger.
    - The `feature` label is **deprecated**. Don't check for it; don't add it. It was a parent marker from the original sub-issue model that we pivoted away from in favor of peer-issue splits.
+
+1.5. **Read human comments since the latest `refined` marker** — authoritative override material.
+
+   When the user resets an issue back to `slice` (after research, after a feedback cycle, or via `aw-feedback`'s "Redo slicing" path), they typically leave a comment explaining what should change. Comments posted between the most recent `refined` marker and now are authoritative input to this run.
+
+   - Filter the `comments` array to skip bot comments (skip any comment whose author is `github-actions[bot]`, `claude[bot]`, `app/claude`, or whose body opens with a `> *Reviewed by` / `> *Sliced by` / `> *Refined automatically` marker).
+   - Of the remaining human comments, focus on those posted after the issue's most recent `refined` event. Use the comment timestamp; if needed, fall back to: any human comment whose timestamp is after the latest bot `Refined automatically by the aw-refine skill` marker comment.
+   - Treat each such human comment as **authoritative**. What the human explicitly stated outweighs any conflicting interpretation of the body alone. Fold the corrections into:
+     - The slice rationale's `## Proposed answers` (when the comment answers an open question or overrides one of slice's would-be assumptions)
+     - The peer-issue bodies, if slicing produces them (when the comment changes how values should split)
+     - The `## Why hitl` section (when the comment reveals a security / data-loss concern that elevates from `afk` to `hitl`)
+   - If the human comment includes "DO NOT" / "Wrong path" / "Files explicitly NOT touched" sections, mirror them in the slice rationale or the peer-issue bodies so `aw-tdd` can't miss them.
 
 2. **First branch — research vs value-listing.**
 

--- a/.claude/skills/aw-tdd/SKILL.md
+++ b/.claude/skills/aw-tdd/SKILL.md
@@ -20,9 +20,21 @@ Implement a single issue end-to-end following the red-green-refactor cycle. The 
 
 0. **Check for a PR already in flight.** Before anything else: `gh pr list --search "resolves #$ISSUE_NUMBER OR fixes #$ISSUE_NUMBER OR closes #$ISSUE_NUMBER" --state open --json number,url`. If any open PR referencing this issue is found, exit silently — a concurrent run has already claimed the issue. Do not rely solely on the `review` label: GitHub label writes have latency, and two concurrent triggers can both pass the label check before either has written to the API.
 
-1. **Read the issue.** `gh issue view $ISSUE_NUMBER --json title,body,labels,number`.
+1. **Read the issue, including comments.** `gh issue view $ISSUE_NUMBER --json title,body,labels,number,comments`.
    - Verify it has `tdd` AND `afk` AND `refined` AND exactly one of `bug` / `enhancement` / `chore`. If not, exit silently.
    - Verify it does NOT have `review` or be closed.
+
+1.4. **Read human comments since the latest `refined` marker** — authoritative override material.
+
+   When the user resets an issue back to `tdd` (manually, or via `aw-feedback`'s "Redo implementation" path), they typically leave a comment explaining what was wrong with the previous attempt or what the implementation must do differently. **Comments posted between the most recent `refined` event and now are authoritative input to this run.** Without folding them in, the same wrong implementation will ship again.
+
+   - Filter the `comments` array to skip bot comments (any comment whose author is `github-actions[bot]`, `claude[bot]`, `app/claude`, or whose body opens with a `> *Refined automatically` / `> *Sliced by` / `> *Reviewed by` / `> *Read by` / `> *Implemented by` marker).
+   - Of the remaining human comments, focus on those posted after the issue's most recent `refined` event. As a fallback heuristic: any human comment whose timestamp is after the latest bot `Refined automatically` marker comment, or after the latest bot `Reviewed by aw-review` comment if that came later.
+   - Treat each such human comment as **authoritative**. What the human explicitly stated outweighs any conflicting interpretation of the body alone. In particular:
+     - "Wrong path" / "Files explicitly NOT touched" / "DO NOT" → those files are forbidden in this run, regardless of what `Files likely to change` in the body says.
+     - "It should be transient, not persistent" / "session-only, not stored" → semantic overrides on storage / persistence shape.
+     - "The previous PR did X but should have done Y" → Y is the requirement; write a red test that asserts Y, not X.
+   - **Combine with retry gaps from step 1.5.** If both override comments AND aw-review rejections exist, treat them as one merged list of red tests — every override-comment requirement gets its own failing test, alongside every `✗ Missing` / regression from the prior PR.
 
 1.5. **Check for prior `aw-review` rejections (retry detection).** Find any closed bot-authored PRs for this issue:
    ```

--- a/docs/agentic-workflow.md
+++ b/docs/agentic-workflow.md
@@ -417,6 +417,25 @@ A `hitl` label without a feedback handler is a one-way pause signal — the huma
 
 This closes the conversation loop. The agent can be redirected from ANY pause point to ANY earlier pipeline stage based on the human's natural-language comment — no slash commands, no manual label edits.
 
+### Choice: every stage reads human comments since its trigger marker
+
+**The pivot.** `aw-feedback`'s reset paths (refine → slice → tdd) all rely on the human's comment carrying the new intent. The original assumption was: "the comment is recorded on the issue, the next stage will see it." That assumption was false. Issue #162 (font-size shortcuts) was reset to `refine` twice with explicit override comments ("transient zoom, not persistent font-size change"); both times `aw-refine` faithfully re-refined the same body and produced the same wrong output, because the skill instructions didn't say "read the comments." Only `aw-review` read comments after the trigger marker — every other stage was working off the body alone.
+
+**The fix.** Every stage skill (`aw-refine`, `aw-slice`, `aw-tdd`) now has an explicit "read human comments since the latest `refined` marker" step. The recipe:
+
+1. `gh issue view` includes `comments` in the JSON fields.
+2. Filter out bot comments (`github-actions[bot]`, `claude[bot]`, marker lines like `> *Refined automatically by`).
+3. Of the remaining human comments, focus on those posted after the most recent `refined` event (or the most recent stage marker, depending on which stage is running).
+4. Treat each such human comment as **authoritative** — it overrides the body when the two conflict.
+5. Fold the corrections into the durable spec the next stage sees:
+   - `aw-refine` rewrites the body so the override is impossible to re-derive wrong.
+   - `aw-slice` folds the override into the slice rationale and (if applicable) into peer-issue bodies.
+   - `aw-tdd` writes a red test for each override-comment requirement, alongside any aw-review gap-list.
+
+**Why this works.** The previous loop only had one read-the-comments stage (`aw-review`), too late in the pipeline — by the time aw-review caught the gap, a wrong PR was already open and the user was already frustrated. Reading comments at every stage means the override propagates through the durable artifacts (refined body, slice rationale, peer-issue bodies, red tests) so each downstream stage sees the corrected intent in its primary input, not as a side note to remember.
+
+**Anti-pattern this fixes.** "I refined the body, the comment is on the issue, surely the next agent will see it" — no, the next agent reads what its skill tells it to read. If the skill doesn't say "read comments," the agent doesn't, and the override is invisible.
+
 ### Choice: aw-review as an independent gate before "ready for review"
 
 **The pivot.** Originally `aw-tdd` opened a draft PR and immediately flipped the issue to `review`, expecting the human to be the next gate. Two PRs (#85 and #86) merged through that gate looked clean on paper (tests green, code reads well) but **didn't actually fix the user's problem**. PR #86 changed 7 pickers in `cmd/modes/` while the user's issue actually pointed at chat-footer pickers — the agent took "command bar pickers" too literally. PR #85 implemented `criterion 4` of issue #62 verbatim while the user had commented THREE times asking for criterion 4 to be flipped — `aw-refine` re-ran but didn't fold the comments into the body, and `aw-tdd` faithfully implemented the stale criterion. Neither the implementer nor the post-merge audit caught it. The user was the reviewer, and the user was angry.


### PR DESCRIPTION
## Summary

- Patch `aw-refine`, `aw-slice`, `aw-tdd` to explicitly read human comments since the latest `refined` marker and treat them as authoritative override material
- Add `comments` to each skill's `gh issue view` query
- Document the pivot as a new "Choice" section in `docs/agentic-workflow.md`

## Why

Only `aw-review` was reading issue comments after the trigger marker. The other three stages worked off the body alone, so any override comment posted via `aw-feedback`'s reset paths (or a manual label flip) was invisible to the next agent. Issue #162 hit this twice — refined and re-refined off the same unchanged body, producing the same wrong implementation both times even though the user had pasted an explicit "transient zoom, not persistent font-size" override comment after each reset.

## What changed

For each of `aw-refine`, `aw-slice`, `aw-tdd`:

1. `gh issue view` now includes `comments` in the JSON fields.
2. New explicit step: filter out bot comments by author and marker lines (`> *Refined automatically by`, `> *Sliced by`, etc.), then focus on human comments posted after the most recent `refined` event.
3. Treat each such comment as **authoritative** — it overrides the body where the two conflict.
4. Fold the corrections into the durable artifact the next stage reads:
   - `aw-refine` → rewrite body so the override is impossible to re-derive wrong
   - `aw-slice` → fold into slice rationale's `## Proposed answers` and (if applicable) into peer-issue bodies
   - `aw-tdd` → write a red test for each override-comment requirement, alongside any aw-review gap-list

`docs/agentic-workflow.md` gets a new "Choice: every stage reads human comments since its trigger marker" section explaining the pivot, the recipe, and the anti-pattern this fixes.

## Test plan

- [ ] Reset an issue from `refined` to `refine` with an override comment and confirm `aw-refine` rewrites the body to reflect the comment, not the original body
- [ ] Reset an issue from `tdd` to `slice` with an override comment and confirm `aw-slice` folds the override into the slice rationale
- [ ] Reset an issue from `review` (or after a closed PR) to `tdd + afk` with an override comment and confirm `aw-tdd` writes a red test for the override requirement

🤖 Generated with [Claude Code](https://claude.com/claude-code)