### PR TITLE
feat(html-viewer): opt-in allow-forms sandbox setting

### DIFF
--- a/src/components/editor/viewers/HtmlViewer.tsx
+++ b/src/components/editor/viewers/HtmlViewer.tsx
@@ -3,6 +3,7 @@ import { Code } from "lucide-react";
 import { highlightDomMatches, clearDomHighlights } from "@/lib/dom-search";
 import { FindBar } from "@/components/editor/FindBar";
 import { CodeEditor } from "./CodeEditor";
+import { useSettingsStore } from "@/stores/settings-store";
 
 interface HtmlViewerProps {
   content: string;
@@ -23,6 +24,7 @@ export function HtmlViewer({
   updateTabContent,
   saveFileWithContent,
 }: HtmlViewerProps) {
+  const allowForms = useSettingsStore((s) => s.htmlViewerAllowForms);
   const [sourceMode, setSourceMode] = useState(false);
   const [findBarOpen, setFindBarOpen] = useState(false);
   const [searchMatches, setSearchMatches] = useState<HTMLElement[]>([]);
@@ -198,11 +200,14 @@ export function HtmlViewer({
           replaceExpanded={false}
           onReplaceExpandedChange={() => {}}
         />
-        {/* Sandboxed iframe — allow-same-origin for local asset loading, no allow-scripts */}
+        {/* Sandboxed iframe — allow-same-origin for local asset loading, no allow-scripts.
+            allow-forms and allow-top-navigation-by-user-activation are opt-in via settings. */}
         <iframe
           ref={iframeRef}
           title={fileName}
-          sandbox="allow-same-origin"
+          sandbox={allowForms
+            ? "allow-same-origin allow-forms allow-top-navigation-by-user-activation"
+            : "allow-same-origin"}
           className="w-full h-full border-0 bg-white"
           aria-label={`Rendered HTML: ${fileName}`}
         />

--- a/src/components/editor/viewers/__tests__/HtmlViewer.test.tsx
+++ b/src/components/editor/viewers/__tests__/HtmlViewer.test.tsx
@@ -1,8 +1,9 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { HtmlViewer } from "../HtmlViewer";
 import { PlainTextViewer } from "../PlainTextViewer";
+import { useSettingsStore } from "@/stores/settings-store";
 
 // Mock CodeEditor to avoid full CodeMirror setup in jsdom
 vi.mock("../CodeEditor", () => ({
@@ -113,6 +114,93 @@ describe("HtmlViewer", () => {
     fireEvent.click(screen.getByRole("button", { name: /source|rendered|code|preview/i }));
     expect(screen.queryByTestId("code-editor")).toBeNull();
     expect(document.querySelector("iframe")).not.toBeNull();
+  });
+});
+
+describe("HtmlViewer sandbox attribute — htmlViewerAllowForms", () => {
+  const htmlContent = "<html><body><form action='/submit'><input type='submit'/></form></body></html>";
+  const filePath = "/path/to/form.html";
+  const fileName = "form.html";
+
+  afterEach(() => {
+    // Reset to default after each test so other tests are not affected
+    useSettingsStore.setState({ htmlViewerAllowForms: false } as Parameters<typeof useSettingsStore.setState>[0]);
+  });
+
+  it("excludes allow-forms and allow-top-navigation-by-user-activation by default (regression guard)", () => {
+    render(
+      <HtmlViewer
+        content={htmlContent}
+        fileName={fileName}
+        filePath={filePath}
+        tabId="tab-forms-default"
+        isDirty={false}
+        updateTabContent={vi.fn()}
+        saveFileWithContent={vi.fn()}
+      />
+    );
+    const iframe = document.querySelector("iframe");
+    expect(iframe).not.toBeNull();
+    const sandbox = iframe!.getAttribute("sandbox");
+    expect(sandbox).not.toContain("allow-forms");
+    expect(sandbox).not.toContain("allow-top-navigation-by-user-activation");
+  });
+
+  it("includes allow-forms in sandbox when htmlViewerAllowForms is true", () => {
+    useSettingsStore.setState({ htmlViewerAllowForms: true } as Parameters<typeof useSettingsStore.setState>[0]);
+    render(
+      <HtmlViewer
+        content={htmlContent}
+        fileName={fileName}
+        filePath={filePath}
+        tabId="tab-forms-on"
+        isDirty={false}
+        updateTabContent={vi.fn()}
+        saveFileWithContent={vi.fn()}
+      />
+    );
+    const iframe = document.querySelector("iframe");
+    expect(iframe).not.toBeNull();
+    const sandbox = iframe!.getAttribute("sandbox");
+    expect(sandbox).toContain("allow-forms");
+  });
+
+  it("includes allow-top-navigation-by-user-activation in sandbox when htmlViewerAllowForms is true", () => {
+    useSettingsStore.setState({ htmlViewerAllowForms: true } as Parameters<typeof useSettingsStore.setState>[0]);
+    render(
+      <HtmlViewer
+        content={htmlContent}
+        fileName={fileName}
+        filePath={filePath}
+        tabId="tab-forms-nav"
+        isDirty={false}
+        updateTabContent={vi.fn()}
+        saveFileWithContent={vi.fn()}
+      />
+    );
+    const iframe = document.querySelector("iframe");
+    expect(iframe).not.toBeNull();
+    const sandbox = iframe!.getAttribute("sandbox");
+    expect(sandbox).toContain("allow-top-navigation-by-user-activation");
+  });
+
+  it("still includes allow-same-origin when htmlViewerAllowForms is true (regression guard)", () => {
+    useSettingsStore.setState({ htmlViewerAllowForms: true } as Parameters<typeof useSettingsStore.setState>[0]);
+    render(
+      <HtmlViewer
+        content={htmlContent}
+        fileName={fileName}
+        filePath={filePath}
+        tabId="tab-forms-same-origin"
+        isDirty={false}
+        updateTabContent={vi.fn()}
+        saveFileWithContent={vi.fn()}
+      />
+    );
+    const iframe = document.querySelector("iframe");
+    expect(iframe).not.toBeNull();
+    const sandbox = iframe!.getAttribute("sandbox");
+    expect(sandbox).toContain("allow-same-origin");
   });
 });
 

--- a/src/components/settings/v2/SystemSettings.tsx
+++ b/src/components/settings/v2/SystemSettings.tsx
@@ -130,6 +130,10 @@ export function SystemSettings({
     (s) => s.setNotifyExternalChanges,
   );
 
+  // HTML viewer
+  const htmlViewerAllowForms = useSettingsStore((s) => s.htmlViewerAllowForms);
+  const setHtmlViewerAllowForms = useSettingsStore((s) => s.setHtmlViewerAllowForms);
+
   // Files
   const showHiddenFiles = useSettingsStore((s) => s.showHiddenFiles);
   const setShowHiddenFiles = useSettingsStore((s) => s.setShowHiddenFiles);
@@ -372,6 +376,24 @@ export function SystemSettings({
               id="notify-external"
               checked={notifyExternalChanges}
               onCheckedChange={setNotifyExternalChanges}
+            />
+          }
+        />
+      </SettingsGroup>
+
+      <SettingsGroup
+        label="HTML viewer"
+        description="Configure sandboxing behaviour when rendering .html and .htm files."
+      >
+        <SettingsRow
+          label="Allow form submissions"
+          description="When on, HTML forms can be submitted inside the viewer iframe. Off by default — only enable if you trust the HTML files you open."
+          htmlFor="html-viewer-allow-forms"
+          control={
+            <Switch
+              id="html-viewer-allow-forms"
+              checked={htmlViewerAllowForms}
+              onCheckedChange={setHtmlViewerAllowForms}
             />
           }
         />

--- a/src/components/settings/v2/__tests__/panels.test.tsx
+++ b/src/components/settings/v2/__tests__/panels.test.tsx
@@ -62,6 +62,12 @@ describe('v2 settings panels', () => {
     expect(screen.getByText('Show hidden files')).toBeTruthy();
   });
 
+  it('SystemSettings renders HTML viewer group with Allow form submissions toggle', () => {
+    renderWithProviders(<SystemSettings />);
+    expect(screen.getByText('HTML viewer')).toBeTruthy();
+    expect(screen.getByText('Allow form submissions')).toBeTruthy();
+  });
+
   it('SystemSettings renders "View update" affordance when an update is available', () => {
     renderWithProviders(
       <SystemSettings

--- a/src/stores/__tests__/settings-store.test.ts
+++ b/src/stores/__tests__/settings-store.test.ts
@@ -1113,7 +1113,7 @@ describe('uiPreview flag', () => {
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(14);
+    expect(parsed.version).toBe(15);
     expect(parsed.state.uiPreview).toBe('legacy');
     expect(parsed.state.accent).toBe('default');
   });
@@ -1255,7 +1255,7 @@ describe('v5 → v6 migration (cmdBarPinned + cmdBarPinnedWidth)', () => {
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(14);
+    expect(parsed.version).toBe(15);
     expect(parsed.state.cmdBarPinned).toBe(false);
     expect(parsed.state.cmdBarPinnedWidth).toBe(400);
   });
@@ -1401,7 +1401,7 @@ describe('v6 → v7 migration (quietChromePreset + quietChromeOverrides)', () =>
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(14);
+    expect(parsed.version).toBe(15);
     expect(parsed.state.quietChromePreset).toBe('default');
     expect(parsed.state.quietChromeOverrides).toBeTruthy();
   });
@@ -1720,7 +1720,7 @@ describe('v7 → v8 migration (sidebar composition)', () => {
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(14);
+    expect(parsed.version).toBe(15);
     expect(parsed.state.sidebarRecentCap).toBe(5);
     expect(parsed.state.sidebarTagsCap).toBe(5);
     // Hidden field stripped by v11 → v12 migration.
@@ -1975,7 +1975,7 @@ describe('v8 → v9 migration (preview invitation timestamps)', () => {
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(14);
+    expect(parsed.version).toBe(15);
     expect(parsed.state.previewInvitationShownAt).toBeNull();
     expect(parsed.state.previewInvitationDismissedAt).toBeNull();
   });
@@ -2077,7 +2077,7 @@ describe('v9 → v10 migration (cmdBarExpandedWidth)', () => {
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(14);
+    expect(parsed.version).toBe(15);
     expect(parsed.state.cmdBarExpandedWidth).toBe(640);
   });
 
@@ -2148,7 +2148,7 @@ describe('v10 → v11 migration (sidebar Mentions composition)', () => {
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(14);
+    expect(parsed.version).toBe(15);
     expect(parsed.state.sidebarMentionsCap).toBe(5);
     expect(parsed.state.sidebarMentionsHidden).toBeUndefined();
   });
@@ -2270,7 +2270,7 @@ describe('v11 → v12 migration (drop Hidden booleans)', () => {
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(14);
+    expect(parsed.version).toBe(15);
     expect(parsed.state.sidebarTagsCap).toBe(0);
     expect(parsed.state.sidebarTagsHidden).toBeUndefined();
   });
@@ -2292,7 +2292,7 @@ describe('v11 → v12 migration (drop Hidden booleans)', () => {
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(14);
+    expect(parsed.version).toBe(15);
     expect(parsed.state.sidebarMentionsCap).toBe(0);
     expect(parsed.state.sidebarMentionsHidden).toBeUndefined();
   });
@@ -2318,7 +2318,7 @@ describe('v11 → v12 migration (drop Hidden booleans)', () => {
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(14);
+    expect(parsed.version).toBe(15);
     expect(parsed.state.sidebarTagsHidden).toBeUndefined();
     expect(parsed.state.sidebarMentionsHidden).toBeUndefined();
   });
@@ -2452,7 +2452,7 @@ describe('v14 migration: releaseChannel', () => {
     expect(useSettingsStore.getState().releaseChannel).toBe('alpha');
   });
 
-  it('bumps persisted version to 14 after migration', async () => {
+  it('bumps persisted version to 15 after migration', async () => {
     localStorageMock.setItem(STORAGE_KEY, buildV13State());
 
     await useSettingsStore.persist.rehydrate();
@@ -2460,6 +2460,52 @@ describe('v14 migration: releaseChannel', () => {
 
     const raw = localStorageMock.getItem(STORAGE_KEY);
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(14);
+    expect(parsed.version).toBe(15);
+  });
+});
+
+// ===========================================================================
+// v15 migration — htmlViewerAllowForms defaults to false on upgrade
+// ===========================================================================
+
+describe('v15 migration: htmlViewerAllowForms', () => {
+  function buildV14State(overrides: Record<string, unknown> = {}): string {
+    const state = {
+      theme: 'system',
+      logLevel: 'warn',
+      autoCheckUpdates: true,
+      releaseChannel: 'stable',
+      ...overrides,
+    };
+    return JSON.stringify({ state, version: 14 });
+  }
+
+  it('migrates v14 state without htmlViewerAllowForms to false', async () => {
+    localStorageMock.setItem(STORAGE_KEY, buildV14State());
+
+    await useSettingsStore.persist.rehydrate();
+    await waitForPersist();
+
+    expect(useSettingsStore.getState().htmlViewerAllowForms).toBe(false);
+  });
+
+  it('preserves existing htmlViewerAllowForms when already present', async () => {
+    localStorageMock.setItem(STORAGE_KEY, buildV14State({ htmlViewerAllowForms: true }));
+
+    await useSettingsStore.persist.rehydrate();
+    await waitForPersist();
+
+    expect(useSettingsStore.getState().htmlViewerAllowForms).toBe(true);
+  });
+
+  it('bumps persisted version to 15 after migration', async () => {
+    localStorageMock.setItem(STORAGE_KEY, buildV14State());
+
+    await useSettingsStore.persist.rehydrate();
+    await waitForPersist();
+
+    const raw = localStorageMock.getItem(STORAGE_KEY);
+    const parsed = JSON.parse(raw!);
+    expect(parsed.version).toBe(15);
   });
 });

--- a/src/stores/settings-store.ts
+++ b/src/stores/settings-store.ts
@@ -310,6 +310,13 @@ interface SettingsStore {
   setStartAtLogin: (start: boolean) => void;
   setNotifyAgentCompletion: (notify: boolean) => void;
   setNotifyExternalChanges: (notify: boolean) => void;
+  /**
+   * When true, the HTML viewer iframe includes `allow-forms` and
+   * `allow-top-navigation-by-user-activation` in its sandbox attribute so
+   * HTML forms can be submitted. Default false (forms are blocked).
+   */
+  htmlViewerAllowForms: boolean;
+  setHtmlViewerAllowForms: (enabled: boolean) => void;
 }
 
 export const useSettingsStore = create<SettingsStore>()(
@@ -723,10 +730,16 @@ export const useSettingsStore = create<SettingsStore>()(
       setNotifyExternalChanges: (notify: boolean) => {
         set({ notifyExternalChanges: notify });
       },
+
+      htmlViewerAllowForms: false,
+
+      setHtmlViewerAllowForms: (enabled: boolean) => {
+        set({ htmlViewerAllowForms: enabled });
+      },
     }),
     {
       name: "notesage-settings",
-      version: 14,
+      version: 15,
 
       migrate: (persisted: unknown, version: number) => {
         const state = persisted as Record<string, unknown>;
@@ -866,6 +879,13 @@ export const useSettingsStore = create<SettingsStore>()(
           // 'stable' so upgrading does not silently opt anyone into alpha.
           if (typeof state.releaseChannel !== 'string') {
             state.releaseChannel = 'stable';
+          }
+        }
+        if (version < 15) {
+          // Issue #186 — HTML viewer allow-forms. Default false (forms blocked)
+          // so existing users see no behaviour change after upgrade.
+          if (typeof state.htmlViewerAllowForms !== 'boolean') {
+            state.htmlViewerAllowForms = false;
           }
         }
         return state;


### PR DESCRIPTION
Resolves #186

## Summary

- Adds `htmlViewerAllowForms: boolean` to `settings-store` (default `false`, persist version bumped to 15) with a corresponding `setHtmlViewerAllowForms` action
- `HtmlViewer.tsx` reads the setting and composes the iframe `sandbox` attribute: when `false` (default) the sandbox is `allow-same-origin` (unchanged); when `true` it becomes `allow-same-origin allow-forms allow-top-navigation-by-user-activation`
- Settings UI: new **HTML viewer** group under Settings → System with an **Allow form submissions** toggle and a description warning that it should only be enabled for trusted HTML files
- Version 15 migration: adds `htmlViewerAllowForms: false` to persisted state that pre-dates this version (zero-change upgrade)

## Test plan

- [x] `src/components/editor/viewers/__tests__/HtmlViewer.test.tsx` — 4 new sandbox tests (default excludes `allow-forms`, opt-in includes `allow-forms` and `allow-top-navigation-by-user-activation`, always includes `allow-same-origin`)
- [x] `src/components/settings/v2/__tests__/panels.test.tsx` — smoke test: `SystemSettings` renders the HTML viewer group with the Allow form submissions label
- [x] `src/stores/__tests__/settings-store.test.ts` — v15 migration tests + existing version-assertion tests updated to `15`
- [x] Full test suite (`pnpm test`): 269 files, 4899 tests, all pass
- [x] Typecheck (`pnpm typecheck`): no errors