### PR TITLE
feat(html-viewer): add opt-in setting to block external resources via CSP

### DIFF
--- a/src/components/editor/viewers/HtmlViewer.tsx
+++ b/src/components/editor/viewers/HtmlViewer.tsx
@@ -5,6 +5,26 @@ import { FindBar } from "@/components/editor/FindBar";
 import { CodeEditor } from "./CodeEditor";
 import { useSettingsStore } from "@/stores/settings-store";
 
+/**
+ * CSP value used when "Block external resources" is enabled.
+ * Allows inline styles/scripts (needed for many self-contained HTML files),
+ * same-origin, data: URIs, and blob: URIs — but blocks all external http/https
+ * origins for images, stylesheets, fonts, and other resources.
+ */
+const BLOCK_EXTERNAL_CSP =
+  "default-src 'self' 'unsafe-inline' data: blob:; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline' data:; font-src 'self' data: blob:;";
+
+/**
+ * Pure helper — prepends a Content-Security-Policy `<meta>` tag to `content`
+ * when `blockExternalResources` is true. When false, returns `content`
+ * unchanged. Exported for unit testing.
+ */
+export function buildHtmlViewerContent(content: string, blockExternalResources: boolean): string {
+  if (!blockExternalResources) return content;
+  const cspMeta = `<meta http-equiv="Content-Security-Policy" content="${BLOCK_EXTERNAL_CSP}">`;
+  return cspMeta + content;
+}
+
 interface HtmlViewerProps {
   content: string;
   fileName: string;
@@ -25,6 +45,7 @@ export function HtmlViewer({
   saveFileWithContent,
 }: HtmlViewerProps) {
   const allowForms = useSettingsStore((s) => s.htmlViewerAllowForms);
+  const blockExternalResources = useSettingsStore((s) => s.htmlViewerBlockExternalResources);
   const [sourceMode, setSourceMode] = useState(false);
   const [findBarOpen, setFindBarOpen] = useState(false);
   const [searchMatches, setSearchMatches] = useState<HTMLElement[]>([]);
@@ -34,7 +55,9 @@ export function HtmlViewer({
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const searchMatchesRef = useRef<HTMLElement[]>([]);
 
-  // Write HTML into the sandboxed iframe when content or mode changes
+  // Write HTML into the sandboxed iframe when content or mode changes.
+  // When blockExternalResources is on, prepend a CSP meta tag so the browser
+  // refuses to load images, stylesheets, and fonts from external origins.
   useEffect(() => {
     if (sourceMode) return;
     const iframe = iframeRef.current;
@@ -42,9 +65,9 @@ export function HtmlViewer({
     const doc = iframe.contentDocument;
     if (!doc) return;
     doc.open();
-    doc.write(content);
+    doc.write(buildHtmlViewerContent(content, blockExternalResources));
     doc.close();
-  }, [content, sourceMode]);
+  }, [content, sourceMode, blockExternalResources]);
 
   // Reset search state when switching modes or content changes
   useEffect(() => {

--- a/src/components/editor/viewers/__tests__/HtmlViewer.test.tsx
+++ b/src/components/editor/viewers/__tests__/HtmlViewer.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
-import { HtmlViewer } from "../HtmlViewer";
+import { HtmlViewer, buildHtmlViewerContent } from "../HtmlViewer";
 import { PlainTextViewer } from "../PlainTextViewer";
 import { useSettingsStore } from "@/stores/settings-store";
 
@@ -199,6 +199,94 @@ describe("HtmlViewer sandbox attribute — htmlViewerAllowForms", () => {
     );
     const iframe = document.querySelector("iframe");
     expect(iframe).not.toBeNull();
+    const sandbox = iframe!.getAttribute("sandbox");
+    expect(sandbox).toContain("allow-same-origin");
+  });
+});
+
+describe("HtmlViewer — buildHtmlViewerContent CSP injection", () => {
+  it("returns content unchanged when blockExternalResources is false", () => {
+    const content = "<html><body><img src='https://example.com/img.png'/></body></html>";
+    const result = buildHtmlViewerContent(content, false);
+    expect(result).toBe(content);
+  });
+
+  it("prepends a CSP meta tag when blockExternalResources is true", () => {
+    const content = "<html><body><img src='https://example.com/img.png'/></body></html>";
+    const result = buildHtmlViewerContent(content, true);
+    expect(result).toContain("Content-Security-Policy");
+    expect(result).toContain("http-equiv");
+  });
+
+  it("CSP meta tag comes before the original content when blocking", () => {
+    const content = "<html><body>hello</body></html>";
+    const result = buildHtmlViewerContent(content, true);
+    const cspIndex = result.indexOf("Content-Security-Policy");
+    const htmlIndex = result.indexOf("<html>");
+    expect(cspIndex).toBeGreaterThanOrEqual(0);
+    // CSP meta should appear before the original html tag OR be embedded inside it
+    // (either prepended before, or injected into the <head>)
+    expect(cspIndex).toBeLessThan(htmlIndex + result.indexOf("hello"));
+  });
+
+  it("CSP blocks external images, stylesheets, and fonts but allows inline and data URIs", () => {
+    const content = "<html><body>test</body></html>";
+    const result = buildHtmlViewerContent(content, true);
+    // Should allow 'self', 'unsafe-inline', and data: while blocking external http
+    const cspTagMatch = result.match(/content="([^"]+)"/i);
+    expect(cspTagMatch).not.toBeNull();
+    const cspValue = cspTagMatch![1];
+    // Must not allow general https? origins
+    expect(cspValue).not.toContain("https:");
+    // Must allow same-origin or 'self' and inline
+    expect(cspValue).toMatch(/'self'|data:/);
+  });
+});
+
+describe("HtmlViewer — htmlViewerBlockExternalResources setting integration", () => {
+  const htmlContent = "<html><body><img src='https://example.com/img.png'/></body></html>";
+  const filePath = "/path/to/page.html";
+  const fileName = "page.html";
+
+  afterEach(() => {
+    useSettingsStore.setState({ htmlViewerBlockExternalResources: false } as Parameters<typeof useSettingsStore.setState>[0]);
+  });
+
+  it("renders the iframe normally when blockExternalResources is false (regression guard)", () => {
+    render(
+      <HtmlViewer
+        content={htmlContent}
+        fileName={fileName}
+        filePath={filePath}
+        tabId="tab-block-off"
+        isDirty={false}
+        updateTabContent={vi.fn()}
+        saveFileWithContent={vi.fn()}
+      />
+    );
+    const iframe = document.querySelector("iframe");
+    expect(iframe).not.toBeNull();
+    // Sandbox stays the same — allow-same-origin, no allow-scripts
+    const sandbox = iframe!.getAttribute("sandbox");
+    expect(sandbox).toContain("allow-same-origin");
+  });
+
+  it("renders the iframe with sandbox when blockExternalResources is true", () => {
+    useSettingsStore.setState({ htmlViewerBlockExternalResources: true } as Parameters<typeof useSettingsStore.setState>[0]);
+    render(
+      <HtmlViewer
+        content={htmlContent}
+        fileName={fileName}
+        filePath={filePath}
+        tabId="tab-block-on"
+        isDirty={false}
+        updateTabContent={vi.fn()}
+        saveFileWithContent={vi.fn()}
+      />
+    );
+    const iframe = document.querySelector("iframe");
+    expect(iframe).not.toBeNull();
+    // Sandbox still has allow-same-origin; CSP is in the written content, not the attribute
     const sandbox = iframe!.getAttribute("sandbox");
     expect(sandbox).toContain("allow-same-origin");
   });

--- a/src/components/settings/v2/SystemSettings.tsx
+++ b/src/components/settings/v2/SystemSettings.tsx
@@ -133,6 +133,8 @@ export function SystemSettings({
   // HTML viewer
   const htmlViewerAllowForms = useSettingsStore((s) => s.htmlViewerAllowForms);
   const setHtmlViewerAllowForms = useSettingsStore((s) => s.setHtmlViewerAllowForms);
+  const htmlViewerBlockExternalResources = useSettingsStore((s) => s.htmlViewerBlockExternalResources);
+  const setHtmlViewerBlockExternalResources = useSettingsStore((s) => s.setHtmlViewerBlockExternalResources);
 
   // Files
   const showHiddenFiles = useSettingsStore((s) => s.showHiddenFiles);
@@ -394,6 +396,18 @@ export function SystemSettings({
               id="html-viewer-allow-forms"
               checked={htmlViewerAllowForms}
               onCheckedChange={setHtmlViewerAllowForms}
+            />
+          }
+        />
+        <SettingsRow
+          label="Block external resources"
+          description="When on, a Content-Security-Policy is injected that prevents remote images, stylesheets, and fonts from loading. Inline styles and same-origin resources still work. Takes effect on the next file open or switch."
+          htmlFor="html-viewer-block-external"
+          control={
+            <Switch
+              id="html-viewer-block-external"
+              checked={htmlViewerBlockExternalResources}
+              onCheckedChange={setHtmlViewerBlockExternalResources}
             />
           }
         />

--- a/src/components/settings/v2/__tests__/panels.test.tsx
+++ b/src/components/settings/v2/__tests__/panels.test.tsx
@@ -68,6 +68,11 @@ describe('v2 settings panels', () => {
     expect(screen.getByText('Allow form submissions')).toBeTruthy();
   });
 
+  it('SystemSettings renders "Block external resources" toggle in the HTML viewer group', () => {
+    renderWithProviders(<SystemSettings />);
+    expect(screen.getByText('Block external resources')).toBeTruthy();
+  });
+
   it('SystemSettings renders "View update" affordance when an update is available', () => {
     renderWithProviders(
       <SystemSettings

--- a/src/stores/__tests__/settings-store.test.ts
+++ b/src/stores/__tests__/settings-store.test.ts
@@ -1113,7 +1113,7 @@ describe('uiPreview flag', () => {
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(15);
+    expect(parsed.version).toBe(16);
     expect(parsed.state.uiPreview).toBe('legacy');
     expect(parsed.state.accent).toBe('default');
   });
@@ -1255,7 +1255,7 @@ describe('v5 → v6 migration (cmdBarPinned + cmdBarPinnedWidth)', () => {
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(15);
+    expect(parsed.version).toBe(16);
     expect(parsed.state.cmdBarPinned).toBe(false);
     expect(parsed.state.cmdBarPinnedWidth).toBe(400);
   });
@@ -1401,7 +1401,7 @@ describe('v6 → v7 migration (quietChromePreset + quietChromeOverrides)', () =>
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(15);
+    expect(parsed.version).toBe(16);
     expect(parsed.state.quietChromePreset).toBe('default');
     expect(parsed.state.quietChromeOverrides).toBeTruthy();
   });
@@ -1720,7 +1720,7 @@ describe('v7 → v8 migration (sidebar composition)', () => {
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(15);
+    expect(parsed.version).toBe(16);
     expect(parsed.state.sidebarRecentCap).toBe(5);
     expect(parsed.state.sidebarTagsCap).toBe(5);
     // Hidden field stripped by v11 → v12 migration.
@@ -1975,7 +1975,7 @@ describe('v8 → v9 migration (preview invitation timestamps)', () => {
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(15);
+    expect(parsed.version).toBe(16);
     expect(parsed.state.previewInvitationShownAt).toBeNull();
     expect(parsed.state.previewInvitationDismissedAt).toBeNull();
   });
@@ -2077,7 +2077,7 @@ describe('v9 → v10 migration (cmdBarExpandedWidth)', () => {
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(15);
+    expect(parsed.version).toBe(16);
     expect(parsed.state.cmdBarExpandedWidth).toBe(640);
   });
 
@@ -2148,7 +2148,7 @@ describe('v10 → v11 migration (sidebar Mentions composition)', () => {
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(15);
+    expect(parsed.version).toBe(16);
     expect(parsed.state.sidebarMentionsCap).toBe(5);
     expect(parsed.state.sidebarMentionsHidden).toBeUndefined();
   });
@@ -2270,7 +2270,7 @@ describe('v11 → v12 migration (drop Hidden booleans)', () => {
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(15);
+    expect(parsed.version).toBe(16);
     expect(parsed.state.sidebarTagsCap).toBe(0);
     expect(parsed.state.sidebarTagsHidden).toBeUndefined();
   });
@@ -2292,7 +2292,7 @@ describe('v11 → v12 migration (drop Hidden booleans)', () => {
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(15);
+    expect(parsed.version).toBe(16);
     expect(parsed.state.sidebarMentionsCap).toBe(0);
     expect(parsed.state.sidebarMentionsHidden).toBeUndefined();
   });
@@ -2318,7 +2318,7 @@ describe('v11 → v12 migration (drop Hidden booleans)', () => {
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(15);
+    expect(parsed.version).toBe(16);
     expect(parsed.state.sidebarTagsHidden).toBeUndefined();
     expect(parsed.state.sidebarMentionsHidden).toBeUndefined();
   });
@@ -2452,7 +2452,7 @@ describe('v14 migration: releaseChannel', () => {
     expect(useSettingsStore.getState().releaseChannel).toBe('alpha');
   });
 
-  it('bumps persisted version to 15 after migration', async () => {
+  it('bumps persisted version to current (16) after migration', async () => {
     localStorageMock.setItem(STORAGE_KEY, buildV13State());
 
     await useSettingsStore.persist.rehydrate();
@@ -2460,7 +2460,7 @@ describe('v14 migration: releaseChannel', () => {
 
     const raw = localStorageMock.getItem(STORAGE_KEY);
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(15);
+    expect(parsed.version).toBe(16);
   });
 });
 
@@ -2498,7 +2498,7 @@ describe('v15 migration: htmlViewerAllowForms', () => {
     expect(useSettingsStore.getState().htmlViewerAllowForms).toBe(true);
   });
 
-  it('bumps persisted version to 15 after migration', async () => {
+  it('bumps persisted version to current (16) after migration', async () => {
     localStorageMock.setItem(STORAGE_KEY, buildV14State());
 
     await useSettingsStore.persist.rehydrate();
@@ -2506,6 +2506,74 @@ describe('v15 migration: htmlViewerAllowForms', () => {
 
     const raw = localStorageMock.getItem(STORAGE_KEY);
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(15);
+    expect(parsed.version).toBe(16);
+  });
+});
+
+// ===========================================================================
+// htmlViewerBlockExternalResources — default value and setter
+// ===========================================================================
+
+describe('htmlViewerBlockExternalResources default and setter', () => {
+  it('defaults to false (external resources allowed by default)', () => {
+    expect(useSettingsStore.getState().htmlViewerBlockExternalResources).toBe(false);
+  });
+
+  it('setHtmlViewerBlockExternalResources(true) enables blocking', () => {
+    useSettingsStore.getState().setHtmlViewerBlockExternalResources(true);
+    expect(useSettingsStore.getState().htmlViewerBlockExternalResources).toBe(true);
+  });
+
+  it('setHtmlViewerBlockExternalResources(false) disables blocking', () => {
+    useSettingsStore.setState({ htmlViewerBlockExternalResources: true } as Parameters<typeof useSettingsStore.setState>[0]);
+    useSettingsStore.getState().setHtmlViewerBlockExternalResources(false);
+    expect(useSettingsStore.getState().htmlViewerBlockExternalResources).toBe(false);
+  });
+});
+
+// ===========================================================================
+// v16 migration — htmlViewerBlockExternalResources defaults to false on upgrade
+// ===========================================================================
+
+describe('v16 migration: htmlViewerBlockExternalResources', () => {
+  function buildV15State(overrides: Record<string, unknown> = {}): string {
+    const state = {
+      theme: 'system',
+      logLevel: 'warn',
+      autoCheckUpdates: true,
+      releaseChannel: 'stable',
+      htmlViewerAllowForms: false,
+      ...overrides,
+    };
+    return JSON.stringify({ state, version: 15 });
+  }
+
+  it('migrates v15 state without htmlViewerBlockExternalResources to false', async () => {
+    localStorageMock.setItem(STORAGE_KEY, buildV15State());
+
+    await useSettingsStore.persist.rehydrate();
+    await waitForPersist();
+
+    expect(useSettingsStore.getState().htmlViewerBlockExternalResources).toBe(false);
+  });
+
+  it('preserves existing htmlViewerBlockExternalResources when already present', async () => {
+    localStorageMock.setItem(STORAGE_KEY, buildV15State({ htmlViewerBlockExternalResources: true }));
+
+    await useSettingsStore.persist.rehydrate();
+    await waitForPersist();
+
+    expect(useSettingsStore.getState().htmlViewerBlockExternalResources).toBe(true);
+  });
+
+  it('bumps persisted version to 16 after migration', async () => {
+    localStorageMock.setItem(STORAGE_KEY, buildV15State());
+
+    await useSettingsStore.persist.rehydrate();
+    await waitForPersist();
+
+    const raw = localStorageMock.getItem(STORAGE_KEY);
+    const parsed = JSON.parse(raw!);
+    expect(parsed.version).toBe(16);
   });
 });

--- a/src/stores/settings-store.ts
+++ b/src/stores/settings-store.ts
@@ -317,6 +317,16 @@ interface SettingsStore {
    */
   htmlViewerAllowForms: boolean;
   setHtmlViewerAllowForms: (enabled: boolean) => void;
+  /**
+   * When true, a Content-Security-Policy meta tag is injected into the HTML
+   * viewer iframe's content before it is written, blocking external network
+   * requests for images, stylesheets, and fonts. Inline styles/scripts and
+   * same-origin (data:, blob:) resources are still allowed. Default false.
+   * Takes effect on the next file open or file switch — not retroactively
+   * for an already-rendered document.
+   */
+  htmlViewerBlockExternalResources: boolean;
+  setHtmlViewerBlockExternalResources: (enabled: boolean) => void;
 }
 
 export const useSettingsStore = create<SettingsStore>()(
@@ -736,10 +746,16 @@ export const useSettingsStore = create<SettingsStore>()(
       setHtmlViewerAllowForms: (enabled: boolean) => {
         set({ htmlViewerAllowForms: enabled });
       },
+
+      htmlViewerBlockExternalResources: false,
+
+      setHtmlViewerBlockExternalResources: (enabled: boolean) => {
+        set({ htmlViewerBlockExternalResources: enabled });
+      },
     }),
     {
       name: "notesage-settings",
-      version: 15,
+      version: 16,
 
       migrate: (persisted: unknown, version: number) => {
         const state = persisted as Record<string, unknown>;
@@ -886,6 +902,14 @@ export const useSettingsStore = create<SettingsStore>()(
           // so existing users see no behaviour change after upgrade.
           if (typeof state.htmlViewerAllowForms !== 'boolean') {
             state.htmlViewerAllowForms = false;
+          }
+        }
+        if (version < 16) {
+          // Issue #183 — HTML viewer block external resources. Default false
+          // (external resources allowed) so existing users see no behaviour
+          // change after upgrade.
+          if (typeof state.htmlViewerBlockExternalResources !== 'boolean') {
+            state.htmlViewerBlockExternalResources = false;
           }
         }
         return state;


### PR DESCRIPTION
Resolves #183

## Summary

Adds a "Block external resources" toggle to the HTML viewer section in System Settings (default OFF). When enabled, a Content-Security-Policy meta tag is injected into the HTML viewer iframe's content before rendering, preventing the browser from fetching external images, stylesheets, and fonts. Inline styles, data URIs, blob URIs, and same-origin resources continue to work. The setting takes effect on the next file open or file switch.

## Red tests added

- `HtmlViewer.test.tsx::buildHtmlViewerContent returns content unchanged when blockExternalResources is false` — regression guard: no-op when blocking is off
- `HtmlViewer.test.tsx::buildHtmlViewerContent prepends a CSP meta tag when blockExternalResources is true` — CSP meta tag is present when blocking is on
- `HtmlViewer.test.tsx::buildHtmlViewerContent CSP meta tag comes before the original content when blocking` — meta tag position in the output string
- `HtmlViewer.test.tsx::buildHtmlViewerContent CSP blocks external images, stylesheets, and fonts but allows inline and data URIs` — CSP value does not contain `https:` and does contain `'self'` / `data:`
- `HtmlViewer.test.tsx::HtmlViewer renders the iframe normally when blockExternalResources is false (regression guard)` — component-level: iframe still renders when setting is off
- `HtmlViewer.test.tsx::HtmlViewer renders the iframe with sandbox when blockExternalResources is true` — component-level: iframe renders with allow-same-origin when setting is on
- `settings-store.test.ts::htmlViewerBlockExternalResources defaults to false` — initial state default
- `settings-store.test.ts::setHtmlViewerBlockExternalResources(true) enables blocking` — setter round-trip
- `settings-store.test.ts::setHtmlViewerBlockExternalResources(false) disables blocking` — setter round-trip
- `settings-store.test.ts::v16 migration: migrates v15 state without htmlViewerBlockExternalResources to false` — upgrade migration
- `settings-store.test.ts::v16 migration: bumps persisted version to 16` — version bump
- `panels.test.tsx::SystemSettings renders "Block external resources" toggle in the HTML viewer group` — UI smoke test

## Green implementation

- **`src/stores/settings-store.ts`**: Added `htmlViewerBlockExternalResources: boolean` (default `false`) to the `SettingsStore` interface and initial state; added `setHtmlViewerBlockExternalResources` setter; bumped store version from 15 → 16; added v16 migration block that defaults missing field to `false`; updated all existing migration tests to expect version 16 (they previously asserted the current-at-the-time value of 15)
- **`src/components/editor/viewers/HtmlViewer.tsx`**: Added exported `buildHtmlViewerContent(content, blockExternalResources)` pure helper that prepends a CSP meta tag when blocking is on; reads `htmlViewerBlockExternalResources` from settings-store; calls helper in the `useEffect` that writes to `doc.write()`; added `blockExternalResources` to the dependency array
- **`src/components/settings/v2/SystemSettings.tsx`**: Added "Block external resources" `SettingsRow` with `Switch` to the existing HTML viewer group, wired to `htmlViewerBlockExternalResources` / `setHtmlViewerBlockExternalResources`

## Refactor

Skipped — implementation is already minimal. The `BLOCK_EXTERNAL_CSP` constant and `buildHtmlViewerContent` helper are extracted at the module level, which is the natural decomposition.

## Decisions made

- **Settings placement** | HTML viewer group in SystemSettings (General/System panel) | The issue body noted "System → HTML viewer" as the desired location, and the HTML viewer group already exists in SystemSettings for the allow-forms toggle from #186. Co-locating the two HTML viewer settings is the obvious grouping.
- **CSP value** | `default-src 'self' 'unsafe-inline' data: blob:; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline' data:; font-src 'self' data: blob:;` | The issue specified "inline `<style>` blocks and same-directory resources still render correctly". `'unsafe-inline'` is required for inline `<style>` tags. `data:` and `blob:` allow embedded images/fonts. This blocks all external http/https origins without breaking self-contained HTML files.
- **CSP injection via string prepend** | Prepend `<meta http-equiv="Content-Security-Policy" ...>` before `doc.write()` | Browsers apply the first CSP meta tag they encounter; prepending ensures it takes precedence over any CSP tags already in the HTML content. Avoids HTML parsing complexity.

## Verification

- [x] Red tests were red before implementation (`buildHtmlViewerContent is not a function`, `htmlViewerBlockExternalResources is undefined`, `Block external resources not found in DOM`)
- [x] All red tests now green (18 HtmlViewer tests, 178 settings-store tests, 8 panel tests)
- [x] `pnpm test` passes (4912 tests, 269 test files)
- [x] `pnpm typecheck` clean
- [x] No unrelated files modified (6 files: 3 source + 3 test, all listed above)

## Notes for reviewer

- The v16 migration correctly handles the three cases: existing users get `false` (default-off), users who already had the field set (from a future downgrade scenario) keep their value, and the persisted version bumps to 16.
- All prior migration tests that asserted `version === 15` have been updated to `version === 16` since the store now lives at v16. This is the correct pattern — each version bump updates ALL the "bumps to current version" assertions in the test file.
- The `buildHtmlViewerContent` function is exported from `HtmlViewer.tsx` (not from a separate lib) to keep the CSP logic co-located with the component that uses it and to make it directly importable in the test without indirection.
- The CSP injection does not affect the sandbox attribute — it operates at the document-content level. The two security mechanisms are complementary: sandbox blocks scripts/navigation/forms; CSP blocks external resource fetches.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the `aw-tdd` skill.