### PR TITLE
fix(aw): aw-review filter matches claude/* branch prefix, not PR author

### DIFF
--- a/.github/workflows/aw-review.yml
+++ b/.github/workflows/aw-review.yml
@@ -34,15 +34,19 @@ concurrency:
 
 jobs:
   review:
-    # Only on bot-authored draft PRs (workflow_dispatch always passes since
-    # it explicitly targets a PR). The pre-flight inside the skill double-
-    # checks; this `if:` saves a runner spin-up on human-authored PRs.
+    # Only on bot-authored draft PRs. Match by BRANCH PREFIX (`claude/*`),
+    # not by PR author. After the WORKFLOW_PAT switch (commit #118),
+    # `aw-tdd`-created PRs are authored by the human PAT owner, not by
+    # `github-actions[bot]`, so the old author-based filter rejected
+    # every bot PR and aw-review silently skipped them. `claude-code-action`
+    # uses the `claude/` branch prefix unconditionally for bot pipelines,
+    # so the prefix is the reliable bot-PR marker. workflow_dispatch always
+    # passes since it explicitly targets a PR. The pre-flight inside the
+    # skill double-checks the branch / event shape.
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event.pull_request.draft == true &&
-       (github.event.pull_request.user.login == 'github-actions[bot]' ||
-        github.event.pull_request.user.login == 'claude[bot]' ||
-        github.event.pull_request.user.login == 'app/claude'))
+       startsWith(github.event.pull_request.head.ref, 'claude/'))
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
## Summary

Unblock `aw-review.yml` so existing and future bot-authored draft PRs actually get reviewed and flipped to ready.

## The bug

After the WORKFLOW_PAT switch (per `docs/agentic-workflow.md` § "WORKFLOW_PAT for bot-PR CI gating"), PRs created by `aw-tdd` / `aw-iterate` / `aw-retrospect` are authored by the human PAT owner, not by `github-actions[bot]`. The previous author-based `if:` filter rejected every one of them:

\`\`\`yaml
github.event.pull_request.user.login == 'github-actions[bot]' ||
github.event.pull_request.user.login == 'claude[bot]' ||
github.event.pull_request.user.login == 'app/claude'
\`\`\`

Every recent `aw-review` run shows `completed/skipped` because the if-clause didn't accept the PAT-owner author. Result: open bot PRs (#190, #192, #174) stuck in draft indefinitely.

## The fix

Match by branch prefix instead. `claude-code-action` uses `claude/*` unconditionally for bot pipelines, so the prefix is the reliable bot-PR marker that survives the PAT-vs-bot-token authorship difference:

\`\`\`yaml
startsWith(github.event.pull_request.head.ref, 'claude/')
\`\`\`

The pre-flight inside the `aw-review` skill still double-checks the event shape.

## Test plan

- [ ] Merge → re-trigger aw-review on the three currently stuck PRs (#190, #192, #174) via `workflow_dispatch`
- [ ] Each PR should get an aw-review checklist comment + `gh pr ready` if clean, or close+reset to `tdd + afk` if gaps found
- [ ] Next bot-authored PR opens → aw-review fires automatically without needing manual dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)