### PR TITLE
docs(prd): aw-ci-repair — auto-fix recurring CI perf-budget flakes

### DIFF
--- a/docs/prds/2026-05-11-aw-ci-repair.md
+++ b/docs/prds/2026-05-11-aw-ci-repair.md
@@ -1,0 +1,275 @@
+# PRD: AW CI Repair — auto-fix recurring perf-budget flakes
+
+|  |  |
+| --- | --- |
+| **Date** | 2026-05-11 |
+| **Status** | Draft |
+| **Priority** | Medium — pipeline-quality work. The current shape is "bot opens PR, CI fails on a known recoverable issue, human spends 5 minutes on a one-line fix, bot PR re-runs". Three of the last five bot PRs hit this pattern. |
+| **Impact** | Bot-authored PRs that fail CI on a known recoverable pattern self-heal: a follow-up commit lands, CI re-runs, the human sees a green PR ready for review instead of a red one needing intervention. New tests can't introduce the same class of flake — a lint rule blocks the pattern at PR-write time. |
+| **Trigger** | PR #191 CI failed three times across retries on `preview-fidelity.spec.ts:331` — `expect(p95).toBeLessThan(500)` against CI macos-latest pace, which lands p95 at 519–715 ms. The fix is one line: honour `PERF_BUDGET_MULTIPLIER` the same way the Vitest perf harness does. The test author already documented the CI pace drift in a sample-count tuning comment (line 306–309) but never patched the budget itself. v0.44.0-alpha.0 release CI hit the same shape on a different test (status-tray segmented picker click). |
+| **Tasks** | [aw-ci-repair-tasks](../tasks/2026-05-11-aw-ci-repair-tasks.md) |
+| **Phase** | AW pipeline maintenance |
+
+## Problem
+
+The AW pipeline (issue → triage → refine → slice → tdd → review → merge) optimises for the bot doing the work and a human doing the merge. The bot is good at writing tests for new behaviour. It is bad at noticing that its test will flake on CI because the absolute budget doesn't account for runner-pace drift.
+
+**Concretely:** every recent bot-authored PR with a perf assertion has either:
+
+1. Hardcoded a numeric literal (`expect(...).toBeLessThan(500)`) inside `e2e/**` or `src/perf/**` without wrapping it in `PERF_BUDGET_MULTIPLIER`, OR
+2. Written the assertion in a file whose workflow job doesn't set `PERF_BUDGET_MULTIPLIER` (e.g. the Playwright e2e job — `PERF_BUDGET_MULTIPLIER=3` was only set on the frontend Vitest job before commit `c43b286a`).
+
+Both shapes fail on CI runners that pace `setTimeout` ~1.5x slower than local AND share the runner with other jobs. The fix is a known migration: read the env var, multiply the budget, set the env var in the workflow file. Always identical. Always one-line.
+
+The cost of these flakes isn't the CI minutes — it's the human cycle time. The user merges a bot PR, the bot opens the next PR five minutes later, that PR fails CI on a perf budget, the user has to context-switch into the failure log, identify the pattern, write the fix, push. Repeat. The aw-review skill explicitly does NOT touch code (read-only by design), so it can't pick this up.
+
+Two failure shapes that look similar but should NOT be auto-fixed:
+
+- **Snapshot drift** — `toMatchSnapshot` failure means the rendered output changed. Auto-accepting silently launders regressions. Human review only.
+- **DOM-changed assertions** — `getByRole('radio')` failing after a component switched from RadioGroup to Select (alpha.0's StatusTray case) is not a flake; it's a test asserting stale DOM. Auto-fixing this would mean rewriting the test logic, which is closer to "implement the feature again" than to "apply a known migration".
+
+The narrow scope below picks the one pattern that is reliably mechanical and high-frequency.
+
+## Goals / Non-Goals
+
+### Goals
+
+1. **Prevent new hardcoded perf budgets.** A custom ESLint rule flags any `expect(...).toBeLessThan(<numeric literal>)` inside `e2e/**/*.spec.ts` or `src/perf/**/*.ts` unless the literal is multiplied by `PERF_BUDGET_MULTIPLIER` (or wrapped in a helper that does). PRs that introduce the pattern fail lint at PR-write time. ESLint runs as part of typecheck/test CI today; no new pipeline step needed.
+2. **Auto-fix existing missing-multiplier failures on bot PRs.** A new `aw-ci-repair` skill triggered by `check_run.completed: failure` (or `workflow_run.completed: failure`) on a bot-authored draft PR's HEAD commit. Pattern-matches one shape only: `expect(N).toBeLessThan(M)` where `N` is within a small multiple of `M`, the assertion is in a perf-related file, and the test is missing the multiplier wrap. Patches the test, ensures the workflow env var is set, pushes one follow-up commit on the same branch.
+3. **Bound the retry blast radius.** One repair attempt per PR. If the same job fails again after the repair commit, fall through to a human comment ("Repair attempted; failure persists — needs human review"). Never two repair commits on one PR.
+4. **Be invisible when there's nothing to fix.** Non-bot PRs are ignored. Failures outside the pattern list post a one-liner comment naming the shape ("Snapshot drift — needs human") and exit. No file changes, no force-pushes.
+5. **Document every repair.** The repair commit body names the pattern, links to the failed run, and shows the diff in plain English. Future retros can see how often the repair fires and on what surfaces.
+
+### Non-Goals
+
+- **Auto-bumping hardcoded thresholds.** "test failed at 715ms against a 500ms budget, so raise the budget to 800ms" hides regressions. The fix is to honour the multiplier; the underlying threshold stays put.
+- **Auto-updating snapshots.** Same reason. `toMatchSnapshot` / `toMatchInlineSnapshot` failures fall through to human review.
+- **Auto-fixing DOM-changed assertions.** `getByRole` / `getByText` failures after a component refactor mean the test is asserting stale DOM. Rewriting the assertion is "what the test should now check", which requires reading the diff and the component — out of scope for a mechanical repair skill.
+- **Repair on human PRs.** Out of scope; humans can read the failure logs themselves.
+- **More than one repair attempt per PR.** A second repair on a freshly-failed run risks loops on a genuinely-regressed test.
+- **Repairing failures in workflow / config files** (`.github/workflows/`, `package.json`, etc.). Workflow-yml edits ARE in scope where the missing-multiplier env var needs to be added to a job — but only as part of the same repair, never as a standalone fix.
+- **A general-purpose "fix any failing test" skill.** This PRD is scoped to ONE pattern. Future PRDs may add more patterns (e.g. type-only fixes — `pnpm typecheck` failures from a missing import) but each new pattern requires its own design review.
+
+## User Stories
+
+- **As Notesage's owner**, when a bot-authored draft PR fails CI on a perf-budget flake, I want the bot to push the one-line fix itself and have CI re-run, so that I don't have to context-switch into a known-recoverable failure to type the same fix again.
+- **As Notesage's owner**, when a bot-authored draft PR fails CI on a NON-recoverable shape (snapshot drift, DOM-changed assertion), I want a one-line comment on the PR explaining why repair didn't fire, so that I know to take a closer look.
+- **As a future contributor**, I want lint to fail my PR at write time if I add a hardcoded perf budget, so that I don't ship the bug class in the first place.
+- **As the AW retrospect skill**, I want repair commits to be self-describing (named pattern, linked run, plain-English diff), so that retro can ask "is this pattern occurring often enough to warrant a different fix?"
+
+## Technical Approach
+
+The system is two independent pieces that compose: prevention (ESLint) keeps the bug class from growing; repair (`aw-ci-repair`) drains the existing tail without human cycles.
+
+### Piece 1 — Regression-lock test: `no-bare-perf-budget`
+
+The project does NOT have ESLint set up (no `eslint.config.*`, no `lint` script in `package.json`). Adding ESLint + a custom rule + a CI step is significant plumbing for a single rule. Notesage already uses a parallel pattern — vitest-based regression-lock tests that parse source files and assert conventions hold. Examples: `aw-workflow-concurrency.test.ts`, `aw-workflow-pat.test.ts`, `tauri-capability-surface.test.ts`.
+
+A new test at `src/lib/__tests__/no-bare-perf-budget.test.ts` walks every file in `e2e/**/*.spec.ts` and `src/perf/**/*.ts`, looks for `expect(...).toBeLessThan(<number>)` (and the sibling matchers — `toBeLessThanOrEqual`, `toBeGreaterThan` for upper-bound durations), and asserts that the argument is NOT a bare numeric literal — it must be a `BinaryExpression` whose operand chain references `PERF_BUDGET_MULTIPLIER`. Approach options for parsing:
+
+- Use the TypeScript compiler API directly (already a dev dep; `ts-morph` would be heavier).
+- Simpler: regex-based parse since the patterns we're checking are syntactically narrow. Mirror the regex shape used in the existing aw-workflow tests.
+
+Whichever approach is chosen, the test fails when:
+
+1. An existing file is edited to introduce a new bare-literal assertion.
+2. A new file is added with the bare-literal pattern.
+
+Companion docs in the test header explain how to fix (the same wrap that `c43b286a` applied to `preview-fidelity.spec.ts:331`). No autofix — failing the test is enough signal at PR-write time.
+
+If ESLint is added to the project for other reasons later, this rule can be migrated then; until then, the vitest regression-lock matches the existing project convention.
+
+### Piece 2 — `aw-ci-repair` skill
+
+Lives at `.claude/skills/aw-ci-repair/SKILL.md` and is driven by `.github/workflows/aw-ci-repair.yml`.
+
+**Trigger:**
+
+```yaml
+on:
+  workflow_run:
+    workflows: ["Test", "Release"]   # the workflow names of CI runs we care about
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to repair (manual override)"
+        required: true
+```
+
+Why `workflow_run` and not `check_run.completed`: `workflow_run` is the modern, documented trigger that gives the failed workflow's PR number via `workflow_run.pull_requests[0]`. `check_run` is per-job and would fire multiple times for the same failure.
+
+**Job-level guards (cheap precheck before the LLM):**
+
+```yaml
+if: >
+  github.event_name == 'workflow_dispatch' ||
+  (github.event.workflow_run.conclusion == 'failure' &&
+   github.event.workflow_run.event == 'pull_request' &&
+   startsWith(github.event.workflow_run.head_branch, 'claude/'))
+```
+
+The branch-prefix filter is the same one `aw-review` uses to gate bot-authored PRs (see `aw-review.yml:46-49`).
+
+**Hard guard inside the skill (pre-LLM bash):**
+
+1. `gh pr view $PR_NUMBER --json author,headRefName,labels,isDraft` — verify draft + bot identity. Exit silently otherwise.
+2. `gh pr view $PR_NUMBER --json comments -q '[.comments[] | select(.body | startswith("> *Repair attempted by `aw-ci-repair`"))]' | jq 'length'` — count prior repair attempts on this PR. If ≥1, exit silently (one-attempt cap).
+3. Fetch the failed run's logs: `gh run view $RUN_ID --log-failed | head -200`. Pipe through `grep -E '^.*Error:|toBeLessThan|expect\('` to extract the failing assertion lines.
+
+**LLM-driven pattern match:**
+
+The skill (markdown body) prescribes:
+
+1. Read the failed log lines. Identify ONE pattern from the list below. If no match, post a comment ("Failure shape not in repair list — needs human review: $SHAPE_NAME") and exit.
+2. **Pattern A — missing PERF_BUDGET_MULTIPLIER in the assertion.** Symptoms: `expect(N).toBeLessThan(M)` where `N` is in the range `[M, M*5]`, file path is in `e2e/**` or `src/perf/**`. Fix: wrap the literal in `<M> * (Number(process.env.PERF_BUDGET_MULTIPLIER) || 1)`. Add a one-line comment above the assertion explaining the wrap.
+3. **Pattern B — workflow job missing the env var.** Detection: after applying pattern A, grep the workflow file that runs the failing test for `PERF_BUDGET_MULTIPLIER`. If absent on the relevant job, add `env: { PERF_BUDGET_MULTIPLIER: "3" }` to the failing step. Use the same `"3"` as the existing frontend job (the chosen CI margin).
+4. Run `pnpm typecheck` AND the targeted failing spec (`pnpm vitest run <file>` or `pnpm test:e2e -- <file>`) — both must pass before commit.
+5. `git commit -m "fix(ci): honour PERF_BUDGET_MULTIPLIER in $FILE (auto-repair on PR #$N)"` + `git push origin $BRANCH`.
+6. Post a structured comment on the PR documenting the repair (pattern matched, file changed, failed-run link).
+
+**Hard gates (same shape as `aw-tdd`'s gate set):**
+
+- `pnpm typecheck` — must pass after the change.
+- The specific failing spec — must pass on the local repair runner.
+- Modified files must be ≤2 (one test file + optionally one workflow yml). More than that means the pattern match was wrong; revert + exit + post comment.
+- No `git push --force` ever. New commits on top of the PR branch only.
+
+**Bot identity:** uses `WORKFLOW_PAT` (same as `aw-tdd` / `aw-iterate`) so the push fires `pull_request: synchronize` and CI re-runs naturally. The recursion-guard discussion from `docs/agentic-workflow.md` ("Choice: WORKFLOW_PAT for bot-PR CI gating") applies as-is.
+
+**Concurrency group:** `aw-stage-ci-repair-${{ github.event.workflow_run.head_branch }}` with `cancel-in-progress: false`. One repair per branch at a time, queued not killed. This is the same pattern as the other aw-* workflows (see "Choice: shared `aw-stage-{stage}-{issue}` concurrency group" in `docs/agentic-workflow.md`).
+
+### Pattern list (initial)
+
+| Pattern | Detection | Repair | Auto? |
+| --- | --- | --- | --- |
+| **A — missing multiplier in test** | `expect(N).toBeLessThan(M)` in `e2e/**` or `src/perf/**`, N ≤ M*5, no `PERF_BUDGET_MULTIPLIER` reference in same expression | Wrap literal: `M * (Number(process.env.PERF_BUDGET_MULTIPLIER) || 1)` | ✅ |
+| **B — missing env var in workflow job** | Detected as part of A; workflow yml job missing `PERF_BUDGET_MULTIPLIER` | Add `env: { PERF_BUDGET_MULTIPLIER: "3" }` to the failing step | ✅ (paired with A) |
+| **C — snapshot drift** | `toMatchSnapshot` / `toMatchInlineSnapshot` failure | Comment: "Snapshot drift — needs human review" | ❌ |
+| **D — DOM-changed assertion** | `Unable to find element with role/text "X"` | Comment: "Test asserts DOM that no longer exists — likely needs to follow a refactor in the same PR" | ❌ |
+| **E — anything else** | Default | Comment: "Failure shape not in repair list" | ❌ |
+
+The PRD ships with patterns A + B autofixing; C / D / E only post a comment and never touch code. Future PRDs may move C / D into auto-fix scope with explicit safety analysis per pattern.
+
+### Why not a generic "fix the test" skill
+
+The temptation is to give the LLM the failed log and let it figure out the fix. Three reasons that's worse:
+
+1. **Loops.** A generic fixer that gets the diagnosis subtly wrong creates a new commit, CI fails differently, the fixer tries again, etc. The one-pattern-per-PRD scope structurally prevents this.
+2. **Hiding regressions.** Snapshot updates and threshold bumps are the most-tempting low-effort fixes the LLM would propose, AND the most-dangerous to land silently. Forbidding them in the skill rules is more reliable than asking the LLM to be cautious.
+3. **Auditability.** When repair fires, the human should be able to read the commit message ("Pattern A: missing multiplier in 1 file") and know what happened without diffing. Generic repair commits drift toward "fix tests" which is not auditable.
+
+## UI/UX
+
+This is pipeline infrastructure — there's no Notesage UI. The visible surface is the PR conversation:
+
+- **On successful repair:** a new commit appears on the PR. The repair workflow posts a comment:
+  > **🔧 Auto-repair applied — pattern A (missing PERF_BUDGET_MULTIPLIER)**
+  >
+  > File: `e2e/tests/preview-fidelity.spec.ts`
+  > Failure: `expect(p95).toBeLessThan(500)` → observed 715 ms on CI macos-latest.
+  > Fix: wrapped budget as `500 * (Number(process.env.PERF_BUDGET_MULTIPLIER) || 1)`.
+  >
+  > Linked failure: [Test #25652369214](https://...)
+  >
+  > CI will re-run automatically. If the same failure repeats, no further repair attempts will be made.
+- **On unrepairable failure:** a single comment:
+  > **❌ Auto-repair could not apply — pattern: snapshot drift**
+  >
+  > File: `src/components/__tests__/StatusTray.test.tsx`
+  > This failure shape is not in the auto-repair list. A human reviewer should investigate.
+  >
+  > Linked failure: [Test #25652369214](https://...)
+- **On a PR already at the one-attempt cap:** no comment, no action. The original repair comment + the persistent CI failure together signal "this needs human eyes" — no need to add more noise.
+
+## Data Model
+
+No new TypeScript interfaces or Zustand stores. Pure pipeline work.
+
+New regression-lock test:
+
+```ts
+// src/lib/__tests__/no-bare-perf-budget.test.ts
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { globSync } from "glob";
+
+// Sibling shape to aw-workflow-pat.test.ts: walk a fixed file set, regex-parse,
+// assert convention.
+const PERF_FILES = [
+  ...globSync("e2e/**/*.spec.ts"),
+  ...globSync("src/perf/**/*.{ts,test.ts}"),
+];
+
+const MATCHERS = ["toBeLessThan", "toBeLessThanOrEqual", "toBeGreaterThan"];
+const BARE_LITERAL = new RegExp(
+  `\\.(?:${MATCHERS.join("|")})\\(\\s*(\\d+(?:\\.\\d+)?)\\s*\\)`,
+  "g",
+);
+
+describe("perf-test budgets honor PERF_BUDGET_MULTIPLIER", () => {
+  it.each(PERF_FILES)("%s uses scaled budgets", (file) => {
+    const src = readFileSync(file, "utf8");
+    const matches = [...src.matchAll(BARE_LITERAL)];
+    expect(matches, `bare numeric budget in ${file} — wrap as N * (Number(process.env.PERF_BUDGET_MULTIPLIER) || 1)`)
+      .toHaveLength(0);
+  });
+});
+```
+
+New skill file: `.claude/skills/aw-ci-repair/SKILL.md` (~120 lines, mirroring `aw-iterate`'s shape).
+
+New workflow file: `.github/workflows/aw-ci-repair.yml` (~70 lines, mirroring `aw-iterate.yml`'s shape).
+
+Regression-lock test: `src/lib/__tests__/aw-workflow-ci-repair.test.ts` — asserts the workflow's `if:` clause matches the documented gate (parallel to `aw-workflow-concurrency.test.ts` and `aw-workflow-pat.test.ts`).
+
+## Dependencies
+
+- **No new runtime libraries.** Custom ESLint rule uses the existing `@typescript-eslint/parser` AST shapes.
+- **`WORKFLOW_PAT`** repo secret (already provisioned for aw-tdd / aw-iterate / aw-retrospect — see `docs/agentic-workflow.md` "Choice: WORKFLOW_PAT for bot-PR CI gating").
+- **No new external services.** The skill only uses `gh` CLI + filesystem ops.
+
+## Quality Gates
+
+### Functional
+
+- [ ] Regression-lock test `no-bare-perf-budget.test.ts` exists and fails when a bare numeric literal is the argument to `toBeLessThan` / `toBeLessThanOrEqual` / `toBeGreaterThan` inside `e2e/**` or `src/perf/**`.
+- [ ] Test passes against current `main` (any existing tests with bare budgets are wrapped as part of the same PR — audit step lands first).
+- [ ] Test runs as part of `pnpm test` (no new CI step needed).
+- [ ] `aw-ci-repair` skill exists at `.claude/skills/aw-ci-repair/SKILL.md`.
+- [ ] `aw-ci-repair.yml` workflow exists, triggers on `workflow_run.completed: failure`, gates on bot-authored draft PRs with `claude/*` branch prefix.
+- [ ] On a synthetic PR with a missing-multiplier failure: skill applies pattern A, pushes one commit, CI re-runs, PR goes green.
+- [ ] On a synthetic PR with a snapshot-drift failure: skill posts a comment naming pattern C and exits without touching files.
+- [ ] One-attempt cap: synthetic PR with a repair commit already on the branch is ignored (no second repair).
+- [ ] Concurrency group key matches the `aw-stage-{stage}-{branch}` convention; covered by the existing `aw-workflow-concurrency.test.ts` once the new workflow is added to its enumeration.
+- [ ] `WORKFLOW_PAT` is used for the workflow's `github_token:` (covered by an extension to `aw-workflow-pat.test.ts`).
+
+### Pipeline
+
+- [ ] Repair commits are signed off with `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>` (matches the rest of the AW pipeline's commit convention).
+- [ ] Repair comments link to the failed run AND the human-readable pattern name.
+- [ ] `aw-retrospect` is updated to recognise repair commits in merged PRs (so retros can count repair frequency per pattern and propose skill rule changes when a pattern fires often enough to suggest a different fix).
+
+### Documentation
+
+- [ ] `docs/agentic-workflow.md` is updated:
+  - Pipeline overview diagram gets a "CI failure → aw-ci-repair → CI rerun" loop.
+  - "Skills" table gets a row for `aw-ci-repair`.
+  - "Workflows" table gets a row for `aw-ci-repair.yml`.
+  - A new "Choice:" section explains the narrow-pattern scope and why generic repair is out of scope.
+- [ ] `docs/architecture.md` doesn't need changes (this is process, not codebase).
+
+### Design
+
+- [ ] No Notesage UI changes; this section is N/A.
+
+## Out of Scope
+
+- **Auto-fixing snapshot drift** — explicit non-goal. Future PRD if signal warrants.
+- **Auto-fixing DOM-changed assertions** — explicit non-goal. Requires reading the component diff in the same PR; closer to "re-implement" than to "repair".
+- **Auto-fixing typecheck failures** — out of scope for v1. The shape is sometimes mechanical (`import { X }` from wrong path) but often non-trivial. Future PRD if pattern emerges.
+- **Auto-fixing Rust test failures** — out of scope. Rust failures are rare in the AW pipeline (most aw-tdd work is frontend-heavy) and the failure shapes are less mechanical.
+- **Auto-fixing on non-bot PRs** — humans can read their own failure logs.
+- **More than one repair attempt per PR** — explicit non-goal. A second repair on a freshly-failed run risks loops.
+- **A general-purpose "ask the LLM to fix any failing test" skill** — the whole point of this PRD is to NOT do that, on the grounds that auditability and bounded blast radius are more valuable than coverage.
+- **Backfilling the multiplier wrap in existing passing tests** — the ESLint rule will flag them on next edit; no need for a mass-rewrite PR. (If `pnpm lint` fails immediately on landing, fix the specific files as part of the same PR; otherwise leave them alone.)

--- a/docs/tasks/2026-05-11-aw-ci-repair-tasks.md
+++ b/docs/tasks/2026-05-11-aw-ci-repair-tasks.md
@@ -1,0 +1,200 @@
+# AW CI Repair — Tasks
+
+|  |  |
+| --- | --- |
+| **Date** | 2026-05-11 |
+| **Status** | Not started |
+| **PRD** | [aw-ci-repair](../prds/2026-05-11-aw-ci-repair.md) |
+| **Total** | 14 tasks: 5S, 7M, 2L |
+| **Suggested order** | M1 Prevention (#1 → #2 → #3) → M2 Skill body (#4 → #5) → M3 Workflow (#6 → #7) → M4 Regression locks (#8 → #9) → M5 Documentation (#10 → #11 → #12) → M6 Validation (#13 → #14) |
+
+## Scope
+
+Two tightly-coupled pieces from PRD §"Technical Approach":
+
+1. **Prevention** — a vitest regression-lock test (`no-bare-perf-budget.test.ts`) that fails when a perf assertion uses a bare numeric literal as its threshold. Mirrors the existing `aw-workflow-*.test.ts` convention; no ESLint plumbing needed.
+2. **Repair** — `aw-ci-repair` skill + `aw-ci-repair.yml` workflow. Triggered by `workflow_run.completed: failure` on a bot-authored draft PR; pattern-matches one of A–E, auto-fixes A+B, comments-and-exits on C–E. One repair attempt per PR.
+
+The MVP scope is intentionally narrow: only Pattern A (missing `PERF_BUDGET_MULTIPLIER` wrap in test) and Pattern B (missing env var in workflow yml) are auto-fixed. C (snapshot drift), D (DOM-changed assertion), E (anything else) only post a comment.
+
+## Risks and open questions
+
+- **Sample size for repair triggers.** Right now we have ~2 known instances of the pattern (PR #191 `preview-fidelity.spec.ts`, alpha.0 release `status-tray.perf.test.ts`). If the bot rarely writes new perf assertions, the repair skill may sit idle for weeks. Prevention is the higher-leverage piece; repair is the existing-tail drain.
+- **`workflow_run` payload reliability.** `workflow_run.pull_requests` is empty for cross-repo PRs and sometimes flaky for same-repo. The skill needs a `gh pr list --search "head:<branch>"` fallback. #6 must include this defensively.
+- **One-attempt cap detection.** Counting prior `aw-ci-repair` comments is a robust signal, but if the bot's own follow-up commits trigger a fresh `workflow_run.failure`, we don't want to re-attempt. The check needs to look for ANY prior repair commit OR comment, not just comment.
+- **False positives on pattern A.** "test failed at 715ms against 500ms" looks like pattern A, but could be a genuine 1.4x regression. The skill's safety net is: it ONLY adds the multiplier wrap, never bumps the threshold. The threshold stays put; if there's an actual regression, the multiplied budget (1500ms) is still exceeded and CI fails again — at which point the one-attempt cap kicks in and the human sees the failure.
+- **ESLint deferred.** PRD originally proposed ESLint; downgraded to vitest regression-lock because the project doesn't have ESLint set up. If ESLint is added for other reasons later, this rule should migrate to a proper ESLint plugin.
+
+---
+
+## M1 — Prevention layer (3 tasks)
+
+### #1 — Audit existing perf assertions and wrap bare budgets
+
+| Field | Value |
+| --- | --- |
+| Description | Walk `e2e/**/*.spec.ts` and `src/perf/**/*.ts` for `expect(...).toBeLessThan(<number>)`, `toBeLessThanOrEqual`, and `toBeGreaterThan` calls. For each call where the argument is a bare numeric literal, wrap it: `N * (Number(process.env.PERF_BUDGET_MULTIPLIER) || 1)`. Note: `c43b286a` already wrapped `preview-fidelity.spec.ts:331`. Other suspected sites: `src/perf/*.perf.test.ts` may pass budgets via the `benchmark()` helper which already honors the multiplier — verify. Goal of this task is "no bare literals remain", not "rewrite the assertions". Run `pnpm test:perf` and `pnpm test:e2e` locally to confirm nothing breaks. |
+| Complexity | M |
+| Category | frontend |
+| Depends on | none |
+| Files | `e2e/**/*.spec.ts`, `src/perf/**/*.ts` (audit only — list files actually changed in commit message) |
+
+### #2 — Add `no-bare-perf-budget.test.ts` regression-lock
+
+| Field | Value |
+| --- | --- |
+| Description | New vitest regression-lock at `src/lib/__tests__/no-bare-perf-budget.test.ts`. Walk `e2e/**/*.spec.ts` and `src/perf/**/*.{ts,test.ts}` via `globSync`. For each file, regex-scan for `\.(toBeLessThan\|toBeLessThanOrEqual\|toBeGreaterThan)\(\s*(\d+(?:\.\d+)?)\s*\)` — bare numeric argument. Assert zero matches per file. Failure message names the file and tells the reader to wrap as `N * (Number(process.env.PERF_BUDGET_MULTIPLIER) || 1)`. Mirror the shape of `src/lib/__tests__/aw-workflow-pat.test.ts` for consistency. Include 1–2 in-test negative-control snippets that demonstrate the regex catches the bad shape AND skips the good shape (multiplied literal, identifier reference). Skip files matching a documented allowlist if any genuinely-fixed budgets exist (e.g. a `setTimeout` target inside a `page.evaluate`); allowlist must be in the test file with a comment explaining each entry. |
+| Complexity | M |
+| Category | frontend |
+| Depends on | #1 |
+| Files | `src/lib/__tests__/no-bare-perf-budget.test.ts` (new) |
+
+### #3 — Verify `pnpm test` includes the new lock
+
+| Field | Value |
+| --- | --- |
+| Description | Run `pnpm test` and confirm `no-bare-perf-budget.test.ts` is picked up. Notesage's default `vitest.config.ts` excludes `src/perf/**` from the main run — confirm `src/lib/__tests__/no-bare-perf-budget.test.ts` lands in the main suite. No new CI step needed; the test runs alongside the existing `aw-workflow-*` regression locks. Verify the test fails on a synthetic bad file (temporarily revert one of the wraps from #1, confirm red, re-apply). |
+| Complexity | S |
+| Category | frontend |
+| Depends on | #2 |
+| Files | `vitest.config.ts` (read-only verification), test runs locally |
+
+---
+
+## M2 — `aw-ci-repair` skill body (2 tasks)
+
+### #4 — Create `.claude/skills/aw-ci-repair/SKILL.md`
+
+| Field | Value |
+| --- | --- |
+| Description | New skill file mirroring the shape of `aw-iterate/SKILL.md`. Frontmatter: `name: aw-ci-repair` + `description:` line. Body covers: (a) when to use vs when to defer (only on bot-authored draft PRs with a `claude/*` branch, only when CI failure shape matches A or B, only when no prior repair attempt has been made); (b) inputs (`PR_NUMBER`, `RUN_ID`, failed-log excerpt); (c) pre-flight bash (verify draft + bot, count prior repair comments/commits, fetch + grep the failed log); (d) pattern list (A–E with detection + repair instructions); (e) hard gates (`pnpm typecheck`, targeted failing spec, ≤2 files modified, no force-push); (f) commit message + comment templates with the documented "🔧 Auto-repair applied" / "❌ Auto-repair could not apply" shapes from the PRD; (g) bot identity (uses `WORKFLOW_PAT` for the push so CI re-runs naturally — same as aw-tdd / aw-iterate). |
+| Complexity | L |
+| Category | tooling |
+| Depends on | none (skill body is self-contained markdown) |
+| Files | `.claude/skills/aw-ci-repair/SKILL.md` (new) |
+
+### #5 — Pattern A + B implementation guidance in SKILL.md
+
+| Field | Value |
+| --- | --- |
+| Description | Inside the SKILL.md body, write the concrete recipe for patterns A and B as numbered steps the LLM agent will follow. Pattern A: identify the failing assertion line from the log; verify the file is in `e2e/**` or `src/perf/**`; confirm the bare-literal shape; apply the wrap via the `Edit` tool with surgical `old_string` / `new_string`; verify the targeted spec passes (`pnpm vitest run <file>` or `pnpm test:e2e <file>`); commit + push. Pattern B: after applying A, read the workflow yml that ran the failing job; if the `PERF_BUDGET_MULTIPLIER` env var is missing on the step that runs the test, add `env: { PERF_BUDGET_MULTIPLIER: "3" }` (matching the value used in `test.yml`'s frontend job). Bundle A + B in the same commit. Document the specific `gh run view --log-failed` parsing recipe — the failure log shape from PR #191 is the reference. Reference the actual fix that landed in `c43b286a` as the worked example. |
+| Complexity | M |
+| Category | tooling |
+| Depends on | #4 |
+| Files | `.claude/skills/aw-ci-repair/SKILL.md` |
+
+---
+
+## M3 — Workflow file (2 tasks)
+
+### #6 — Create `.github/workflows/aw-ci-repair.yml`
+
+| Field | Value |
+| --- | --- |
+| Description | New workflow mirroring `aw-iterate.yml`'s shape. Trigger: `workflow_run.completed` on the workflows we care about (initial list: `Test`, optionally `Release`) + `workflow_dispatch` with `pr_number` input. Job-level `if:` clause: dispatched events always pass; `workflow_run` events pass only when `conclusion == 'failure'` AND `event == 'pull_request'` AND `head_branch` starts with `claude/`. Resolve the PR number defensively: `workflow_run.pull_requests[0]` first, fall back to `gh pr list --search "head:<branch>"` if empty. Permissions block: `contents: write`, `pull-requests: write`, `actions: read`, `id-token: write`. `concurrency.group` = `aw-stage-ci-repair-${{ github.event.workflow_run.head_branch || github.run_id }}` with `cancel-in-progress: false`. claude-code-action step: `github_token: ${{ secrets.WORKFLOW_PAT }}` (PR-creating workflow per Choice: WORKFLOW_PAT for bot-PR CI gating). `--allowedTools` includes Bash(gh:*), Bash(grep:*), Bash(rg:*), Read, Edit, Write, Glob — repair needs Edit and Write that aw-review doesn't. `--max-turns 40` is sufficient given the narrow pattern set. |
+| Complexity | M |
+| Category | tooling |
+| Depends on | #4 (skill must exist for the workflow to invoke) |
+| Files | `.github/workflows/aw-ci-repair.yml` (new) |
+
+### #7 — Workflow prompt body + hard-constraint reminders
+
+| Field | Value |
+| --- | --- |
+| Description | The `prompt:` block in `aw-ci-repair.yml` invokes the skill and restates the hard constraints (same convention as `aw-review.yml:65-86`). Constraints to restate: (a) only patterns A and B may modify files; (b) ≤2 files per commit; (c) never `--force` push; (d) one repair attempt per PR — abort if a prior repair comment OR commit exists; (e) `pnpm typecheck` AND the targeted spec MUST pass before commit; (f) the commit message MUST name the pattern and link to the failed run. Include the run id, branch, and resolved PR number as variables interpolated into the prompt. |
+| Complexity | S |
+| Category | tooling |
+| Depends on | #6 |
+| Files | `.github/workflows/aw-ci-repair.yml` |
+
+---
+
+## M4 — Regression locks (2 tasks)
+
+### #8 — Add `aw-ci-repair.yml` to existing aw-workflow-*.test.ts files
+
+| Field | Value |
+| --- | --- |
+| Description | Extend the three existing AW workflow regression-lock tests so they enumerate the new workflow: (a) `aw-workflow-concurrency.test.ts` — assert the workflow has `concurrency.group` matching `aw-stage-ci-repair-*` and `cancel-in-progress: false`; (b) `aw-workflow-pat.test.ts` — assert the claude-code-action step uses `${{ secrets.WORKFLOW_PAT }}` (this is a PR-modifying workflow per "Choice: WORKFLOW_PAT for bot-PR CI gating"); (c) `aw-workflow-defensive-checks.test.ts` — extend whatever scope this lock covers to include the new workflow. Walk each test, find the file-list constant or pattern that enumerates workflows, add `aw-ci-repair.yml`. |
+| Complexity | S |
+| Category | frontend |
+| Depends on | #6 |
+| Files | `src/lib/__tests__/aw-workflow-concurrency.test.ts`, `src/lib/__tests__/aw-workflow-pat.test.ts`, `src/lib/__tests__/aw-workflow-defensive-checks.test.ts` |
+
+### #9 — Dedicated `aw-ci-repair-shape.test.ts` regression lock
+
+| Field | Value |
+| --- | --- |
+| Description | New `src/lib/__tests__/aw-ci-repair-shape.test.ts` that asserts properties specific to this workflow: (a) trigger includes `workflow_run.completed` AND `workflow_dispatch`; (b) `if:` clause checks `conclusion == 'failure'` AND branch prefix `claude/`; (c) one-attempt cap is documented in the SKILL.md body (regex-search the skill markdown for "one attempt" or "≤1 repair"); (d) pattern list covers A, B (autofix) AND C, D, E (comment-only). Mirror the shape of `aw-author-association-gate.test.ts`. |
+| Complexity | M |
+| Category | frontend |
+| Depends on | #4, #6 |
+| Files | `src/lib/__tests__/aw-ci-repair-shape.test.ts` (new) |
+
+---
+
+## M5 — Documentation (3 tasks)
+
+### #10 — Update `docs/agentic-workflow.md` pipeline diagram + tables
+
+| Field | Value |
+| --- | --- |
+| Description | Add `aw-ci-repair` to (a) the mermaid pipeline overview as a "CI failure → aw-ci-repair → CI rerun" branch from the Draft PR node; (b) the Skills table (one row, mirroring the aw-iterate row); (c) the Workflows table (one row). Update the workflow count from "ten workflows" to "eleven" wherever it appears. |
+| Complexity | M |
+| Category | docs |
+| Depends on | #4, #6 |
+| Files | `docs/agentic-workflow.md` |
+
+### #11 — New "Choice:" section explaining the narrow-pattern scope
+
+| Field | Value |
+| --- | --- |
+| Description | Add a new "Choice: narrow-pattern auto-repair (#TBD)" subsection under "Design choices and rationale" in `docs/agentic-workflow.md`. Explain: (a) the recurring failure pattern (missing `PERF_BUDGET_MULTIPLIER`); (b) why generic "fix any failing test" repair is rejected (loops, hiding regressions, auditability); (c) why patterns C/D/E are comment-only; (d) the one-attempt cap rationale. Mirror the tone of "Choice: WORKFLOW_PAT for bot-PR CI gating" — problem statement, fix, side effects, knock-on changes, regression-lock reference. |
+| Complexity | M |
+| Category | docs |
+| Depends on | #10 |
+| Files | `docs/agentic-workflow.md` |
+
+### #12 — Teach `aw-retrospect` to recognise repair commits
+
+| Field | Value |
+| --- | --- |
+| Description | Update `.claude/skills/aw-retrospect/SKILL.md` so the retrospect agent knows about repair commits and can include them as signal. Specifically: the merge-commit history walk should recognise commits authored by the WORKFLOW_PAT owner with subject starting `fix(ci): honour PERF_BUDGET_MULTIPLIER` and treat repeated occurrences as a "this pattern is firing often — consider a different skill rule" signal. No code in `aw-retrospect` itself (it's a markdown skill) — just instruction updates so the LLM picks the pattern up. |
+| Complexity | S |
+| Category | tooling |
+| Depends on | #4 |
+| Files | `.claude/skills/aw-retrospect/SKILL.md` |
+
+---
+
+## M6 — Validation (2 tasks)
+
+### #13 — Live validation via synthetic failure
+
+| Field | Value |
+| --- | --- |
+| Description | After M1–M5 land on `main`, validate end-to-end by opening a synthetic PR that contains a bare-literal perf assertion. Branch name must be `claude/<something>` so the gate fires. Push → CI should fail on `no-bare-perf-budget.test.ts` FIRST (prevention layer catches it before runtime). Force the perf assertion to fail at runtime by setting an unreachable budget (e.g. `expect(p95).toBeLessThan(1)`) — confirm `aw-ci-repair` fires, applies the wrap, pushes a commit, CI re-runs. Document the validation run in `.claude/skill-feedback.md` for future retros. Close the synthetic PR afterward; do not merge. |
+| Complexity | L |
+| Category | tooling |
+| Depends on | #1–#12 (everything must be on main) |
+| Files | synthetic test PR (closed after validation) |
+
+### #14 — Pattern C (snapshot drift) validation
+
+| Field | Value |
+| --- | --- |
+| Description | Second validation: open a `claude/*` PR that modifies a snapshot test so the snapshot fails. Verify `aw-ci-repair` posts the documented "❌ Auto-repair could not apply — pattern: snapshot drift" comment AND makes zero file changes. Close the synthetic PR without merging. Document in `.claude/skill-feedback.md`. |
+| Complexity | M |
+| Category | tooling |
+| Depends on | #13 |
+| Files | synthetic test PR (closed after validation) |
+
+---
+
+## Done definition
+
+- All 14 tasks marked ✅
+- `pnpm test` passes including the new `no-bare-perf-budget.test.ts` and `aw-ci-repair-shape.test.ts`
+- `docs/agentic-workflow.md` reflects the new skill + workflow + Choice section
+- Two live validation runs documented (#13 + #14)
+- Repair commit subject convention (`fix(ci): honour PERF_BUDGET_MULTIPLIER`) is documented in `aw-retrospect`'s SKILL.md so retros count occurrences over time


### PR DESCRIPTION
## Summary

Lands the PRD + task breakdown for the `aw-ci-repair` pipeline addition discussed in the v0.44.0-alpha.1 post-mortem (PR #191's CI flake on \`preview-fidelity.spec.ts\`).

- **PRD** — \`docs/prds/2026-05-11-aw-ci-repair.md\`
- **Tasks** — \`docs/tasks/2026-05-11-aw-ci-repair-tasks.md\` (14 tasks across 6 milestones)

## What this enables

Two pieces that compose:

1. **Prevention** — a vitest regression-lock test (\`no-bare-perf-budget.test.ts\`) that fails when a perf assertion uses a bare numeric literal as its budget. Catches the pattern at PR-write time. Mirrors the existing \`aw-workflow-*.test.ts\` convention; no ESLint plumbing needed.
2. **Repair** — a new \`aw-ci-repair\` skill triggered by \`workflow_run.completed: failure\` on bot-authored draft PRs. Auto-fixes ONLY pattern A (missing \`PERF_BUDGET_MULTIPLIER\` wrap in test) and pattern B (missing env var in workflow yml). Comments-and-exits on snapshot drift, DOM-changed assertions, and anything else. One repair attempt per PR.

## Why now

Three of the last five bot PRs have hit the same shape (hardcoded perf budget → CI flakes on macos-latest). Each repair is a one-line fix the human has to type repeatedly. PR #191 hit it twice in this session alone. Implementation is gated on this PRD landing so the AW pipeline has filesystem references to read when it picks up the implementation issue.

## What this PR is NOT

- Implementation. A separate issue follows that goes through the AW pipeline (triage → refine → slice → tdd → review) using these docs as the spec.

## Test plan

- [ ] Markdown links resolve in both directions (PRD → tasks, tasks → PRD)
- [ ] Visual scan of the PRD for tone / accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)