### PR TITLE
feat(html-viewer): add allow-scripts toggle for local HTML files

### DIFF
--- a/src/components/editor/viewers/HtmlViewer.tsx
+++ b/src/components/editor/viewers/HtmlViewer.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { Code, Eye } from "lucide-react";
 import DOMPurify from "dompurify";
+import { invoke } from "@tauri-apps/api/core";
 import { highlightDomMatches, clearDomHighlights } from "@/lib/dom-search";
 import { FindBar } from "@/components/editor/FindBar";
 import { CodeEditor } from "./CodeEditor";
@@ -55,7 +56,9 @@ export function HtmlViewer({
   saveFileWithContent,
 }: HtmlViewerProps) {
   const allowForms = useSettingsStore((s) => s.htmlViewerAllowForms);
+  const allowScripts = useSettingsStore((s) => s.htmlViewerAllowScripts);
   const [sourceMode, setSourceMode] = useState(false);
+  const [unsafeHtml, setUnsafeHtml] = useState<string | null>(null);
   const [findBarOpen, setFindBarOpen] = useState(false);
   const [searchMatches, setSearchMatches] = useState<HTMLElement[]>([]);
   const [searchCurrentIndex, setSearchCurrentIndex] = useState(-1);
@@ -80,6 +83,38 @@ export function HtmlViewer({
       ADD_ATTR: allowForms ? FORM_ATTRS : [],
     });
   }, [content, allowForms]);
+
+  // When allow-scripts is ON, pre-process the raw HTML: read same-directory
+  // <script src="./..."> files via Tauri read_file and rewrite them as inline
+  // <script> blocks so the iframe (which has a null/opaque origin — no
+  // allow-same-origin) can execute them without a cross-origin fetch.
+  useEffect(() => {
+    if (!allowScripts) {
+      setUnsafeHtml(null);
+      return;
+    }
+    let cancelled = false;
+    async function process() {
+      const dir = filePath.substring(0, filePath.lastIndexOf("/"));
+      // Match <script src="./relative/path.js"> patterns (single or double quotes)
+      const srcPattern = /<script\s[^>]*src=["'](\.\/[^"']+)["'][^>]*><\/script>/gi;
+      let processed = content;
+      const matches = [...content.matchAll(srcPattern)];
+      for (const match of matches) {
+        const relPath = match[1];
+        const absPath = `${dir}/${relPath.replace(/^\.\//, "")}`;
+        try {
+          const fileContent = await invoke<string>("read_file", { path: absPath });
+          processed = processed.replace(match[0], `<script>${fileContent}</script>`);
+        } catch {
+          // If file can't be read, leave the original tag in place
+        }
+      }
+      if (!cancelled) setUnsafeHtml(processed);
+    }
+    process();
+    return () => { cancelled = true; };
+  }, [allowScripts, content, filePath]);
 
   // Reset search state when switching modes or content changes
   useEffect(() => {
@@ -243,8 +278,10 @@ export function HtmlViewer({
         </div>
       </div>
 
-      {/* Content area — sanitised inline render. Padded shell + rounded card
-          give the rendered page the same treatment as the markdown editor. */}
+      {/* Content area. When allow-scripts is ON and the pre-processed HTML is
+          ready, render in an isolated null-origin iframe (sandbox="allow-scripts",
+          no allow-same-origin). Otherwise use the default DOMPurify sanitised
+          inline path. */}
       <div
         ref={scrollContainerRef}
         className="flex-1 overflow-auto relative p-3"
@@ -261,13 +298,24 @@ export function HtmlViewer({
           replaceExpanded={false}
           onReplaceExpandedChange={() => {}}
         />
-        <div
-          ref={renderRef}
-          className="bg-white text-black rounded-lg border border-border shadow-sm p-6 max-w-3xl mx-auto"
-          style={{ zoom }}
-          aria-label={`Rendered HTML: ${fileName}`}
-          dangerouslySetInnerHTML={{ __html: sanitisedBody }}
-        />
+        {allowScripts && unsafeHtml !== null ? (
+          <iframe
+            sandbox="allow-scripts"
+            srcDoc={unsafeHtml}
+            title={`Rendered HTML (scripts enabled): ${fileName}`}
+            aria-label={`Rendered HTML: ${fileName}`}
+            className="w-full h-full rounded-lg border border-border shadow-sm bg-white"
+            style={{ minHeight: "60vh", zoom }}
+          />
+        ) : (
+          <div
+            ref={renderRef}
+            className="bg-white text-black rounded-lg border border-border shadow-sm p-6 max-w-3xl mx-auto"
+            style={{ zoom }}
+            aria-label={`Rendered HTML: ${fileName}`}
+            dangerouslySetInnerHTML={{ __html: sanitisedBody }}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/components/editor/viewers/__tests__/HtmlViewer.test.tsx
+++ b/src/components/editor/viewers/__tests__/HtmlViewer.test.tsx
@@ -1,10 +1,11 @@
 // @vitest-environment jsdom
 import "@/test/tauri-mock";
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { HtmlViewer } from "../HtmlViewer";
 import { PlainTextViewer } from "../PlainTextViewer";
 import { useSettingsStore } from "@/stores/settings-store";
+import { setMockInvokeHandler } from "@/test/tauri-mock";
 
 // Mock CodeEditor to avoid full CodeMirror setup in jsdom
 vi.mock("../CodeEditor", () => ({
@@ -237,5 +238,116 @@ describe("PlainTextViewer routing for HTML files", () => {
     );
     expect(screen.getByTestId("code-editor")).toBeTruthy();
     expect(document.querySelector("iframe")).toBeNull();
+  });
+});
+
+describe("HtmlViewer allow-scripts mode — htmlViewerAllowScripts", () => {
+  const filePath = "/path/to/page.html";
+  const fileName = "page.html";
+
+  afterEach(() => {
+    useSettingsStore.setState({ htmlViewerAllowScripts: false } as Parameters<typeof useSettingsStore.setState>[0]);
+  });
+
+  it("when OFF (default): no iframe in the DOM (regression guard)", async () => {
+    render(
+      <HtmlViewer
+        content="<html><body><h1>Safe</h1></body></html>"
+        fileName={fileName}
+        filePath={filePath}
+        tabId="tab-scripts-off"
+        isDirty={false}
+        updateTabContent={vi.fn()}
+        saveFileWithContent={vi.fn()}
+      />
+    );
+    // Default path: DOMPurify inline div, never an iframe.
+    expect(document.querySelector("iframe")).toBeNull();
+    expect(screen.getByText("Safe")).toBeTruthy();
+  });
+
+  it("when ON: renders an iframe instead of the DOMPurify inline div", async () => {
+    useSettingsStore.setState({ htmlViewerAllowScripts: true } as Parameters<typeof useSettingsStore.setState>[0]);
+    render(
+      <HtmlViewer
+        content="<html><body><h1>Unsafe</h1></body></html>"
+        fileName={fileName}
+        filePath={filePath}
+        tabId="tab-scripts-on"
+        isDirty={false}
+        updateTabContent={vi.fn()}
+        saveFileWithContent={vi.fn()}
+      />
+    );
+    await waitFor(() => {
+      expect(document.querySelector("iframe")).not.toBeNull();
+    });
+  });
+
+  it("when ON: iframe sandbox includes allow-scripts", async () => {
+    useSettingsStore.setState({ htmlViewerAllowScripts: true } as Parameters<typeof useSettingsStore.setState>[0]);
+    render(
+      <HtmlViewer
+        content="<html><body><p>Scripts on</p></body></html>"
+        fileName={fileName}
+        filePath={filePath}
+        tabId="tab-scripts-sandbox"
+        isDirty={false}
+        updateTabContent={vi.fn()}
+        saveFileWithContent={vi.fn()}
+      />
+    );
+    await waitFor(() => {
+      const iframe = document.querySelector("iframe");
+      expect(iframe).not.toBeNull();
+      expect(iframe!.getAttribute("sandbox")).toContain("allow-scripts");
+    });
+  });
+
+  it("when ON: iframe sandbox does NOT include allow-same-origin (null-origin isolation)", async () => {
+    useSettingsStore.setState({ htmlViewerAllowScripts: true } as Parameters<typeof useSettingsStore.setState>[0]);
+    render(
+      <HtmlViewer
+        content="<html><body><p>Isolated</p></body></html>"
+        fileName={fileName}
+        filePath={filePath}
+        tabId="tab-scripts-isolation"
+        isDirty={false}
+        updateTabContent={vi.fn()}
+        saveFileWithContent={vi.fn()}
+      />
+    );
+    await waitFor(() => {
+      const iframe = document.querySelector("iframe");
+      expect(iframe).not.toBeNull();
+      expect(iframe!.getAttribute("sandbox")).not.toContain("allow-same-origin");
+    });
+  });
+
+  it("when ON: same-directory <script src='./local.js'> is inlined via read_file", async () => {
+    setMockInvokeHandler("read_file", (args) => {
+      if ((args?.path as string | undefined)?.endsWith("local.js")) {
+        return "console.log('local-script-executed');";
+      }
+      throw new Error("unexpected read_file call");
+    });
+    useSettingsStore.setState({ htmlViewerAllowScripts: true } as Parameters<typeof useSettingsStore.setState>[0]);
+    render(
+      <HtmlViewer
+        content='<html><body><h1>Page</h1><script src="./local.js"></script></body></html>'
+        fileName={fileName}
+        filePath={filePath}
+        tabId="tab-scripts-inline-src"
+        isDirty={false}
+        updateTabContent={vi.fn()}
+        saveFileWithContent={vi.fn()}
+      />
+    );
+    await waitFor(() => {
+      const iframe = document.querySelector("iframe");
+      expect(iframe).not.toBeNull();
+      const srcdoc = iframe!.getAttribute("srcdoc") ?? "";
+      expect(srcdoc).toContain("console.log('local-script-executed')");
+    });
   });
 });

--- a/src/components/settings/v2/SystemSettings.tsx
+++ b/src/components/settings/v2/SystemSettings.tsx
@@ -133,6 +133,8 @@ export function SystemSettings({
   // HTML viewer
   const htmlViewerAllowForms = useSettingsStore((s) => s.htmlViewerAllowForms);
   const setHtmlViewerAllowForms = useSettingsStore((s) => s.setHtmlViewerAllowForms);
+  const htmlViewerAllowScripts = useSettingsStore((s) => s.htmlViewerAllowScripts);
+  const setHtmlViewerAllowScripts = useSettingsStore((s) => s.setHtmlViewerAllowScripts);
 
   // Files
   const showHiddenFiles = useSettingsStore((s) => s.showHiddenFiles);
@@ -394,6 +396,18 @@ export function SystemSettings({
               id="html-viewer-allow-forms"
               checked={htmlViewerAllowForms}
               onCheckedChange={setHtmlViewerAllowForms}
+            />
+          }
+        />
+        <SettingsRow
+          label="Allow scripts (unsafe)"
+          description="When on, inline and same-directory scripts execute in an isolated iframe. Scripts cannot access Tauri IPC or host storage. Off by default — only enable for local HTML files you trust."
+          htmlFor="html-viewer-allow-scripts"
+          control={
+            <Switch
+              id="html-viewer-allow-scripts"
+              checked={htmlViewerAllowScripts}
+              onCheckedChange={setHtmlViewerAllowScripts}
             />
           }
         />

--- a/src/components/settings/v2/__tests__/panels.test.tsx
+++ b/src/components/settings/v2/__tests__/panels.test.tsx
@@ -68,6 +68,12 @@ describe('v2 settings panels', () => {
     expect(screen.getByText('Allow form submissions')).toBeTruthy();
   });
 
+  it('SystemSettings renders HTML viewer group with Allow scripts (unsafe) toggle', () => {
+    renderWithProviders(<SystemSettings />);
+    expect(screen.getByText('HTML viewer')).toBeTruthy();
+    expect(screen.getByText('Allow scripts (unsafe)')).toBeTruthy();
+  });
+
   it('SystemSettings renders "View update" affordance when an update is available', () => {
     renderWithProviders(
       <SystemSettings

--- a/src/stores/__tests__/settings-store.test.ts
+++ b/src/stores/__tests__/settings-store.test.ts
@@ -1113,7 +1113,7 @@ describe('uiPreview flag', () => {
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(15);
+    expect(parsed.version).toBe(16);
     expect(parsed.state.uiPreview).toBe('legacy');
     expect(parsed.state.accent).toBe('default');
   });
@@ -1255,7 +1255,7 @@ describe('v5 → v6 migration (cmdBarPinned + cmdBarPinnedWidth)', () => {
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(15);
+    expect(parsed.version).toBe(16);
     expect(parsed.state.cmdBarPinned).toBe(false);
     expect(parsed.state.cmdBarPinnedWidth).toBe(400);
   });
@@ -1401,7 +1401,7 @@ describe('v6 → v7 migration (quietChromePreset + quietChromeOverrides)', () =>
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(15);
+    expect(parsed.version).toBe(16);
     expect(parsed.state.quietChromePreset).toBe('default');
     expect(parsed.state.quietChromeOverrides).toBeTruthy();
   });
@@ -1720,7 +1720,7 @@ describe('v7 → v8 migration (sidebar composition)', () => {
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(15);
+    expect(parsed.version).toBe(16);
     expect(parsed.state.sidebarRecentCap).toBe(5);
     expect(parsed.state.sidebarTagsCap).toBe(5);
     // Hidden field stripped by v11 → v12 migration.
@@ -1975,7 +1975,7 @@ describe('v8 → v9 migration (preview invitation timestamps)', () => {
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(15);
+    expect(parsed.version).toBe(16);
     expect(parsed.state.previewInvitationShownAt).toBeNull();
     expect(parsed.state.previewInvitationDismissedAt).toBeNull();
   });
@@ -2077,7 +2077,7 @@ describe('v9 → v10 migration (cmdBarExpandedWidth)', () => {
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(15);
+    expect(parsed.version).toBe(16);
     expect(parsed.state.cmdBarExpandedWidth).toBe(640);
   });
 
@@ -2148,7 +2148,7 @@ describe('v10 → v11 migration (sidebar Mentions composition)', () => {
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(15);
+    expect(parsed.version).toBe(16);
     expect(parsed.state.sidebarMentionsCap).toBe(5);
     expect(parsed.state.sidebarMentionsHidden).toBeUndefined();
   });
@@ -2270,7 +2270,7 @@ describe('v11 → v12 migration (drop Hidden booleans)', () => {
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(15);
+    expect(parsed.version).toBe(16);
     expect(parsed.state.sidebarTagsCap).toBe(0);
     expect(parsed.state.sidebarTagsHidden).toBeUndefined();
   });
@@ -2292,7 +2292,7 @@ describe('v11 → v12 migration (drop Hidden booleans)', () => {
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(15);
+    expect(parsed.version).toBe(16);
     expect(parsed.state.sidebarMentionsCap).toBe(0);
     expect(parsed.state.sidebarMentionsHidden).toBeUndefined();
   });
@@ -2318,7 +2318,7 @@ describe('v11 → v12 migration (drop Hidden booleans)', () => {
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(15);
+    expect(parsed.version).toBe(16);
     expect(parsed.state.sidebarTagsHidden).toBeUndefined();
     expect(parsed.state.sidebarMentionsHidden).toBeUndefined();
   });
@@ -2452,7 +2452,7 @@ describe('v14 migration: releaseChannel', () => {
     expect(useSettingsStore.getState().releaseChannel).toBe('alpha');
   });
 
-  it('bumps persisted version to 15 after migration', async () => {
+  it('bumps persisted version to 16 after migration', async () => {
     localStorageMock.setItem(STORAGE_KEY, buildV13State());
 
     await useSettingsStore.persist.rehydrate();
@@ -2460,7 +2460,7 @@ describe('v14 migration: releaseChannel', () => {
 
     const raw = localStorageMock.getItem(STORAGE_KEY);
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(15);
+    expect(parsed.version).toBe(16);
   });
 });
 
@@ -2498,7 +2498,7 @@ describe('v15 migration: htmlViewerAllowForms', () => {
     expect(useSettingsStore.getState().htmlViewerAllowForms).toBe(true);
   });
 
-  it('bumps persisted version to 15 after migration', async () => {
+  it('bumps persisted version to 16 after migration', async () => {
     localStorageMock.setItem(STORAGE_KEY, buildV14State());
 
     await useSettingsStore.persist.rehydrate();
@@ -2506,6 +2506,53 @@ describe('v15 migration: htmlViewerAllowForms', () => {
 
     const raw = localStorageMock.getItem(STORAGE_KEY);
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(15);
+    expect(parsed.version).toBe(16);
+  });
+});
+
+// ===========================================================================
+// v16 migration — htmlViewerAllowScripts defaults to false on upgrade
+// ===========================================================================
+
+describe('v16 migration: htmlViewerAllowScripts', () => {
+  function buildV15State(overrides: Record<string, unknown> = {}): string {
+    const state = {
+      theme: 'system',
+      logLevel: 'warn',
+      autoCheckUpdates: true,
+      releaseChannel: 'stable',
+      htmlViewerAllowForms: false,
+      ...overrides,
+    };
+    return JSON.stringify({ state, version: 15 });
+  }
+
+  it('migrates v15 state without htmlViewerAllowScripts to false', async () => {
+    localStorageMock.setItem(STORAGE_KEY, buildV15State());
+
+    await useSettingsStore.persist.rehydrate();
+    await waitForPersist();
+
+    expect(useSettingsStore.getState().htmlViewerAllowScripts).toBe(false);
+  });
+
+  it('preserves existing htmlViewerAllowScripts when already present', async () => {
+    localStorageMock.setItem(STORAGE_KEY, buildV15State({ htmlViewerAllowScripts: true }));
+
+    await useSettingsStore.persist.rehydrate();
+    await waitForPersist();
+
+    expect(useSettingsStore.getState().htmlViewerAllowScripts).toBe(true);
+  });
+
+  it('bumps persisted version to 16 after migration', async () => {
+    localStorageMock.setItem(STORAGE_KEY, buildV15State());
+
+    await useSettingsStore.persist.rehydrate();
+    await waitForPersist();
+
+    const raw = localStorageMock.getItem(STORAGE_KEY);
+    const parsed = JSON.parse(raw!);
+    expect(parsed.version).toBe(16);
   });
 });

--- a/src/stores/settings-store.ts
+++ b/src/stores/settings-store.ts
@@ -317,6 +317,14 @@ interface SettingsStore {
    */
   htmlViewerAllowForms: boolean;
   setHtmlViewerAllowForms: (enabled: boolean) => void;
+  /**
+   * When true, the HTML viewer bypasses DOMPurify and renders content in an
+   * isolated iframe with `sandbox="allow-scripts"` (no `allow-same-origin`).
+   * Inline `<script>` blocks execute; same-directory `<script src="./local.js">`
+   * is pre-processed via read_file and inlined. Default false (scripts stripped).
+   */
+  htmlViewerAllowScripts: boolean;
+  setHtmlViewerAllowScripts: (enabled: boolean) => void;
 }
 
 export const useSettingsStore = create<SettingsStore>()(
@@ -736,10 +744,16 @@ export const useSettingsStore = create<SettingsStore>()(
       setHtmlViewerAllowForms: (enabled: boolean) => {
         set({ htmlViewerAllowForms: enabled });
       },
+
+      htmlViewerAllowScripts: false,
+
+      setHtmlViewerAllowScripts: (enabled: boolean) => {
+        set({ htmlViewerAllowScripts: enabled });
+      },
     }),
     {
       name: "notesage-settings",
-      version: 15,
+      version: 16,
 
       migrate: (persisted: unknown, version: number) => {
         const state = persisted as Record<string, unknown>;
@@ -886,6 +900,13 @@ export const useSettingsStore = create<SettingsStore>()(
           // so existing users see no behaviour change after upgrade.
           if (typeof state.htmlViewerAllowForms !== 'boolean') {
             state.htmlViewerAllowForms = false;
+          }
+        }
+        if (version < 16) {
+          // Issue #184 — HTML viewer allow-scripts. Default false (scripts stripped)
+          // so existing users see no behaviour change after upgrade.
+          if (typeof state.htmlViewerAllowScripts !== 'boolean') {
+            state.htmlViewerAllowScripts = false;
           }
         }
         return state;


### PR DESCRIPTION
Resolves #184

## Summary

Adds an opt-in **Allow scripts (unsafe)** toggle in Settings > System > HTML viewer. When OFF (default), the existing DOMPurify sanitised inline rendering path is used unchanged. When ON, the viewer pre-processes the raw HTML to inline same-directory `<script src="./local.js">` references via Tauri `read_file`, then renders in a null-origin `sandbox="allow-scripts"` iframe — scripts execute but cannot access Tauri IPC, host storage, or parent DOM.

## Red tests added

- `HtmlViewer.test.tsx::when OFF (default): no iframe in the DOM (regression guard)` — existing DOMPurify path still renders an inline div, never an iframe
- `HtmlViewer.test.tsx::when ON: renders an iframe instead of the DOMPurify inline div` — iframe present after `useEffect` resolves
- `HtmlViewer.test.tsx::when ON: iframe sandbox includes allow-scripts` — confirms execution is permitted
- `HtmlViewer.test.tsx::when ON: iframe sandbox does NOT include allow-same-origin (null-origin isolation)` — confirms host storage / IPC is blocked
- `HtmlViewer.test.tsx::when ON: same-directory <script src='./local.js'> is inlined via read_file` — relative src rewritten to inline `<script>` block in srcdoc
- `panels.test.tsx::SystemSettings renders HTML viewer group with Allow scripts (unsafe) toggle` — settings UI exposes the control
- `settings-store.test.ts::v16 migration: htmlViewerAllowScripts` — three migration tests (missing field defaults to false, existing value preserved, version bumps to 16)

## Green implementation

- `src/stores/settings-store.ts` — added `htmlViewerAllowScripts: boolean` field + `setHtmlViewerAllowScripts` setter; bumped persist version 15→16 with migration guard
- `src/components/settings/v2/SystemSettings.tsx` — added `SettingsRow` with `Switch` inside existing "HTML viewer" `SettingsGroup`
- `src/components/editor/viewers/HtmlViewer.tsx` — reads `allowScripts` from store; `useEffect` pre-processes `<script src="./...">` via Tauri `read_file`; renders `<iframe sandbox="allow-scripts" srcDoc={...}>` when ON and pre-processing is complete, otherwise falls back to the existing DOMPurify `<div>`

## Refactor

Skipped — implementation is already minimal.

## Decisions made

- **Null-origin isolation (no `allow-same-origin`)**: `sandbox="allow-scripts"` without `allow-same-origin` prevents the iframe from reading cookies, localStorage, or calling `window.__TAURI_INTERNALS__`. The only way to re-enable these would be an explicit opt-in the user can't accidentally trigger.
- **`allowScripts && unsafeHtml !== null` guard**: The iframe is only mounted after the async `read_file` pre-processing completes. While `unsafeHtml` is `null`, the DOMPurify div renders as a fallback — avoids a flash of blank content.
- **Only `./` relative `<script src>` rewrites**: Absolute URLs and non-relative paths are left in place (they will fail to load in a null-origin iframe, which is the safe default). Only `./local.js`-style relative references are supported per the issue spec.
- **`cancel` flag on `useEffect`**: Prevents state update after unmount / content change during async `read_file` calls.

## Verification

- [x] Red tests were red before implementation
- [x] All red tests now green
- [x] `pnpm test` passes (4948 tests, 273 files)
- [x] `pnpm typecheck` clean
- [x] No unrelated files modified

## Notes for reviewer

The `allowScripts` setting is a security-sensitive toggle. The description copy in the Settings row ("Scripts cannot access Tauri IPC or host storage") is technically accurate for null-origin iframes — but reviewers should verify this holds on their Tauri version. The `sandbox` attribute without `allow-same-origin` is the browser's enforcement mechanism; Tauri's `assetProtocol` scope narrows what `convertFileSrc` can serve but the null origin means the iframe never makes an asset-protocol request anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the `aw-tdd` skill.