### PR TITLE
feat(html-viewer): add Unsafe preview mode toggle for CDN/inline scripts

### DIFF
--- a/src/components/editor/viewers/HtmlViewer.tsx
+++ b/src/components/editor/viewers/HtmlViewer.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
-import { Code, Eye } from "lucide-react";
+import { Code, Eye, ShieldAlert } from "lucide-react";
 import DOMPurify from "dompurify";
 import { invoke } from "@tauri-apps/api/core";
 import { highlightDomMatches, clearDomHighlights } from "@/lib/dom-search";
@@ -7,6 +7,16 @@ import { FindBar } from "@/components/editor/FindBar";
 import { CodeEditor } from "./CodeEditor";
 import { useSettingsStore } from "@/stores/settings-store";
 import { registerZoomController } from "@/hooks/useEditorZoom";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 
 interface HtmlViewerProps {
   content: string;
@@ -63,6 +73,8 @@ export function HtmlViewer({
   const [searchMatches, setSearchMatches] = useState<HTMLElement[]>([]);
   const [searchCurrentIndex, setSearchCurrentIndex] = useState(-1);
   const [zoom, setZoom] = useState(1.0);
+  const [unsafeMode, setUnsafeMode] = useState(false);
+  const [showConfirmDialog, setShowConfirmDialog] = useState(false);
 
   const renderRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -123,6 +135,12 @@ export function HtmlViewer({
     searchMatchesRef.current = [];
     setSearchCurrentIndex(-1);
   }, [sourceMode, content]);
+
+  // Unsafe mode is session-only — reset when the user switches to a different tab
+  useEffect(() => {
+    setUnsafeMode(false);
+    setShowConfirmDialog(false);
+  }, [tabId]);
 
   // Listen for Cmd+F / notesage:find-open — only active in rendered mode
   useEffect(() => {
@@ -251,72 +269,140 @@ export function HtmlViewer({
   }
 
   return (
-    <div className="h-full flex flex-col">
-      <div className={toolbarClass} data-testid="html-viewer-toolbar">
-        <span className="text-xs text-muted-foreground truncate max-w-[200px]">
-          {fileName}
-        </span>
-        <span className="text-xs text-muted-foreground ml-2">Rendered</span>
-        {zoom !== 1.0 && (
-          <span
-            className="text-xs text-muted-foreground ml-2 tabular-nums"
-            aria-label="Zoom level"
-          >
-            {Math.round(zoom * 100)}%
+    <>
+      <AlertDialog open={showConfirmDialog} onOpenChange={setShowConfirmDialog}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Enable Unsafe Preview Mode?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This file will render unmodified HTML including all scripts —
+              inline and external (CDN). Only enable for files you trust.
+              DOMPurify sanitisation will be bypassed for this session.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                setUnsafeMode(true);
+                setShowConfirmDialog(false);
+              }}
+            >
+              Accept
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <div className="h-full flex flex-col">
+        <div className={toolbarClass} data-testid="html-viewer-toolbar">
+          <span className="text-xs text-muted-foreground truncate max-w-[200px]">
+            {fileName}
           </span>
-        )}
-        <div className="ml-auto">
-          <button
-            type="button"
-            aria-label="Switch to source view"
-            onClick={() => setSourceMode(true)}
-            className="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-colors border border-border"
-          >
-            <Code className="h-3.5 w-3.5" aria-hidden="true" />
-            Source
-          </button>
+          <span className="text-xs text-muted-foreground ml-2">
+            {unsafeMode ? "Unsafe preview" : "Rendered"}
+          </span>
+          {!unsafeMode && zoom !== 1.0 && (
+            <span
+              className="text-xs text-muted-foreground ml-2 tabular-nums"
+              aria-label="Zoom level"
+            >
+              {Math.round(zoom * 100)}%
+            </span>
+          )}
+          <div className="ml-auto flex items-center gap-1.5">
+            <button
+              type="button"
+              aria-label="Unsafe preview mode"
+              title={
+                unsafeMode
+                  ? "Unsafe preview active — scripts are executing"
+                  : "Enable unsafe preview mode (renders scripts)"
+              }
+              onClick={() => {
+                if (!unsafeMode) {
+                  setShowConfirmDialog(true);
+                } else {
+                  setUnsafeMode(false);
+                }
+              }}
+              className={`inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium transition-colors border ${
+                unsafeMode
+                  ? "bg-destructive/10 text-destructive border-destructive/30 hover:bg-destructive/20"
+                  : "text-muted-foreground hover:bg-muted hover:text-foreground border-border"
+              }`}
+            >
+              <ShieldAlert className="h-3.5 w-3.5" aria-hidden="true" />
+              Unsafe preview
+            </button>
+            <button
+              type="button"
+              aria-label="Switch to source view"
+              onClick={() => setSourceMode(true)}
+              className="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-colors border border-border"
+            >
+              <Code className="h-3.5 w-3.5" aria-hidden="true" />
+              Source
+            </button>
+          </div>
+        </div>
+
+        {/* Content area. Three render paths, in priority order:
+            1. Unsafe preview mode (user clicked toolbar toggle + accepted dialog) —
+               raw HTML in a sandboxed iframe. Most aggressive: bypasses everything
+               including the DOMPurify pass; lets CDN + inline scripts execute.
+               Session-only, per-tab.
+            2. `htmlViewerAllowScripts` setting ON — pre-processed HTML (local
+               <script src="./..."> resolved + inlined) in a sandboxed iframe.
+               Persistent across sessions; local scripts only.
+            3. Default — DOMPurify sanitised inline div. */}
+        <div
+          ref={scrollContainerRef}
+          className="flex-1 overflow-auto relative p-3"
+        >
+          {unsafeMode ? (
+            <iframe
+              srcDoc={content}
+              sandbox="allow-scripts"
+              className="w-full h-full border-0 rounded-lg"
+              title={`Unsafe preview: ${fileName}`}
+            />
+          ) : (
+            <>
+              <FindBar
+                open={findBarOpen}
+                onClose={handleClose}
+                matchCount={searchMatches.length}
+                currentMatch={searchCurrentIndex}
+                onSearch={handleSearch}
+                onNext={handleNext}
+                onPrevious={handlePrevious}
+                replaceEnabled={false}
+                replaceExpanded={false}
+                onReplaceExpandedChange={() => {}}
+              />
+              {allowScripts && unsafeHtml !== null ? (
+                <iframe
+                  sandbox="allow-scripts"
+                  srcDoc={unsafeHtml}
+                  title={`Rendered HTML (scripts enabled): ${fileName}`}
+                  aria-label={`Rendered HTML: ${fileName}`}
+                  className="w-full h-full rounded-lg border border-border shadow-sm bg-white"
+                  style={{ minHeight: "60vh", zoom }}
+                />
+              ) : (
+                <div
+                  ref={renderRef}
+                  className="bg-white text-black rounded-lg border border-border shadow-sm p-6 max-w-3xl mx-auto"
+                  style={{ zoom }}
+                  aria-label={`Rendered HTML: ${fileName}`}
+                  dangerouslySetInnerHTML={{ __html: sanitisedBody }}
+                />
+              )}
+            </>
+          )}
         </div>
       </div>
-
-      {/* Content area. When allow-scripts is ON and the pre-processed HTML is
-          ready, render in an isolated null-origin iframe (sandbox="allow-scripts",
-          no allow-same-origin). Otherwise use the default DOMPurify sanitised
-          inline path. */}
-      <div
-        ref={scrollContainerRef}
-        className="flex-1 overflow-auto relative p-3"
-      >
-        <FindBar
-          open={findBarOpen}
-          onClose={handleClose}
-          matchCount={searchMatches.length}
-          currentMatch={searchCurrentIndex}
-          onSearch={handleSearch}
-          onNext={handleNext}
-          onPrevious={handlePrevious}
-          replaceEnabled={false}
-          replaceExpanded={false}
-          onReplaceExpandedChange={() => {}}
-        />
-        {allowScripts && unsafeHtml !== null ? (
-          <iframe
-            sandbox="allow-scripts"
-            srcDoc={unsafeHtml}
-            title={`Rendered HTML (scripts enabled): ${fileName}`}
-            aria-label={`Rendered HTML: ${fileName}`}
-            className="w-full h-full rounded-lg border border-border shadow-sm bg-white"
-            style={{ minHeight: "60vh", zoom }}
-          />
-        ) : (
-          <div
-            ref={renderRef}
-            className="bg-white text-black rounded-lg border border-border shadow-sm p-6 max-w-3xl mx-auto"
-            style={{ zoom }}
-            aria-label={`Rendered HTML: ${fileName}`}
-            dangerouslySetInnerHTML={{ __html: sanitisedBody }}
-          />
-        )}
-      </div>
-    </div>
+    </>
   );
 }

--- a/src/components/editor/viewers/__tests__/HtmlViewer.test.tsx
+++ b/src/components/editor/viewers/__tests__/HtmlViewer.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import "@/test/tauri-mock";
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { HtmlViewer } from "../HtmlViewer";
 import { PlainTextViewer } from "../PlainTextViewer";
@@ -68,8 +68,8 @@ describe("HtmlViewer", () => {
         saveFileWithContent={vi.fn()}
       />
     );
-    // There should be a toggle button
-    const toggleButton = screen.getByRole("button", { name: /source|rendered|code|preview/i });
+    // There should be a source-view toggle button in rendered mode
+    const toggleButton = screen.getByRole("button", { name: /switch to source view/i });
     expect(toggleButton).toBeTruthy();
   });
 
@@ -88,8 +88,8 @@ describe("HtmlViewer", () => {
     // Initially in rendered mode — no code editor
     expect(screen.queryByTestId("code-editor")).toBeNull();
 
-    // Click toggle to source mode
-    const toggleButton = screen.getByRole("button", { name: /source|rendered|code|preview/i });
+    // Click source toggle
+    const toggleButton = screen.getByRole("button", { name: /switch to source view/i });
     fireEvent.click(toggleButton);
 
     // Should now show CodeEditor
@@ -109,10 +109,10 @@ describe("HtmlViewer", () => {
       />
     );
     // Click to enter source mode
-    fireEvent.click(screen.getByRole("button", { name: /source|rendered|code|preview/i }));
+    fireEvent.click(screen.getByRole("button", { name: /switch to source view/i }));
     expect(screen.getByTestId("code-editor")).toBeTruthy();
-    // Click again to return to rendered mode (re-query the new button)
-    fireEvent.click(screen.getByRole("button", { name: /source|rendered|code|preview/i }));
+    // Click the rendered-view button to return
+    fireEvent.click(screen.getByRole("button", { name: /switch to rendered view/i }));
     expect(screen.queryByTestId("code-editor")).toBeNull();
     // Inline-rendered body is back, and the rendered text is visible.
     expect(screen.getByText("Hello")).toBeTruthy();
@@ -349,5 +349,111 @@ describe("HtmlViewer allow-scripts mode — htmlViewerAllowScripts", () => {
       const srcdoc = iframe!.getAttribute("srcdoc") ?? "";
       expect(srcdoc).toContain("console.log('local-script-executed')");
     });
+  });
+});
+
+describe("HtmlViewer — Unsafe preview mode", () => {
+  const htmlWithScript =
+    '<html><body><h1>CDN App</h1><script src="https://cdn.example.com/lib.js"></script></body></html>';
+  const fileName = "app.html";
+  const filePath = "/path/to/app.html";
+
+  // Unsafe-mode tests must run with the `htmlViewerAllowScripts` setting OFF
+  // so the setting-driven iframe path doesn't preempt the toolbar-toggle path.
+  // The setting is a sticky persisted value; reset before AND after each test.
+  beforeEach(() => {
+    useSettingsStore.setState({ htmlViewerAllowScripts: false } as Parameters<typeof useSettingsStore.setState>[0]);
+  });
+  afterEach(() => {
+    useSettingsStore.setState({ htmlViewerAllowScripts: false } as Parameters<typeof useSettingsStore.setState>[0]);
+  });
+
+  const defaultProps = {
+    content: htmlWithScript,
+    fileName,
+    filePath,
+    tabId: "tab-unsafe-1",
+    isDirty: false,
+    updateTabContent: vi.fn(),
+    saveFileWithContent: vi.fn(),
+  };
+
+  it("renders an 'Unsafe preview mode' toggle button in the toolbar (default OFF)", () => {
+    render(<HtmlViewer {...defaultProps} />);
+    // The toggle must exist in the rendered-mode toolbar
+    const toggle = screen.getByRole("button", { name: /unsafe preview/i });
+    expect(toggle).toBeTruthy();
+    // No iframe by default — DOMPurify safe mode is active
+    expect(document.querySelector("iframe")).toBeNull();
+  });
+
+  it("clicking the Unsafe preview toggle shows a security acknowledgment dialog", () => {
+    render(<HtmlViewer {...defaultProps} />);
+    const toggle = screen.getByRole("button", { name: /unsafe preview/i });
+    fireEvent.click(toggle);
+    // AlertDialog must appear with a recognisable warning
+    expect(screen.getByRole("alertdialog")).toBeTruthy();
+    // Dialog must offer Accept and Cancel actions
+    expect(screen.getByRole("button", { name: /accept|enable|confirm/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeTruthy();
+  });
+
+  it("accepting the dialog renders raw HTML in a sandboxed iframe (allow-scripts)", () => {
+    render(<HtmlViewer {...defaultProps} />);
+    fireEvent.click(screen.getByRole("button", { name: /unsafe preview/i }));
+    fireEvent.click(screen.getByRole("button", { name: /accept|enable|confirm/i }));
+    // An iframe must replace the dangerouslySetInnerHTML div
+    const iframe = document.querySelector("iframe");
+    expect(iframe).not.toBeNull();
+    // sandbox must be exactly allow-scripts (no allow-same-origin)
+    expect(iframe!.getAttribute("sandbox")).toBe("allow-scripts");
+    // The raw HTML (including the CDN script tag) must be in srcdoc — not stripped
+    const srcdoc = iframe!.getAttribute("srcdoc") ?? "";
+    expect(srcdoc).toContain("cdn.example.com");
+    expect(srcdoc).toContain("CDN App");
+  });
+
+  it("cancelling the dialog keeps DOMPurify safe mode active — no iframe", () => {
+    render(<HtmlViewer {...defaultProps} />);
+    fireEvent.click(screen.getByRole("button", { name: /unsafe preview/i }));
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    // No iframe — DOMPurify path remains
+    expect(document.querySelector("iframe")).toBeNull();
+    // Scripts are still stripped
+    expect(document.querySelector("script")).toBeNull();
+  });
+
+  it("unsafe mode resets to OFF when tabId changes (session-only)", () => {
+    const { rerender } = render(<HtmlViewer {...defaultProps} tabId="tab-a" />);
+    // Activate unsafe mode
+    fireEvent.click(screen.getByRole("button", { name: /unsafe preview/i }));
+    fireEvent.click(screen.getByRole("button", { name: /accept|enable|confirm/i }));
+    expect(document.querySelector("iframe")).not.toBeNull();
+
+    // Simulate tab switch by changing tabId
+    rerender(<HtmlViewer {...defaultProps} tabId="tab-b" />);
+    // Unsafe mode must reset — no iframe
+    expect(document.querySelector("iframe")).toBeNull();
+  });
+
+  it("DOMPurify path unchanged — script tags stripped when unsafe mode is OFF (regression guard)", () => {
+    render(<HtmlViewer {...defaultProps} />);
+    // No unsafe mode activation — safe path only
+    expect(document.querySelector("script")).toBeNull();
+    expect(document.querySelector("iframe")).toBeNull();
+    // The non-script content is still rendered
+    expect(screen.getByText("CDN App")).toBeTruthy();
+  });
+
+  it("unsafe mode iframe passes the full raw HTML content through without sanitisation", () => {
+    const inlineScript =
+      '<html><body><h1>Inline</h1><script>window._test = 42;</script></body></html>';
+    render(<HtmlViewer {...defaultProps} content={inlineScript} />);
+    fireEvent.click(screen.getByRole("button", { name: /unsafe preview/i }));
+    fireEvent.click(screen.getByRole("button", { name: /accept|enable|confirm/i }));
+    const iframe = document.querySelector("iframe");
+    expect(iframe).not.toBeNull();
+    // Raw inline script is preserved in srcdoc
+    expect(iframe!.getAttribute("srcdoc")).toContain("window._test = 42");
   });
 });


### PR DESCRIPTION
Resolves #185

## Summary

Adds a per-session **Unsafe preview mode** toggle button to the HTML viewer toolbar. When activated (after a one-time-per-session security acknowledgment dialog), the viewer renders the raw HTML file in a sandboxed iframe (`sandbox="allow-scripts"`) instead of the DOMPurify-sanitised inline div. This allows external CDN scripts and inline script blocks to execute — a trusted-file escape hatch for users with self-contained HTML tools or reports.

The DOMPurify safe path is completely unchanged. The toggle is session-only (defaults OFF, resets on tab switch), and no persistent setting is added.

## Red tests added

- `HtmlViewer — Unsafe preview mode > renders an 'Unsafe preview mode' toggle button in the toolbar (default OFF)` — toggle exists in rendered-mode toolbar
- `HtmlViewer — Unsafe preview mode > clicking the Unsafe preview toggle shows a security acknowledgment dialog` — dialog with Accept/Cancel appears on click
- `HtmlViewer — Unsafe preview mode > accepting the dialog renders raw HTML in a sandboxed iframe (allow-scripts)` — iframe with `sandbox="allow-scripts"` rendered; raw HTML (including CDN script tags) in srcdoc
- `HtmlViewer — Unsafe preview mode > cancelling the dialog keeps DOMPurify safe mode active — no iframe` — Cancel leaves DOMPurify path, no iframe
- `HtmlViewer — Unsafe preview mode > unsafe mode resets to OFF when tabId changes (session-only)` — rerender with new tabId removes iframe
- `HtmlViewer — Unsafe preview mode > DOMPurify path unchanged — script tags stripped when unsafe mode is OFF (regression guard)` — passes before impl (correctly; tests existing unchanged behavior)
- `HtmlViewer — Unsafe preview mode > unsafe mode iframe passes the full raw HTML content through without sanitisation` — inline script text present in srcdoc

Also updated 3 existing tests that used an overly broad button-name regex (`/source|rendered|code|preview/i`) that would now match both the new "Unsafe preview" button and the "Source" button — updated to use the specific aria-labels (`Switch to source view` / `Switch to rendered view`).

## Green implementation

- `src/components/editor/viewers/HtmlViewer.tsx` — added `unsafeMode` + `showConfirmDialog` state; reset effect on `tabId` change; "Unsafe preview mode" toolbar button (ShieldAlert icon); `AlertDialog` confirmation; iframe rendering branch when unsafe mode is active
- `src/components/editor/viewers/__tests__/HtmlViewer.test.tsx` — 7 new tests + 3 existing test queries tightened

## Refactor

Skipped — implementation is already minimal.

## Decisions made

- **Iframe sandbox level: `allow-scripts` only (no `allow-same-origin`)** | Chosen | Stricter default prevents script access to localStorage/sessionStorage; matches the assumption in the issue body. Override by comment.
- **AlertDialog from shadcn/ui (not a custom modal)** | Chosen | Consistent with other confirmation dialogs in the codebase (TabBar unsaved-changes dialog uses the same pattern).
- **Toggle clicking active unsafe mode turns it OFF without re-prompting** | Chosen | Simpler UX than requiring a second confirmation to deactivate; the risk is entering unsafe mode accidentally (handled by the initial dialog), not disabling it.
- **Zoom and FindBar are suppressed in unsafe mode** | Chosen | The iframe is a foreign document; `zoom` CSS and DOM search utilities can't reach inside it. Both are hidden/no-op when `unsafeMode` is true to avoid misleading UI state.

## Verification

- [x] Red tests were red before implementation
- [x] All red tests now green
- [x] `pnpm test` passes (full suite — 4946 tests)
- [x] `pnpm typecheck` clean
- [x] No unrelated files modified

## Notes for reviewer

- The iframe uses `srcdoc` (not `src`), so no network request is made for the document itself — CDN *scripts referenced inside* the HTML will make network requests when the iframe loads (that's the intent).
- `allow-scripts` without `allow-same-origin` means scripts in the iframe run in a unique opaque origin — they cannot read `localStorage`, `document.cookie`, or `window.opener`. This is the recommended sandbox config for "run scripts but don't give them storage access."
- Find-in-document and zoom are disabled in unsafe mode (toolbar shows no zoom %, FindBar not rendered). Both are DOM-based utilities that cannot cross the iframe boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the \`aw-tdd\` skill.