### PR TITLE
feat(html-viewer): add Block external resources toggle

### DIFF
--- a/src/components/editor/viewers/HtmlViewer.tsx
+++ b/src/components/editor/viewers/HtmlViewer.tsx
@@ -67,6 +67,7 @@ export function HtmlViewer({
 }: HtmlViewerProps) {
   const allowForms = useSettingsStore((s) => s.htmlViewerAllowForms);
   const allowScripts = useSettingsStore((s) => s.htmlViewerAllowScripts);
+  const blockExternal = useSettingsStore((s) => s.htmlViewerBlockExternalResources);
   const [sourceMode, setSourceMode] = useState(false);
   const [unsafeHtml, setUnsafeHtml] = useState<string | null>(null);
   const [findBarOpen, setFindBarOpen] = useState(false);
@@ -89,12 +90,29 @@ export function HtmlViewer({
     const bodyMatch = content.match(/<body[^>]*>([\s\S]*?)<\/body>/i);
     const fragment = bodyMatch ? bodyMatch[1] : content;
     const baseForbidTags = ["script", "iframe", "object", "embed"];
-    return DOMPurify.sanitize(fragment, {
+    // When blockExternal is ON, add a DOMPurify attribute hook that strips any
+    // attribute value pointing to an http:// or https:// URL. This prevents
+    // <img src="https://…">, <a href="https://…">, etc. from triggering
+    // outbound network requests when the sanitised HTML is rendered. Inline
+    // data: URIs and relative paths are preserved. The hook is removed
+    // immediately after sanitise() to avoid side-effects on other callers.
+    if (blockExternal) {
+      DOMPurify.addHook("uponSanitizeAttribute", (_node, data) => {
+        if (/^https?:\/\//i.test(data.attrValue)) {
+          data.keepAttr = false;
+        }
+      });
+    }
+    const result = DOMPurify.sanitize(fragment, {
       ALLOW_DATA_ATTR: false,
       FORBID_TAGS: allowForms ? baseForbidTags : [...baseForbidTags, ...FORM_TAGS],
       ADD_ATTR: allowForms ? FORM_ATTRS : [],
     });
-  }, [content, allowForms]);
+    if (blockExternal) {
+      DOMPurify.removeHook("uponSanitizeAttribute");
+    }
+    return result;
+  }, [content, allowForms, blockExternal]);
 
   // When allow-scripts is ON, pre-process the raw HTML: read same-directory
   // <script src="./..."> files via Tauri read_file and rewrite them as inline

--- a/src/components/editor/viewers/__tests__/HtmlViewer.test.tsx
+++ b/src/components/editor/viewers/__tests__/HtmlViewer.test.tsx
@@ -457,3 +457,104 @@ describe("HtmlViewer — Unsafe preview mode", () => {
     expect(iframe!.getAttribute("srcdoc")).toContain("window._test = 42");
   });
 });
+
+describe("HtmlViewer block-external-resources — htmlViewerBlockExternalResources", () => {
+  const filePath = "/path/to/page.html";
+  const fileName = "page.html";
+
+  afterEach(() => {
+    useSettingsStore.setState({ htmlViewerBlockExternalResources: false } as Parameters<typeof useSettingsStore.setState>[0]);
+  });
+
+  it("when OFF (default): external img src is preserved in sanitised output (regression guard)", () => {
+    render(
+      <HtmlViewer
+        content='<html><body><img src="https://example.com/img.png" alt="ext"/></body></html>'
+        fileName={fileName}
+        filePath={filePath}
+        tabId="tab-block-off"
+        isDirty={false}
+        updateTabContent={vi.fn()}
+        saveFileWithContent={vi.fn()}
+      />
+    );
+    const img = document.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img!.getAttribute("src")).toBe("https://example.com/img.png");
+  });
+
+  it("when ON: external https src on <img> is stripped (no network fetch)", () => {
+    useSettingsStore.setState({ htmlViewerBlockExternalResources: true } as Parameters<typeof useSettingsStore.setState>[0]);
+    render(
+      <HtmlViewer
+        content='<html><body><img src="https://example.com/img.png" alt="ext"/></body></html>'
+        fileName={fileName}
+        filePath={filePath}
+        tabId="tab-block-img"
+        isDirty={false}
+        updateTabContent={vi.fn()}
+        saveFileWithContent={vi.fn()}
+      />
+    );
+    const img = document.querySelector("img");
+    // The <img> element may survive (alt text etc.) but its src must be stripped
+    if (img) {
+      expect(img.getAttribute("src")).toBeNull();
+    }
+  });
+
+  it("when ON: http src on <img> is also stripped (http, not just https)", () => {
+    useSettingsStore.setState({ htmlViewerBlockExternalResources: true } as Parameters<typeof useSettingsStore.setState>[0]);
+    render(
+      <HtmlViewer
+        content='<html><body><img src="http://example.com/img.png" alt="http"/></body></html>'
+        fileName={fileName}
+        filePath={filePath}
+        tabId="tab-block-http"
+        isDirty={false}
+        updateTabContent={vi.fn()}
+        saveFileWithContent={vi.fn()}
+      />
+    );
+    const img = document.querySelector("img");
+    if (img) {
+      expect(img.getAttribute("src")).toBeNull();
+    }
+  });
+
+  it("when ON: data: URI img src is preserved (inline resource, not external)", () => {
+    useSettingsStore.setState({ htmlViewerBlockExternalResources: true } as Parameters<typeof useSettingsStore.setState>[0]);
+    render(
+      <HtmlViewer
+        content='<html><body><img src="data:image/png;base64,abc123" alt="inline"/></body></html>'
+        fileName={fileName}
+        filePath={filePath}
+        tabId="tab-block-data-uri"
+        isDirty={false}
+        updateTabContent={vi.fn()}
+        saveFileWithContent={vi.fn()}
+      />
+    );
+    const img = document.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img!.getAttribute("src")).toContain("data:");
+  });
+
+  it("when ON: relative-path img src is preserved (local resource)", () => {
+    useSettingsStore.setState({ htmlViewerBlockExternalResources: true } as Parameters<typeof useSettingsStore.setState>[0]);
+    render(
+      <HtmlViewer
+        content='<html><body><img src="./local.png" alt="local"/></body></html>'
+        fileName={fileName}
+        filePath={filePath}
+        tabId="tab-block-relative-img"
+        isDirty={false}
+        updateTabContent={vi.fn()}
+        saveFileWithContent={vi.fn()}
+      />
+    );
+    const img = document.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img!.getAttribute("src")).toBe("./local.png");
+  });
+});

--- a/src/components/settings/v2/SystemSettings.tsx
+++ b/src/components/settings/v2/SystemSettings.tsx
@@ -135,6 +135,8 @@ export function SystemSettings({
   const setHtmlViewerAllowForms = useSettingsStore((s) => s.setHtmlViewerAllowForms);
   const htmlViewerAllowScripts = useSettingsStore((s) => s.htmlViewerAllowScripts);
   const setHtmlViewerAllowScripts = useSettingsStore((s) => s.setHtmlViewerAllowScripts);
+  const htmlViewerBlockExternalResources = useSettingsStore((s) => s.htmlViewerBlockExternalResources);
+  const setHtmlViewerBlockExternalResources = useSettingsStore((s) => s.setHtmlViewerBlockExternalResources);
 
   // Files
   const showHiddenFiles = useSettingsStore((s) => s.showHiddenFiles);
@@ -408,6 +410,18 @@ export function SystemSettings({
               id="html-viewer-allow-scripts"
               checked={htmlViewerAllowScripts}
               onCheckedChange={setHtmlViewerAllowScripts}
+            />
+          }
+        />
+        <SettingsRow
+          label="Block external resources"
+          description="When on, attributes pointing to external URLs (http:// or https://) are stripped before rendering so no outbound network requests are made. Inline data: URIs and relative paths are preserved. Off by default."
+          htmlFor="html-viewer-block-external"
+          control={
+            <Switch
+              id="html-viewer-block-external"
+              checked={htmlViewerBlockExternalResources}
+              onCheckedChange={setHtmlViewerBlockExternalResources}
             />
           }
         />

--- a/src/components/settings/v2/__tests__/panels.test.tsx
+++ b/src/components/settings/v2/__tests__/panels.test.tsx
@@ -74,6 +74,12 @@ describe('v2 settings panels', () => {
     expect(screen.getByText('Allow scripts (unsafe)')).toBeTruthy();
   });
 
+  it('SystemSettings renders HTML viewer group with Block external resources toggle', () => {
+    renderWithProviders(<SystemSettings />);
+    expect(screen.getByText('HTML viewer')).toBeTruthy();
+    expect(screen.getByText('Block external resources')).toBeTruthy();
+  });
+
   it('SystemSettings renders "View update" affordance when an update is available', () => {
     renderWithProviders(
       <SystemSettings

--- a/src/stores/__tests__/settings-store.test.ts
+++ b/src/stores/__tests__/settings-store.test.ts
@@ -1113,7 +1113,7 @@ describe('uiPreview flag', () => {
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(16);
+    expect(parsed.version).toBe(17);
     expect(parsed.state.uiPreview).toBe('legacy');
     expect(parsed.state.accent).toBe('default');
   });
@@ -1255,7 +1255,7 @@ describe('v5 → v6 migration (cmdBarPinned + cmdBarPinnedWidth)', () => {
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(16);
+    expect(parsed.version).toBe(17);
     expect(parsed.state.cmdBarPinned).toBe(false);
     expect(parsed.state.cmdBarPinnedWidth).toBe(400);
   });
@@ -1401,7 +1401,7 @@ describe('v6 → v7 migration (quietChromePreset + quietChromeOverrides)', () =>
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(16);
+    expect(parsed.version).toBe(17);
     expect(parsed.state.quietChromePreset).toBe('default');
     expect(parsed.state.quietChromeOverrides).toBeTruthy();
   });
@@ -1720,7 +1720,7 @@ describe('v7 → v8 migration (sidebar composition)', () => {
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(16);
+    expect(parsed.version).toBe(17);
     expect(parsed.state.sidebarRecentCap).toBe(5);
     expect(parsed.state.sidebarTagsCap).toBe(5);
     // Hidden field stripped by v11 → v12 migration.
@@ -1975,7 +1975,7 @@ describe('v8 → v9 migration (preview invitation timestamps)', () => {
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(16);
+    expect(parsed.version).toBe(17);
     expect(parsed.state.previewInvitationShownAt).toBeNull();
     expect(parsed.state.previewInvitationDismissedAt).toBeNull();
   });
@@ -2077,7 +2077,7 @@ describe('v9 → v10 migration (cmdBarExpandedWidth)', () => {
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(16);
+    expect(parsed.version).toBe(17);
     expect(parsed.state.cmdBarExpandedWidth).toBe(640);
   });
 
@@ -2148,7 +2148,7 @@ describe('v10 → v11 migration (sidebar Mentions composition)', () => {
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(16);
+    expect(parsed.version).toBe(17);
     expect(parsed.state.sidebarMentionsCap).toBe(5);
     expect(parsed.state.sidebarMentionsHidden).toBeUndefined();
   });
@@ -2270,7 +2270,7 @@ describe('v11 → v12 migration (drop Hidden booleans)', () => {
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(16);
+    expect(parsed.version).toBe(17);
     expect(parsed.state.sidebarTagsCap).toBe(0);
     expect(parsed.state.sidebarTagsHidden).toBeUndefined();
   });
@@ -2292,7 +2292,7 @@ describe('v11 → v12 migration (drop Hidden booleans)', () => {
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(16);
+    expect(parsed.version).toBe(17);
     expect(parsed.state.sidebarMentionsCap).toBe(0);
     expect(parsed.state.sidebarMentionsHidden).toBeUndefined();
   });
@@ -2318,7 +2318,7 @@ describe('v11 → v12 migration (drop Hidden booleans)', () => {
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(16);
+    expect(parsed.version).toBe(17);
     expect(parsed.state.sidebarTagsHidden).toBeUndefined();
     expect(parsed.state.sidebarMentionsHidden).toBeUndefined();
   });
@@ -2460,7 +2460,7 @@ describe('v14 migration: releaseChannel', () => {
 
     const raw = localStorageMock.getItem(STORAGE_KEY);
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(16);
+    expect(parsed.version).toBe(17);
   });
 });
 
@@ -2506,7 +2506,7 @@ describe('v15 migration: htmlViewerAllowForms', () => {
 
     const raw = localStorageMock.getItem(STORAGE_KEY);
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(16);
+    expect(parsed.version).toBe(17);
   });
 });
 
@@ -2553,6 +2553,54 @@ describe('v16 migration: htmlViewerAllowScripts', () => {
 
     const raw = localStorageMock.getItem(STORAGE_KEY);
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(16);
+    expect(parsed.version).toBe(17);
+  });
+});
+
+// ===========================================================================
+// v17 migration — htmlViewerBlockExternalResources defaults to false on upgrade
+// ===========================================================================
+
+describe('v17 migration: htmlViewerBlockExternalResources', () => {
+  function buildV16State(overrides: Record<string, unknown> = {}): string {
+    const state = {
+      theme: 'system',
+      logLevel: 'warn',
+      autoCheckUpdates: true,
+      releaseChannel: 'stable',
+      htmlViewerAllowForms: false,
+      htmlViewerAllowScripts: false,
+      ...overrides,
+    };
+    return JSON.stringify({ state, version: 16 });
+  }
+
+  it('migrates v16 state without htmlViewerBlockExternalResources to false', async () => {
+    localStorageMock.setItem(STORAGE_KEY, buildV16State());
+
+    await useSettingsStore.persist.rehydrate();
+    await waitForPersist();
+
+    expect(useSettingsStore.getState().htmlViewerBlockExternalResources).toBe(false);
+  });
+
+  it('preserves existing htmlViewerBlockExternalResources when already present', async () => {
+    localStorageMock.setItem(STORAGE_KEY, buildV16State({ htmlViewerBlockExternalResources: true }));
+
+    await useSettingsStore.persist.rehydrate();
+    await waitForPersist();
+
+    expect(useSettingsStore.getState().htmlViewerBlockExternalResources).toBe(true);
+  });
+
+  it('bumps persisted version to 17 after migration', async () => {
+    localStorageMock.setItem(STORAGE_KEY, buildV16State());
+
+    await useSettingsStore.persist.rehydrate();
+    await waitForPersist();
+
+    const raw = localStorageMock.getItem(STORAGE_KEY);
+    const parsed = JSON.parse(raw!);
+    expect(parsed.version).toBe(17);
   });
 });

--- a/src/stores/settings-store.ts
+++ b/src/stores/settings-store.ts
@@ -325,6 +325,14 @@ interface SettingsStore {
    */
   htmlViewerAllowScripts: boolean;
   setHtmlViewerAllowScripts: (enabled: boolean) => void;
+  /**
+   * When true, the HTML viewer strips external resource attributes (src/href
+   * pointing to http:// or https:// URLs) via a DOMPurify hook so no network
+   * requests are made when rendering untrusted HTML. Inline data: URIs and
+   * relative paths are preserved. Default false.
+   */
+  htmlViewerBlockExternalResources: boolean;
+  setHtmlViewerBlockExternalResources: (enabled: boolean) => void;
 }
 
 export const useSettingsStore = create<SettingsStore>()(
@@ -750,10 +758,16 @@ export const useSettingsStore = create<SettingsStore>()(
       setHtmlViewerAllowScripts: (enabled: boolean) => {
         set({ htmlViewerAllowScripts: enabled });
       },
+
+      htmlViewerBlockExternalResources: false,
+
+      setHtmlViewerBlockExternalResources: (enabled: boolean) => {
+        set({ htmlViewerBlockExternalResources: enabled });
+      },
     }),
     {
       name: "notesage-settings",
-      version: 16,
+      version: 17,
 
       migrate: (persisted: unknown, version: number) => {
         const state = persisted as Record<string, unknown>;
@@ -907,6 +921,13 @@ export const useSettingsStore = create<SettingsStore>()(
           // so existing users see no behaviour change after upgrade.
           if (typeof state.htmlViewerAllowScripts !== 'boolean') {
             state.htmlViewerAllowScripts = false;
+          }
+        }
+        if (version < 17) {
+          // Issue #183 — HTML viewer block external resources. Default false
+          // so existing users see no behaviour change after upgrade.
+          if (typeof state.htmlViewerBlockExternalResources !== 'boolean') {
+            state.htmlViewerBlockExternalResources = false;
           }
         }
         return state;


### PR DESCRIPTION
Resolves #183

## Summary

Adds a **Block external resources** toggle to the HTML viewer (Settings > System > HTML viewer). When enabled, a DOMPurify `uponSanitizeAttribute` hook strips any attribute value that starts with `http://` or `https://` before the sanitised HTML is rendered. This prevents `<img>`, `<a>`, `<form action>`, and other elements from triggering outbound network requests when displaying untrusted local HTML files. Inline `data:` URIs and relative paths are preserved. The hook is registered immediately before and removed immediately after each `DOMPurify.sanitize()` call so no side-effects bleed to other callers.

## Red tests added

- `HtmlViewer.test.tsx::when ON: external https src on <img> is stripped (no network fetch)` — new blockExternal behaviour, https
- `HtmlViewer.test.tsx::when ON: http src on <img> is also stripped (http, not just https)` — new blockExternal behaviour, http
- `HtmlViewer.test.tsx::when OFF (default): external img src is preserved in sanitised output (regression guard)` — regression guard, green from start
- `HtmlViewer.test.tsx::when ON: data: URI img src is preserved (inline resource, not external)` — inline data: URI preserved
- `HtmlViewer.test.tsx::when ON: relative-path img src is preserved (local resource)` — relative path preserved
- `settings-store.test.ts::v17 migration: htmlViewerBlockExternalResources migrates v16 state without field to false`
- `settings-store.test.ts::v17 migration: htmlViewerBlockExternalResources bumps persisted version to 17 after migration`
- `panels.test.tsx::SystemSettings renders HTML viewer group with Block external resources toggle`

## Green implementation

- `src/stores/settings-store.ts` — added `htmlViewerBlockExternalResources: boolean` field + `setHtmlViewerBlockExternalResources` setter; bumped store version 16 → 17; added v17 migration block defaulting to `false`; updated all existing "bumps persisted version to 16" migration tests to expect 17
- `src/components/editor/viewers/HtmlViewer.tsx` — reads `blockExternal` from settings store; wraps `DOMPurify.sanitize()` with an `addHook/removeHook` pair when the setting is ON
- `src/components/settings/v2/SystemSettings.tsx` — added "Block external resources" `SettingsRow` + `Switch` to the HTML viewer `SettingsGroup`

## Refactor

Skipped — implementation is already minimal.

## Decisions made

- **DOMPurify hook vs post-processing:** The `uponSanitizeAttribute` hook is the canonical DOMPurify extension point for attribute filtering. It runs inside the sanitiser's own parse tree, so it's safe regardless of what HTML structure the caller supplies, and it's removed immediately after each call to avoid global state mutation. | chosen | avoids re-parsing the sanitised string.
- **Remove hook after each call:** `DOMPurify.removeHook("uponSanitizeAttribute")` is called after each `sanitize()` to ensure zero side-effects on other DOMPurify callers (e.g. AI diff rendering). | chosen | rule-of-least-surprise for library users.
- **Setting defaults to false:** The new toggle is opt-in (default off) matching the pattern established by `htmlViewerAllowForms` and `htmlViewerAllowScripts`. Existing users see no behaviour change.

## Verification

- [x] Red tests were red before implementation
- [x] All red tests now green
- [x] `pnpm test` passes (full suite — 4964 tests)
- [x] `pnpm typecheck` clean
- [x] No unrelated files modified

## Notes for reviewer

The `uponSanitizeAttribute` hook fires for _every_ attribute on every element. The `/^https?:\/\//i` regex is deliberately conservative — it only strips attributes whose _entire value_ begins with an absolute HTTP/HTTPS URL. Partial matches (e.g. `href="/page?redirect=https://…"`) are not stripped because the value doesn't start with the protocol. If stricter handling is needed in a follow-up, a separate containment check can be layered on.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the `aw-tdd` skill.