### PR TITLE
feat(html-viewer): add Block external resources toggle (#183)

### DIFF
--- a/src/components/editor/viewers/HtmlViewer.tsx
+++ b/src/components/editor/viewers/HtmlViewer.tsx
@@ -67,6 +67,7 @@ export function HtmlViewer({
 }: HtmlViewerProps) {
   const allowForms = useSettingsStore((s) => s.htmlViewerAllowForms);
   const allowScripts = useSettingsStore((s) => s.htmlViewerAllowScripts);
+  const blockExternal = useSettingsStore((s) => s.htmlViewerBlockExternalResources);
   const [sourceMode, setSourceMode] = useState(false);
   const [unsafeHtml, setUnsafeHtml] = useState<string | null>(null);
   const [findBarOpen, setFindBarOpen] = useState(false);
@@ -89,12 +90,30 @@ export function HtmlViewer({
     const bodyMatch = content.match(/<body[^>]*>([\s\S]*?)<\/body>/i);
     const fragment = bodyMatch ? bodyMatch[1] : content;
     const baseForbidTags = ["script", "iframe", "object", "embed"];
-    return DOMPurify.sanitize(fragment, {
+
+    // When block-external-resources is ON, add a hook that strips attribute
+    // values starting with `https?:` from `src`, `href`, and `srcset`.
+    // The hook is added immediately before sanitise() and removed after so it
+    // does not leak into other DOMPurify consumers (ai-suggestion.ts, etc.).
+    if (blockExternal) {
+      DOMPurify.addHook("uponSanitizeAttribute", (_node, data) => {
+        if (!["src", "href", "srcset"].includes(data.attrName)) return;
+        if (/^https?:/i.test(data.attrValue)) data.keepAttr = false;
+      });
+    }
+
+    const result = DOMPurify.sanitize(fragment, {
       ALLOW_DATA_ATTR: false,
       FORBID_TAGS: allowForms ? baseForbidTags : [...baseForbidTags, ...FORM_TAGS],
       ADD_ATTR: allowForms ? FORM_ATTRS : [],
     });
-  }, [content, allowForms]);
+
+    if (blockExternal) {
+      DOMPurify.removeHook("uponSanitizeAttribute");
+    }
+
+    return result;
+  }, [content, allowForms, blockExternal]);
 
   // When allow-scripts is ON, pre-process the raw HTML: read same-directory
   // <script src="./..."> files via Tauri read_file and rewrite them as inline

--- a/src/components/editor/viewers/__tests__/HtmlViewer.test.tsx
+++ b/src/components/editor/viewers/__tests__/HtmlViewer.test.tsx
@@ -352,6 +352,149 @@ describe("HtmlViewer allow-scripts mode — htmlViewerAllowScripts", () => {
   });
 });
 
+describe("HtmlViewer — block external resources — htmlViewerBlockExternalResources", () => {
+  const filePath = "/path/to/page.html";
+  const fileName = "page.html";
+
+  afterEach(() => {
+    useSettingsStore.setState({ htmlViewerBlockExternalResources: false } as Parameters<typeof useSettingsStore.setState>[0]);
+  });
+
+  it("when OFF (default): remote https:// img src passes through (regression guard)", () => {
+    render(
+      <HtmlViewer
+        content='<html><body><img src="https://example.com/photo.jpg" alt="remote"></body></html>'
+        fileName={fileName}
+        filePath={filePath}
+        tabId="tab-block-ext-off"
+        isDirty={false}
+        updateTabContent={vi.fn()}
+        saveFileWithContent={vi.fn()}
+      />
+    );
+    const img = document.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img!.getAttribute("src")).toBe("https://example.com/photo.jpg");
+  });
+
+  it("when ON: remote https:// img src is stripped before render", () => {
+    useSettingsStore.setState({ htmlViewerBlockExternalResources: true } as Parameters<typeof useSettingsStore.setState>[0]);
+    render(
+      <HtmlViewer
+        content='<html><body><img src="https://example.com/photo.jpg" alt="remote"></body></html>'
+        fileName={fileName}
+        filePath={filePath}
+        tabId="tab-block-ext-on-https"
+        isDirty={false}
+        updateTabContent={vi.fn()}
+        saveFileWithContent={vi.fn()}
+      />
+    );
+    const img = document.querySelector("img");
+    expect(img).not.toBeNull();
+    // src must be stripped (falsy or absent) — no remote fetch
+    expect(img!.getAttribute("src")).toBeFalsy();
+  });
+
+  it("when ON: remote http:// img src is also stripped", () => {
+    useSettingsStore.setState({ htmlViewerBlockExternalResources: true } as Parameters<typeof useSettingsStore.setState>[0]);
+    render(
+      <HtmlViewer
+        content='<html><body><img src="http://example.com/photo.jpg" alt="remote http"></body></html>'
+        fileName={fileName}
+        filePath={filePath}
+        tabId="tab-block-ext-on-http"
+        isDirty={false}
+        updateTabContent={vi.fn()}
+        saveFileWithContent={vi.fn()}
+      />
+    );
+    const img = document.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img!.getAttribute("src")).toBeFalsy();
+  });
+
+  it("when ON: relative-path img src is preserved (only remote URIs stripped)", () => {
+    useSettingsStore.setState({ htmlViewerBlockExternalResources: true } as Parameters<typeof useSettingsStore.setState>[0]);
+    render(
+      <HtmlViewer
+        content='<html><body><img src="./images/photo.jpg" alt="local"></body></html>'
+        fileName={fileName}
+        filePath={filePath}
+        tabId="tab-block-ext-rel-img"
+        isDirty={false}
+        updateTabContent={vi.fn()}
+        saveFileWithContent={vi.fn()}
+      />
+    );
+    const img = document.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img!.getAttribute("src")).toBe("./images/photo.jpg");
+  });
+
+  it("when ON: inline <style> blocks — DOMPurify strips <style> elements from body fragments by default (pre-existing behaviour, not our hook)", () => {
+    useSettingsStore.setState({ htmlViewerBlockExternalResources: true } as Parameters<typeof useSettingsStore.setState>[0]);
+    render(
+      <HtmlViewer
+        content='<html><body><style>body { color: red; }</style><p>Styled</p></body></html>'
+        fileName={fileName}
+        filePath={filePath}
+        tabId="tab-block-ext-style"
+        isDirty={false}
+        updateTabContent={vi.fn()}
+        saveFileWithContent={vi.fn()}
+      />
+    );
+    // Note: DOMPurify strips <style> elements from body fragments by default
+    // (they are not in DOMPurify's safe-element list for fragment mode).
+    // This is pre-existing behaviour introduced BEFORE this PR — the
+    // `uponSanitizeAttribute` hook only processes attributes on elements that
+    // survive the element-filter pass, so it does not change <style> handling.
+    // The surrounding paragraph still renders correctly.
+    expect(document.querySelector("style")).toBeNull();
+    expect(screen.getByText("Styled")).toBeTruthy();
+  });
+
+  it("when ON: <link href=\"https://...\"> is absent — DOMPurify strips <link> elements by default (pre-existing behaviour, not our hook)", () => {
+    useSettingsStore.setState({ htmlViewerBlockExternalResources: true } as Parameters<typeof useSettingsStore.setState>[0]);
+    render(
+      <HtmlViewer
+        content='<html><body><link href="https://cdn.example.com/style.css" rel="stylesheet"><p>No external CSS</p></body></html>'
+        fileName={fileName}
+        filePath={filePath}
+        tabId="tab-block-ext-link-https"
+        isDirty={false}
+        updateTabContent={vi.fn()}
+        saveFileWithContent={vi.fn()}
+      />
+    );
+    // DOMPurify strips <link> elements entirely (not in the safe-by-default allowlist).
+    // Our hook would strip the href if <link> were allowed — but the element never reaches it.
+    // Either way the remote stylesheet is NOT applied, which is the acceptance criterion.
+    expect(document.querySelector("link")).toBeNull();
+  });
+
+  it("when ON: <link href=\"./styles.css\"> (relative path) is also absent — DOMPurify strips <link> by default", () => {
+    useSettingsStore.setState({ htmlViewerBlockExternalResources: true } as Parameters<typeof useSettingsStore.setState>[0]);
+    render(
+      <HtmlViewer
+        content='<html><body><link href="./styles.css" rel="stylesheet"><p>Local CSS</p></body></html>'
+        fileName={fileName}
+        filePath={filePath}
+        tabId="tab-block-ext-link-rel"
+        isDirty={false}
+        updateTabContent={vi.fn()}
+        saveFileWithContent={vi.fn()}
+      />
+    );
+    // DOMPurify strips <link> regardless of toggle state — the hook targets src/href/srcset
+    // attribute values that begin with https?:, so a relative-path <link> href is NOT
+    // affected by our hook even if the element were allowed. Both ON and OFF produce
+    // no <link> element in the sanitised output (pre-existing DOMPurify behaviour).
+    expect(document.querySelector("link")).toBeNull();
+  });
+});
+
 describe("HtmlViewer — Unsafe preview mode", () => {
   const htmlWithScript =
     '<html><body><h1>CDN App</h1><script src="https://cdn.example.com/lib.js"></script></body></html>';

--- a/src/components/settings/v2/SystemSettings.tsx
+++ b/src/components/settings/v2/SystemSettings.tsx
@@ -135,6 +135,8 @@ export function SystemSettings({
   const setHtmlViewerAllowForms = useSettingsStore((s) => s.setHtmlViewerAllowForms);
   const htmlViewerAllowScripts = useSettingsStore((s) => s.htmlViewerAllowScripts);
   const setHtmlViewerAllowScripts = useSettingsStore((s) => s.setHtmlViewerAllowScripts);
+  const htmlViewerBlockExternalResources = useSettingsStore((s) => s.htmlViewerBlockExternalResources);
+  const setHtmlViewerBlockExternalResources = useSettingsStore((s) => s.setHtmlViewerBlockExternalResources);
 
   // Files
   const showHiddenFiles = useSettingsStore((s) => s.showHiddenFiles);
@@ -408,6 +410,18 @@ export function SystemSettings({
               id="html-viewer-allow-scripts"
               checked={htmlViewerAllowScripts}
               onCheckedChange={setHtmlViewerAllowScripts}
+            />
+          }
+        />
+        <SettingsRow
+          label="Block external resources"
+          description="When on, remote images, stylesheets, and fonts (URLs starting with http:// or https://) are stripped before rendering. Inline styles, data: URIs, and relative-path resources are unaffected. Takes effect on the next file open or switch."
+          htmlFor="html-viewer-block-external"
+          control={
+            <Switch
+              id="html-viewer-block-external"
+              checked={htmlViewerBlockExternalResources}
+              onCheckedChange={setHtmlViewerBlockExternalResources}
             />
           }
         />

--- a/src/components/settings/v2/__tests__/panels.test.tsx
+++ b/src/components/settings/v2/__tests__/panels.test.tsx
@@ -74,6 +74,12 @@ describe('v2 settings panels', () => {
     expect(screen.getByText('Allow scripts (unsafe)')).toBeTruthy();
   });
 
+  it('SystemSettings renders HTML viewer group with Block external resources toggle', () => {
+    renderWithProviders(<SystemSettings />);
+    expect(screen.getByText('HTML viewer')).toBeTruthy();
+    expect(screen.getByText('Block external resources')).toBeTruthy();
+  });
+
   it('SystemSettings renders "View update" affordance when an update is available', () => {
     renderWithProviders(
       <SystemSettings

--- a/src/stores/__tests__/settings-store.test.ts
+++ b/src/stores/__tests__/settings-store.test.ts
@@ -1113,7 +1113,7 @@ describe('uiPreview flag', () => {
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(16);
+    expect(parsed.version).toBe(17);
     expect(parsed.state.uiPreview).toBe('legacy');
     expect(parsed.state.accent).toBe('default');
   });
@@ -1255,7 +1255,7 @@ describe('v5 → v6 migration (cmdBarPinned + cmdBarPinnedWidth)', () => {
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(16);
+    expect(parsed.version).toBe(17);
     expect(parsed.state.cmdBarPinned).toBe(false);
     expect(parsed.state.cmdBarPinnedWidth).toBe(400);
   });
@@ -1401,7 +1401,7 @@ describe('v6 → v7 migration (quietChromePreset + quietChromeOverrides)', () =>
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(16);
+    expect(parsed.version).toBe(17);
     expect(parsed.state.quietChromePreset).toBe('default');
     expect(parsed.state.quietChromeOverrides).toBeTruthy();
   });
@@ -1720,7 +1720,7 @@ describe('v7 → v8 migration (sidebar composition)', () => {
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(16);
+    expect(parsed.version).toBe(17);
     expect(parsed.state.sidebarRecentCap).toBe(5);
     expect(parsed.state.sidebarTagsCap).toBe(5);
     // Hidden field stripped by v11 → v12 migration.
@@ -1975,7 +1975,7 @@ describe('v8 → v9 migration (preview invitation timestamps)', () => {
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(16);
+    expect(parsed.version).toBe(17);
     expect(parsed.state.previewInvitationShownAt).toBeNull();
     expect(parsed.state.previewInvitationDismissedAt).toBeNull();
   });
@@ -2077,7 +2077,7 @@ describe('v9 → v10 migration (cmdBarExpandedWidth)', () => {
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(16);
+    expect(parsed.version).toBe(17);
     expect(parsed.state.cmdBarExpandedWidth).toBe(640);
   });
 
@@ -2148,7 +2148,7 @@ describe('v10 → v11 migration (sidebar Mentions composition)', () => {
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(16);
+    expect(parsed.version).toBe(17);
     expect(parsed.state.sidebarMentionsCap).toBe(5);
     expect(parsed.state.sidebarMentionsHidden).toBeUndefined();
   });
@@ -2270,7 +2270,7 @@ describe('v11 → v12 migration (drop Hidden booleans)', () => {
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(16);
+    expect(parsed.version).toBe(17);
     expect(parsed.state.sidebarTagsCap).toBe(0);
     expect(parsed.state.sidebarTagsHidden).toBeUndefined();
   });
@@ -2292,7 +2292,7 @@ describe('v11 → v12 migration (drop Hidden booleans)', () => {
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(16);
+    expect(parsed.version).toBe(17);
     expect(parsed.state.sidebarMentionsCap).toBe(0);
     expect(parsed.state.sidebarMentionsHidden).toBeUndefined();
   });
@@ -2318,7 +2318,7 @@ describe('v11 → v12 migration (drop Hidden booleans)', () => {
     const raw = localStorageMock.getItem(STORAGE_KEY);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(16);
+    expect(parsed.version).toBe(17);
     expect(parsed.state.sidebarTagsHidden).toBeUndefined();
     expect(parsed.state.sidebarMentionsHidden).toBeUndefined();
   });
@@ -2460,7 +2460,7 @@ describe('v14 migration: releaseChannel', () => {
 
     const raw = localStorageMock.getItem(STORAGE_KEY);
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(16);
+    expect(parsed.version).toBe(17);
   });
 });
 
@@ -2506,7 +2506,7 @@ describe('v15 migration: htmlViewerAllowForms', () => {
 
     const raw = localStorageMock.getItem(STORAGE_KEY);
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(16);
+    expect(parsed.version).toBe(17);
   });
 });
 
@@ -2553,6 +2553,65 @@ describe('v16 migration: htmlViewerAllowScripts', () => {
 
     const raw = localStorageMock.getItem(STORAGE_KEY);
     const parsed = JSON.parse(raw!);
-    expect(parsed.version).toBe(16);
+    expect(parsed.version).toBe(17);
+  });
+});
+
+// ===========================================================================
+// v17 migration — htmlViewerBlockExternalResources defaults to false on upgrade
+// ===========================================================================
+
+describe('v17 migration: htmlViewerBlockExternalResources', () => {
+  function buildV16State(overrides: Record<string, unknown> = {}): string {
+    const state = {
+      theme: 'system',
+      logLevel: 'warn',
+      autoCheckUpdates: true,
+      releaseChannel: 'stable',
+      htmlViewerAllowForms: false,
+      htmlViewerAllowScripts: false,
+      ...overrides,
+    };
+    return JSON.stringify({ state, version: 16 });
+  }
+
+  it('htmlViewerBlockExternalResources defaults to false (new installs)', () => {
+    expect(useSettingsStore.getState().htmlViewerBlockExternalResources).toBe(false);
+  });
+
+  it('setHtmlViewerBlockExternalResources toggles the setting', () => {
+    useSettingsStore.getState().setHtmlViewerBlockExternalResources(true);
+    expect(useSettingsStore.getState().htmlViewerBlockExternalResources).toBe(true);
+    useSettingsStore.getState().setHtmlViewerBlockExternalResources(false);
+    expect(useSettingsStore.getState().htmlViewerBlockExternalResources).toBe(false);
+  });
+
+  it('migrates v16 state without htmlViewerBlockExternalResources to false', async () => {
+    localStorageMock.setItem(STORAGE_KEY, buildV16State());
+
+    await useSettingsStore.persist.rehydrate();
+    await waitForPersist();
+
+    expect(useSettingsStore.getState().htmlViewerBlockExternalResources).toBe(false);
+  });
+
+  it('preserves existing htmlViewerBlockExternalResources when already present', async () => {
+    localStorageMock.setItem(STORAGE_KEY, buildV16State({ htmlViewerBlockExternalResources: true }));
+
+    await useSettingsStore.persist.rehydrate();
+    await waitForPersist();
+
+    expect(useSettingsStore.getState().htmlViewerBlockExternalResources).toBe(true);
+  });
+
+  it('bumps persisted version to 17 after migration', async () => {
+    localStorageMock.setItem(STORAGE_KEY, buildV16State());
+
+    await useSettingsStore.persist.rehydrate();
+    await waitForPersist();
+
+    const raw = localStorageMock.getItem(STORAGE_KEY);
+    const parsed = JSON.parse(raw!);
+    expect(parsed.version).toBe(17);
   });
 });

--- a/src/stores/settings-store.ts
+++ b/src/stores/settings-store.ts
@@ -325,6 +325,16 @@ interface SettingsStore {
    */
   htmlViewerAllowScripts: boolean;
   setHtmlViewerAllowScripts: (enabled: boolean) => void;
+  /**
+   * When true, the HTML viewer strips external network resources (remote `src`,
+   * `href`, and `srcset` attribute values starting with `https?:`) via a
+   * DOMPurify `uponSanitizeAttribute` hook before rendering. Inline `<style>`
+   * blocks, `data:` URIs, `blob:` URIs, and relative paths are unaffected.
+   * Default false (all resources load freely — matching the natural
+   * "open an HTML file and see what's in it" behaviour most users expect).
+   */
+  htmlViewerBlockExternalResources: boolean;
+  setHtmlViewerBlockExternalResources: (enabled: boolean) => void;
 }
 
 export const useSettingsStore = create<SettingsStore>()(
@@ -750,10 +760,16 @@ export const useSettingsStore = create<SettingsStore>()(
       setHtmlViewerAllowScripts: (enabled: boolean) => {
         set({ htmlViewerAllowScripts: enabled });
       },
+
+      htmlViewerBlockExternalResources: false,
+
+      setHtmlViewerBlockExternalResources: (enabled: boolean) => {
+        set({ htmlViewerBlockExternalResources: enabled });
+      },
     }),
     {
       name: "notesage-settings",
-      version: 16,
+      version: 17,
 
       migrate: (persisted: unknown, version: number) => {
         const state = persisted as Record<string, unknown>;
@@ -907,6 +923,13 @@ export const useSettingsStore = create<SettingsStore>()(
           // so existing users see no behaviour change after upgrade.
           if (typeof state.htmlViewerAllowScripts !== 'boolean') {
             state.htmlViewerAllowScripts = false;
+          }
+        }
+        if (version < 17) {
+          // Issue #183 — HTML viewer block-external-resources. Default false
+          // (all resources load freely) so existing users see no behaviour change.
+          if (typeof state.htmlViewerBlockExternalResources !== 'boolean') {
+            state.htmlViewerBlockExternalResources = false;
           }
         }
         return state;


### PR DESCRIPTION
## Summary

Implements issue #183 — adds a Settings > System > HTML viewer toggle to block external resources (remote images, stylesheets, fonts) when rendering local HTML files.

- New `htmlViewerBlockExternalResources` boolean in `settings-store` (version 16 → 17, migration defaults to `false` so existing users see no behaviour change)
- DOMPurify `uponSanitizeAttribute` hook in `HtmlViewer.tsx` strips `src`, `href`, and `srcset` attribute values matching `^https?:` before rendering; hook is added and removed around each `sanitize()` call to avoid leaking into other DOMPurify consumers
- "Block external resources" `Switch` row added to the HTML viewer `SettingsGroup` in `SystemSettings.tsx`
- Relative-path resources (`./image.png`), data: URIs, and inline styles are unaffected

## Decisions made

- **Scope: `src`/`href`/`srcset` only** — these are the attributes that fetch remote resources in rendered HTML. Other attributes (e.g. `action` on forms) are already handled by the `htmlViewerAllowForms` toggle.
- **DOMPurify hook, not post-processing** — uses the recommended `uponSanitizeAttribute` hook rather than DOM tree post-processing, ensuring stripping happens in the same sanitise pass and avoids a second parse.
- **`<link>` and `<style>` elements**: DOMPurify strips both from body fragments by default (they are not in the safe-element list). This pre-existing behaviour means external stylesheets referenced via `<link href="https://...">` are already absent from the rendered tree — our hook's `href` attribute strip would be redundant for link elements, but the hook runs on all elements so it is correct and consistent. Tests document this behaviour explicitly.
- **Default OFF** — preserves current behaviour for all existing users on upgrade; power users opt in.

## Test plan

- [x] `HtmlViewer.test.tsx` — 7 new tests covering: toggle OFF (regression guard), `https://` img stripped, `http://` img stripped, relative-path img preserved, `<style>` element behaviour (DOMPurify strips by default), `<link href="https://...">` behaviour (DOMPurify strips `<link>` by default), `<link href="./styles.css">` behaviour (same)
- [x] `settings-store.test.ts` — 5 new tests for v17 migration: default false on new install, setter toggles value, migrates v16 state, preserves existing value, version bumps to 17
- [x] `panels.test.tsx` — smoke test that "Block external resources" label renders in SystemSettings HTML viewer group
- [x] `pnpm test` — 4968 tests, 273 files, all passed
- [x] `pnpm typecheck` — clean

Resolves #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)