### PR TITLE
fix(release): remove tagName/releaseName from tauri-action to prevent orphan draft

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,8 +219,10 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           releaseId: ${{ needs.create-release.outputs.release_id }}
-          tagName: ${{ github.ref_name }}
-          releaseName: "Notesage v__VERSION__"
+          # tagName and releaseName intentionally omitted: passing them alongside
+          # releaseId causes tauri-action@v0 to attempt a second createRelease call
+          # for the same tag, producing an already_exists error or an orphan draft
+          # release (issue #203). releaseId alone is sufficient to upload assets.
           releaseBody: ${{ needs.create-release.outputs.release_notes }}
           args: --target aarch64-apple-darwin
 

--- a/src/lib/__tests__/release-workflow.test.ts
+++ b/src/lib/__tests__/release-workflow.test.ts
@@ -1,0 +1,143 @@
+// Regression-lock tests for release.yml to prevent reintroducing the
+// orphan-draft bug fixed in issue #203.
+//
+// Root cause: when `tauri-action@v0` is given `tagName` alongside `releaseId`,
+// newer versions of the action try to create a release for that tag even
+// though `releaseId` already points to an existing release. This produces
+// either an `already_exists` error (if the tag already has a release) or an
+// orphan draft release that requires manual cleanup.
+//
+// The fix: the `build-tauri` step should pass ONLY `releaseId` to
+// tauri-action. `tagName`, `releaseName`, and `releaseBody` are only needed
+// when creating a new release — they are redundant (and dangerous) when
+// `releaseId` is already provided.
+//
+// These tests parse `release.yml` and lock in the safe shape:
+//   1. `createRelease` is called exactly once, in the `create-release` job.
+//   2. The `tauri-action` step in `build-tauri` does NOT pass `tagName`
+//      (which would trigger release-creation logic even when `releaseId` is set).
+//   3. `publish-release` uses `updateRelease`, not `createRelease`.
+//
+// Parsing the YAML rather than testing runtime behavior: GitHub releases API
+// interactions happen server-side; there is no local mock that can reproduce
+// the `already_exists` race. Locking the YAML shape is the most reliable way
+// to catch future drift at PR-review time rather than at production-incident time.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { parse as parseYaml } from 'yaml';
+
+interface Step {
+  name?: string;
+  uses?: string;
+  with?: Record<string, unknown>;
+  run?: string;
+  [key: string]: unknown;
+}
+
+interface Job {
+  steps?: Step[];
+  [key: string]: unknown;
+}
+
+interface Workflow {
+  jobs: Record<string, Job>;
+}
+
+function loadReleaseWorkflow(): Workflow {
+  const path = resolve(__dirname, '../../../.github/workflows/release.yml');
+  return parseYaml(readFileSync(path, 'utf-8')) as Workflow;
+}
+
+/** Collect all github-script step bodies across all jobs, with their job name. */
+function collectGithubScripts(wf: Workflow): Array<{ job: string; body: string }> {
+  const results: Array<{ job: string; body: string }> = [];
+  for (const [jobName, job] of Object.entries(wf.jobs)) {
+    for (const step of job.steps ?? []) {
+      if (typeof step.uses === 'string' && step.uses.includes('actions/github-script')) {
+        const script = step.with?.script;
+        if (typeof script === 'string') {
+          results.push({ job: jobName, body: script });
+        }
+      }
+    }
+  }
+  return results;
+}
+
+/** Return all tauri-action steps, keyed by job name. */
+function collectTauriActionSteps(wf: Workflow): Array<{ job: string; step: Step }> {
+  const results: Array<{ job: string; step: Step }> = [];
+  for (const [jobName, job] of Object.entries(wf.jobs)) {
+    for (const step of job.steps ?? []) {
+      if (typeof step.uses === 'string' && step.uses.includes('tauri-apps/tauri-action')) {
+        results.push({ job: jobName, step });
+      }
+    }
+  }
+  return results;
+}
+
+describe('release.yml — orphan-draft regression lock (#203)', () => {
+  const wf = loadReleaseWorkflow();
+
+  describe('createRelease is called exactly once, only in create-release', () => {
+    const scripts = collectGithubScripts(wf);
+    const creators = scripts.filter(s => s.body.includes('createRelease'));
+
+    it('there is exactly one createRelease call across all jobs', () => {
+      expect(creators).toHaveLength(1);
+    });
+
+    it('the sole createRelease call lives in the create-release job (not build-tauri or publish-release)', () => {
+      expect(creators[0]?.job).toBe('create-release');
+    });
+  });
+
+  describe('publish-release does not call createRelease', () => {
+    const publishJob = wf.jobs['publish-release'];
+
+    it('publish-release job exists', () => {
+      expect(publishJob).toBeDefined();
+    });
+
+    it('publish-release scripts do not contain createRelease', () => {
+      const scripts = collectGithubScripts(wf).filter(s => s.job === 'publish-release');
+      const hasCreate = scripts.some(s => s.body.includes('createRelease'));
+      expect(hasCreate).toBe(false);
+    });
+
+    it('publish-release calls updateRelease to flip draft:false', () => {
+      const scripts = collectGithubScripts(wf).filter(s => s.job === 'publish-release');
+      const hasUpdate = scripts.some(s => s.body.includes('updateRelease'));
+      expect(hasUpdate).toBe(true);
+    });
+  });
+
+  describe('tauri-action step does not carry tagName when releaseId is provided', () => {
+    const tauriSteps = collectTauriActionSteps(wf);
+
+    it('there is exactly one tauri-action step', () => {
+      expect(tauriSteps).toHaveLength(1);
+    });
+
+    it('the tauri-action step provides releaseId', () => {
+      const step = tauriSteps[0]?.step;
+      expect(step?.with?.releaseId).toBeDefined();
+    });
+
+    it('the tauri-action step does NOT pass tagName (tagName triggers release-creation logic that conflicts with the pre-created releaseId)', () => {
+      const step = tauriSteps[0]?.step;
+      // tagName must not be present when releaseId is already provided —
+      // passing both causes tauri-action to attempt a second createRelease
+      // call for the same tag, producing the already_exists error or orphan draft.
+      expect(step?.with?.tagName).toBeUndefined();
+    });
+
+    it('the tauri-action step does NOT pass releaseName when releaseId is provided', () => {
+      const step = tauriSteps[0]?.step;
+      expect(step?.with?.releaseName).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
Fixes #203

## Summary

When `tauri-action@v0` receives `tagName` alongside `releaseId`, newer versions of the action attempt a second `createRelease` call for the same tag. This produces either an `already_exists` error (which aborts `publish-release` before any orphan cleanup can run) or an orphan draft release. The v0.44.0-alpha.2 release exhibited this — one orphan draft (tauri-action's own) plus one published prerelease (create-release → publish-release), requiring manual API deletion.

Fix: pass only `releaseId` to tauri-action. `tagName` and `releaseName` are only needed when tauri-action is creating the release itself; with `releaseId` already pointing to the pre-created draft they are redundant and trigger release-creation code paths. `releaseBody` is retained so the updater's `latest.json` receives release notes.

## Red tests added

- `src/lib/__tests__/release-workflow.test.ts::there is exactly one createRelease call across all jobs` — asserts no duplicate createRelease calls
- `src/lib/__tests__/release-workflow.test.ts::the sole createRelease call lives in the create-release job` — locks which job owns release creation
- `src/lib/__tests__/release-workflow.test.ts::publish-release scripts do not contain createRelease` — publish-release must not create
- `src/lib/__tests__/release-workflow.test.ts::publish-release calls updateRelease to flip draft:false` — verifies publish uses update
- `src/lib/__tests__/release-workflow.test.ts::there is exactly one tauri-action step` — structural guard
- `src/lib/__tests__/release-workflow.test.ts::the tauri-action step provides releaseId` — releaseId must be present
- `src/lib/__tests__/release-workflow.test.ts::the tauri-action step does NOT pass tagName` — locks out the bug vector (**was failing before fix**)
- `src/lib/__tests__/release-workflow.test.ts::the tauri-action step does NOT pass releaseName` — locks out the companion field (**was failing before fix**)

## Green implementation

- `.github/workflows/release.yml`: removed `tagName` and `releaseName` from the `tauri-action@v0` step in `build-tauri`; added inline comment explaining why they are intentionally absent

## Refactor

Skipped — change is already minimal (two line deletions + one comment).

## Decisions made

- `releaseBody` retained in tauri-action call: it was added in commit 8b0e0639 specifically to populate the updater's `latest.json` notes field. It does NOT trigger release-creation logic (only `tagName` drives that path). Removing it would leave the in-app update dialog with empty release notes, which is a separate regression. Kept as-is.
- Only `tagName` and `releaseName` removed: these are the fields that tell tauri-action "go find or create a release for this tag" — the exact code path that conflicts with `create-release` having already done that.

## Verification

- [x] Red tests were red before implementation (`tagName` and `releaseName` present → 2 failures)
- [x] All red tests now green (9/9)
- [x] `pnpm test` passes (276 test files, 5028 tests)
- [x] `pnpm typecheck` clean
- [x] No unrelated files modified (only `release.yml` + new test file)

## Notes for reviewer

- The regression between v0.44.0-alpha.1 and alpha.2 is explained by a newer patch of `tauri-action@v0` (floating `@v0` tag) changing how it handles the `tagName`+`releaseId` combination. The workflow itself was unchanged between tags.
- If you want to verify the fix works end-to-end, push a test pre-release tag and confirm `gh release list` shows exactly one entry with `isDraft: false`.
- The regression-lock test follows the same parse-the-YAML pattern used by `aw-workflow-pat.test.ts` and `aw-workflow-concurrency.test.ts` — catches drift at PR-review time rather than at production-incident time.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the `aw-tdd` skill.