### PR TITLE
fix(editor): restore scroll guard for zero-height collapsed cursor

### DIFF
--- a/src/hooks/__tests__/useCursorScrollGuard.test.ts
+++ b/src/hooks/__tests__/useCursorScrollGuard.test.ts
@@ -94,6 +94,35 @@ function mockCursorAt(cursorBottom: number): void {
   vi.spyOn(window, 'getSelection').mockReturnValue(selection as unknown as Selection);
 }
 
+/**
+ * Mock a collapsed (zero-height) cursor at a given y-position.
+ *
+ * This simulates a cursor at an empty line: the range reports height=0
+ * because there are no characters on the line, but top/bottom still
+ * reflect the cursor's real screen position.
+ */
+function mockCollapsedCursorAt(cursorY: number): void {
+  const range = {
+    collapse: vi.fn(),
+    getBoundingClientRect: vi.fn(() => ({
+      top: cursorY,
+      bottom: cursorY, // height === 0: top === bottom
+      height: 0,
+      width: 0,
+      left: 100,
+      right: 100,
+      x: 100,
+      y: cursorY,
+      toJSON: () => ({}),
+    })),
+  };
+  const selection = {
+    rangeCount: 1,
+    getRangeAt: vi.fn(() => range),
+  };
+  vi.spyOn(window, 'getSelection').mockReturnValue(selection as unknown as Selection);
+}
+
 /** Mock window.getSelection to return no selection. */
 function mockNoSelection(): void {
   vi.spyOn(window, 'getSelection').mockReturnValue(null);
@@ -167,6 +196,56 @@ describe('useCursorScrollGuard', () => {
     const scrollContainerRef = { current: el };
     renderHook(() => useCursorScrollGuard(scrollContainerRef));
 
+    act(() => { fireKeydown(); });
+
+    expect(scrollBy).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // Regression: zero-height (collapsed) cursor — issue #210
+  //
+  // When the cursor is on an empty line the browser may report a range rect
+  // with height === 0.  The previous guard `if (cursorRect.height === 0) return`
+  // caused the hook to bail out even when the cursor y-position was behind the
+  // cmd bar, re-introducing the bug fixed by PR #182.
+  // -------------------------------------------------------------------------
+
+  it('scrolls when cursor rect has zero height but is below the safe zone (regression #210)', () => {
+    const { el, scrollBy } = mountScrollContainer();
+    const cmdBarTopEdge = 500;
+    mountCmdBar(cmdBarTopEdge);
+    // Collapsed cursor at y=480 — safeBottom = 500-60 = 440, overlap = 40
+    mockCollapsedCursorAt(480);
+
+    renderHook(() => useCursorScrollGuard({ current: el }));
+    act(() => { fireKeydown(); });
+
+    expect(scrollBy).toHaveBeenCalledTimes(1);
+    expect(scrollBy).toHaveBeenCalledWith(
+      expect.objectContaining({ top: 40 }),
+    );
+  });
+
+  it('does not scroll when cursor rect is fully degenerate (all zeros)', () => {
+    const { el, scrollBy } = mountScrollContainer();
+    mountCmdBar(500);
+    // Degenerate rect: all zeros — no valid screen position
+    mockCollapsedCursorAt(0);
+
+    renderHook(() => useCursorScrollGuard({ current: el }));
+    act(() => { fireKeydown(); });
+
+    expect(scrollBy).not.toHaveBeenCalled();
+  });
+
+  it('does not scroll when zero-height cursor is above the safe zone', () => {
+    const { el, scrollBy } = mountScrollContainer();
+    const cmdBarTopEdge = 600;
+    mountCmdBar(cmdBarTopEdge);
+    // Collapsed cursor at y=400 — safeBottom = 600-60 = 540, no overlap
+    mockCollapsedCursorAt(400);
+
+    renderHook(() => useCursorScrollGuard({ current: el }));
     act(() => { fireKeydown(); });
 
     expect(scrollBy).not.toHaveBeenCalled();

--- a/src/hooks/useCursorScrollGuard.ts
+++ b/src/hooks/useCursorScrollGuard.ts
@@ -40,7 +40,11 @@ export function useCursorScrollGuard(
 
     const range = selection.getRangeAt(0);
     const cursorRect = range.getBoundingClientRect();
-    if (!cursorRect || cursorRect.height === 0) return;
+    // Guard against a fully degenerate rect (browser returned all-zero values,
+    // meaning the range has no screen position — e.g. selection outside the
+    // rendered viewport).  A collapsed cursor on an empty line is NOT degenerate:
+    // it has height === 0 but valid top/bottom reflecting its real y position.
+    if (!cursorRect || (cursorRect.top === 0 && cursorRect.bottom === 0)) return;
 
     const safeBottom = cmdBar.getBoundingClientRect().top - BREATHING_ROOM_PX;
 


### PR DESCRIPTION
Fixes #210

## Summary

The `useCursorScrollGuard` hook was bailing out early when the cursor's `getBoundingClientRect()` reported `height === 0`. This happens on empty lines — the browser returns a collapsed rect where `top === bottom` (a valid screen position, just with no character height). After CSS `zoom` was applied to the editor content wrapper in commit `17ffcba8`, cursors at empty lines near the bottom of long documents would be hidden behind the floating command bar with no auto-scroll recovery, re-introducing the bug fixed by PR #182.

**Root cause:** The guard `if (!cursorRect || cursorRect.height === 0) return` incorrectly treated all zero-height rects as "no position available". A cursor on an empty line is a collapsed range (`top === bottom`, `height === 0`) but still has a valid, non-zero `top`/`bottom` that reflects the cursor's real y-position in the viewport.

**Fix:** Replace the `height === 0` guard with a check for a fully degenerate rect (`top === 0 && bottom === 0`), which is the actual signal that `getBoundingClientRect()` has no renderable position to report. Collapsed cursors on visible empty lines now correctly participate in the safe-zone comparison and trigger the upward scroll when needed.

## Red tests added

- `src/hooks/__tests__/useCursorScrollGuard.test.ts::scrolls when cursor rect has zero height but is below the safe zone (regression #210)` — covers the primary regression: collapsed cursor (height=0) below the cmd bar safe zone must trigger scroll
- `src/hooks/__tests__/useCursorScrollGuard.test.ts::does not scroll when cursor rect is fully degenerate (all zeros)` — regression guard: fully degenerate rect (browser returned no position) remains a no-op
- `src/hooks/__tests__/useCursorScrollGuard.test.ts::does not scroll when zero-height cursor is above the safe zone` — regression guard: collapsed cursor already above the safe zone is correctly left alone

## Green implementation

- `src/hooks/useCursorScrollGuard.ts` — replaced `cursorRect.height === 0` early-return guard with `cursorRect.top === 0 && cursorRect.bottom === 0` (fully-degenerate-rect check)

## Refactor

Skipped — the change is a single guard condition replacement; no structural cleanup needed.

## Decisions made

- **What counts as "degenerate":** Using `top === 0 && bottom === 0` rather than checking all six rect fields. A cursor at the very top of the viewport (y=0) would be above the cmd bar safe zone regardless, so false-skipping it is harmless; checking only top+bottom avoids overly defensive code.
- **No CSS zoom compensation:** Investigation confirmed the coordinate math in `scrollBy` vs `getBoundingClientRect` is consistent regardless of CSS zoom on a child element (the scroll container itself is not zoomed, so the delta is in the same pixel space as the viewport coords returned by the Range API). No zoom correction is needed.

## Verification

- [x] Red tests were red before implementation
- [x] All red tests now green
- [x] `pnpm test` passes (full suite — 5078 tests, 278 files)
- [x] `pnpm typecheck` clean
- [x] No unrelated files modified (only `useCursorScrollGuard.ts` and its test file)

## Notes for reviewer

The two "additive" tests (`does not scroll when cursor rect is fully degenerate` and `does not scroll when zero-height cursor is above the safe zone`) were GREEN before implementation — they cover existing behavior preserved by the fix. Only the primary regression test was RED before implementation, as required.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the `aw-tdd` skill.