### PR TITLE
fix(export): preserve multi-line table cells in PDF, DOCX, and HTML export

### DIFF
--- a/src-tauri/src/export/markdown_to_docx.rs
+++ b/src-tauri/src/export/markdown_to_docx.rs
@@ -529,9 +529,17 @@ impl<'a> DocxConverter<'a> {
                 self.cell_runs = Some(Vec::new());
             }
             NodeValue::HtmlInline(ref html) => {
-                // Pass HTML comments through for table metadata
-                if html.trim().starts_with("<!--") {
+                let trimmed = html.trim();
+                if trimmed.starts_with("<!--") {
+                    // Pass HTML comments through for table metadata
                     self.add_text(html);
+                } else if trimmed == "<br>" || trimmed == "<br/>" || trimmed == "<br />" {
+                    // The Notesage editor serializes multi-block table-cell content
+                    // using <br> separators. Emit a text-wrapping break so both
+                    // lines appear on separate lines in the exported DOCX,
+                    // consistent with NodeValue::LineBreak handling.
+                    let run = self.style_run(Run::new().add_break(BreakType::TextWrapping));
+                    self.push_run(run);
                 }
             }
             NodeValue::HtmlBlock(ref hb) => {
@@ -2051,5 +2059,110 @@ mod tests {
         let bytes = result.unwrap();
         assert!(!bytes.is_empty());
         assert_eq!(&bytes[0..4], b"PK\x03\x04");
+    }
+
+    // --- Multi-line table cell (<br> separator) ---
+    // The Notesage editor serializes multi-block cell content as a single GFM row
+    // with <br>-separated text. Both parts must survive into the DOCX XML so the
+    // exported document shows the content on separate visual lines.
+
+    #[test]
+    fn test_table_multiline_cell_br_produces_valid_docx() {
+        // Verify that <br> in a table cell does not break DOCX generation
+        let md = "| Name | Notes |\n|---|---|\n| Alice | Line1<br>Line2 |\n";
+        let result = markdown_to_docx(
+            md,
+            "Test",
+            "clean",
+            &DocxOptions {
+                include_toc: false,
+                include_page_numbers: false,
+                page_size: "a4".to_string(),
+                project_root: None,
+            },
+            None,
+            None,
+            None,
+        );
+        assert!(result.is_ok(), "DOCX with multi-line table cell failed: {:?}", result.err());
+        let bytes = result.unwrap();
+        assert!(!bytes.is_empty());
+        assert_eq!(&bytes[0..4], b"PK\x03\x04");
+    }
+
+    #[test]
+    fn test_table_multiline_cell_br_both_lines_in_docx_xml() {
+        // Unzip the DOCX and verify the document.xml contains both cell text fragments.
+        use std::io::{Cursor, Read};
+        let md = "| Name | Notes |\n|---|---|\n| Alice | Line1<br>Line2 |\n";
+        let result = markdown_to_docx(
+            md,
+            "Test",
+            "clean",
+            &DocxOptions {
+                include_toc: false,
+                include_page_numbers: false,
+                page_size: "a4".to_string(),
+                project_root: None,
+            },
+            None,
+            None,
+            None,
+        );
+        let bytes = result.unwrap();
+        let cursor = Cursor::new(bytes);
+        let mut archive = zip::ZipArchive::new(cursor)
+            .expect("DOCX should be a valid zip archive");
+        let mut doc_xml = String::new();
+        archive
+            .by_name("word/document.xml")
+            .expect("word/document.xml should exist")
+            .read_to_string(&mut doc_xml)
+            .expect("should read document.xml");
+
+        assert!(
+            doc_xml.contains("Line1"),
+            "first line of multi-line cell missing from document.xml: {}",
+            &doc_xml[..doc_xml.len().min(2000)]
+        );
+        assert!(
+            doc_xml.contains("Line2"),
+            "second line of multi-line cell missing from document.xml: {}",
+            &doc_xml[..doc_xml.len().min(2000)]
+        );
+        // A text-wrapping break (<w:br w:type="textWrapping"/>) must appear
+        assert!(
+            doc_xml.contains("textWrapping"),
+            "text-wrapping break missing from document.xml: {}",
+            &doc_xml[..doc_xml.len().min(2000)]
+        );
+    }
+
+    #[test]
+    fn test_table_multiline_cell_br_self_closing_variants_docx() {
+        // All three <br> variants must produce a valid DOCX
+        for br in &["<br>", "<br/>", "<br />"] {
+            let md = format!("| A | B |\n|---|---|\n| x | Part1{}Part2 |\n", br);
+            let result = markdown_to_docx(
+                &md,
+                "Test",
+                "clean",
+                &DocxOptions {
+                    include_toc: false,
+                    include_page_numbers: false,
+                    page_size: "a4".to_string(),
+                    project_root: None,
+                },
+                None,
+                None,
+                None,
+            );
+            assert!(
+                result.is_ok(),
+                "DOCX with br variant '{}' failed: {:?}",
+                br,
+                result.err()
+            );
+        }
     }
 }

--- a/src-tauri/src/export/markdown_to_html.rs
+++ b/src-tauri/src/export/markdown_to_html.rs
@@ -49,6 +49,7 @@ pub fn markdown_to_html(markdown: &str, theme: &str, project_root: Option<&str>,
 
     // Post-process the HTML
     let html = postprocess_embedded_svgs(&html_output, embedded_svgs);
+    let html = postprocess_br_placeholders(&html);
     let html = postprocess_callouts(&html);
     let html = postprocess_link_previews(&html);
     let html = postprocess_sparklines(&html);
@@ -90,6 +91,15 @@ fn postprocess_embedded_svgs(html: &str, embedded_svgs: Option<&[String]>) -> St
         // Fallback: keep original code block
         caps.get(0).unwrap().as_str().to_string()
     }).to_string()
+}
+
+/// Replace `NOTESAGE_BR_PLACEHOLDER` tokens (inserted by `preprocess_markdown`
+/// for `<br>` tags in table cells) with actual HTML `<br>` elements.
+///
+/// comrak strips raw HTML when `unsafe_` is not set, so `<br>` in table cells
+/// is replaced with a safe placeholder before parsing and restored here.
+fn postprocess_br_placeholders(html: &str) -> String {
+    html.replace("NOTESAGE_BR_PLACEHOLDER", "<br>")
 }
 
 // ---------------------------------------------------------------------------
@@ -244,7 +254,20 @@ fn preprocess_markdown(markdown: &str, project_root: Option<&str>) -> (String, T
             current_table_meta.clear();
         }
 
-        result.push_str(line);
+        // Replace <br> in table data rows with a safe placeholder before comrak
+        // strips it (comrak replaces raw HTML with "<!-- raw HTML omitted -->"
+        // when unsafe_ is not set). The placeholder is replaced with <br> in
+        // postprocess_br_placeholders after comrak renders the HTML.
+        let line_to_write = if in_table && is_table_row && !is_separator && header_seen {
+            std::borrow::Cow::Owned(
+                line.replace("<br />", "NOTESAGE_BR_PLACEHOLDER")
+                    .replace("<br/>", "NOTESAGE_BR_PLACEHOLDER")
+                    .replace("<br>", "NOTESAGE_BR_PLACEHOLDER"),
+            )
+        } else {
+            std::borrow::Cow::Borrowed(line)
+        };
+        result.push_str(&line_to_write);
         result.push('\n');
     }
 
@@ -1067,5 +1090,61 @@ mod tests {
         let html = markdown_to_html(md, "light", None, None);
         assert!(html.contains("<h1>Chemistry</h1>"), "h1 Chemistry missing: {}", html);
         assert!(html.contains("<h1>Physics</h1>"), "h1 Physics missing: {}", html);
+    }
+
+    // --- Multi-line table cell (<br> separator) ---
+    // The Notesage editor serializes multi-block cell content as a single GFM row
+    // with <br>-separated text. Both parts must survive into the HTML output so
+    // the exported file renders both lines.
+
+    #[test]
+    fn test_table_multiline_cell_br_both_lines_in_html() {
+        // Notesage editor output: <br> separates multi-paragraph cell content
+        let md = "| Name | Notes |\n|---|---|\n| Alice | Line1<br>Line2 |\n";
+        let html = markdown_to_html(md, "light", None, None);
+        assert!(
+            html.contains("Line1"),
+            "first line of multi-line cell missing from HTML: {}",
+            html
+        );
+        assert!(
+            html.contains("Line2"),
+            "second line of multi-line cell missing from HTML: {}",
+            html
+        );
+    }
+
+    #[test]
+    fn test_table_multiline_cell_br_produces_br_tag_in_html() {
+        // The <br> separator must appear as an HTML <br> element so that the
+        // two lines render on separate visual lines in the browser.
+        let md = "| Name | Notes |\n|---|---|\n| Alice | Line1<br>Line2 |\n";
+        let html = markdown_to_html(md, "light", None, None);
+        assert!(
+            html.contains("<br") || html.contains("<br>") || html.contains("<br />"),
+            "HTML <br> element missing from output: {}",
+            html
+        );
+    }
+
+    #[test]
+    fn test_table_multiline_cell_br_self_closing_variants_html() {
+        // All three <br> variants must survive into the HTML output
+        for br in &["<br>", "<br/>", "<br />"] {
+            let md = format!("| A | B |\n|---|---|\n| x | Part1{}Part2 |\n", br);
+            let html = markdown_to_html(&md, "light", None, None);
+            assert!(
+                html.contains("Part1"),
+                "first part missing for br variant '{}': {}",
+                br,
+                html
+            );
+            assert!(
+                html.contains("Part2"),
+                "second part missing for br variant '{}': {}",
+                br,
+                html
+            );
+        }
     }
 }

--- a/src-tauri/src/export/markdown_to_typst.rs
+++ b/src-tauri/src/export/markdown_to_typst.rs
@@ -262,10 +262,16 @@ impl<'s> Converter<'s> {
                 self.write("\\\n");
             }
             NodeValue::HtmlInline(ref html) => {
-                // When inside a table cell, pass HTML comments through to the cell buffer
-                // so column metadata can be extracted by parse_column_metadata.
-                if self.cell_buffer.is_some() && html.trim().starts_with("<!--") {
+                let trimmed = html.trim();
+                if self.cell_buffer.is_some() && trimmed.starts_with("<!--") {
+                    // Pass HTML comments through to the cell buffer so column
+                    // metadata can be extracted by parse_column_metadata.
                     self.write(html);
+                } else if trimmed == "<br>" || trimmed == "<br/>" || trimmed == "<br />" {
+                    // The Notesage editor serializes multi-block table-cell content
+                    // using <br> separators. Treat these as Typst line breaks,
+                    // consistent with NodeValue::LineBreak.
+                    self.write("\\\n");
                 }
                 // Otherwise skip raw HTML — not representable in Typst
             }
@@ -1357,5 +1363,77 @@ fn main() {}
         let world = NotesageWorld::new(typst);
         let result = world.export_pdf();
         assert!(result.is_ok(), "PDF export with sub/sup failed: {:?}", result.err());
+    }
+
+    // --- Multi-line table cell (<br> separator) ---
+    // The Notesage editor serializes multi-block cell content as a single GFM row
+    // with <br>-separated text (e.g. "Line1<br>Line2"). Both parts must reach the
+    // Typst output so they appear in the exported PDF.
+
+    #[test]
+    fn test_table_multiline_cell_br_both_lines_present() {
+        // Notesage editor output for a cell with two paragraphs
+        let input = "| Name | Notes |\n|---|---|\n| Alice | Line1<br>Line2 |\n";
+        let output = markdown_to_typst(input, None);
+        assert!(
+            output.contains("Line1"),
+            "first line of multi-line cell missing from Typst output: {}",
+            output
+        );
+        assert!(
+            output.contains("Line2"),
+            "second line of multi-line cell missing from Typst output: {}",
+            output
+        );
+    }
+
+    #[test]
+    fn test_table_multiline_cell_br_has_line_break() {
+        // The two lines must be separated by a Typst line break (backslash-newline),
+        // not run together as one continuous string.
+        let input = "| Name | Notes |\n|---|---|\n| Alice | Line1<br>Line2 |\n";
+        let output = markdown_to_typst(input, None);
+        // Typst line break syntax is `\` followed by newline.
+        assert!(
+            output.contains("Line1\\\n") || output.contains("Line1\\"),
+            "Typst line break after first line missing: {}",
+            output
+        );
+    }
+
+    #[test]
+    fn test_table_multiline_cell_br_compiles_to_pdf() {
+        use super::super::typst_world::NotesageWorld;
+
+        let markdown = "# Meeting\n\n| Name | Notes |\n|---|---|\n| Alice | Arrived early<br>Took minutes |\n| Bob | Remote<br>Joined late |\n";
+        let typst = markdown_to_typst(markdown, None);
+        let world = NotesageWorld::new(typst);
+        let result = world.export_pdf();
+        assert!(
+            result.is_ok(),
+            "PDF export with multi-line table cells failed: {:?}",
+            result.err()
+        );
+    }
+
+    #[test]
+    fn test_table_multiline_cell_br_self_closing_variants() {
+        // Editor may emit <br>, <br/>, or <br /> — all must be treated as line breaks
+        for br in &["<br>", "<br/>", "<br />"] {
+            let input = format!("| A | B |\n|---|---|\n| x | Part1{}Part2 |\n", br);
+            let output = markdown_to_typst(&input, None);
+            assert!(
+                output.contains("Part1"),
+                "first part missing for br variant '{}': {}",
+                br,
+                output
+            );
+            assert!(
+                output.contains("Part2"),
+                "second part missing for br variant '{}': {}",
+                br,
+                output
+            );
+        }
     }
 }


### PR DESCRIPTION
## What

Fixes #209 — multi-line table cells (cells with more than one block, e.g. a paragraph followed by a bullet list) were silently losing their second-and-later parts in all three export formats.

## Root cause

The Notesage editor serializes multi-block table-cell content as a single GFM pipe-table row where cell parts are joined by literal `<br>` HTML tags:

```
| Name | Notes |
|---|---|
| Alice | Line1<br>Line2 |
```

All three export backends discarded these `<br>` tags:

| Backend | What happened |
|---|---|
| PDF (Typst) | `HtmlInline` handler only passed through `<!-- ... -->` comments; `<br>` was silently dropped, concatenating cell parts without any separator |
| DOCX | Same — `HtmlInline` only forwarded HTML comments |
| HTML | comrak replaces raw HTML with `<!-- raw HTML omitted -->` when `unsafe_` is not set, so `<br>` never reached the rendered output |

## Fix

- **`markdown_to_typst.rs`**: detect `<br>`, `<br/>`, `<br />` in `HtmlInline` handler and emit a Typst line break (`\\\n`), consistent with `NodeValue::LineBreak` handling.
- **`markdown_to_docx.rs`**: detect `<br>` variants in `HtmlInline` and push a `BreakType::TextWrapping` run, consistent with `NodeValue::LineBreak` handling.
- **`markdown_to_html.rs`**: replace `<br>` in table data rows with a safe placeholder `NOTESAGE_BR_PLACEHOLDER` in `preprocess_markdown` (before comrak strips it), then restore it as `<br>` in a new `postprocess_br_placeholders` step after comrak rendering.

## Tests

10 new unit tests added across the three export modules:

- `test_table_multiline_cell_br_both_lines_present` — Typst output contains both cell text parts
- `test_table_multiline_cell_br_has_line_break` — Typst output contains a line-break marker
- `test_table_multiline_cell_br_compiles_to_pdf` — end-to-end PDF compilation succeeds
- `test_table_multiline_cell_br_self_closing_variants` — all three `<br>` variants handled in Typst
- `test_table_multiline_cell_br_produces_valid_docx` — DOCX generation succeeds
- `test_table_multiline_cell_br_both_lines_in_docx_xml` — DOCX XML contains both lines and a `textWrapping` break
- `test_table_multiline_cell_br_self_closing_variants_docx` — all three `<br>` variants handled in DOCX
- `test_table_multiline_cell_br_both_lines_in_html` — HTML output contains both text parts
- `test_table_multiline_cell_br_produces_br_tag_in_html` — HTML output contains a `<br>` element
- `test_table_multiline_cell_br_self_closing_variants_html` — all three `<br>` variants handled in HTML

## Test results

- `cargo test --lib`: 676 passed, 2 failed (pre-existing platform-specific font tests unrelated to this change)
- `pnpm test`: 278 test files, 5075 tests — all pass
- `pnpm typecheck`: passes

## Files changed

- `src-tauri/src/export/markdown_to_typst.rs`
- `src-tauri/src/export/markdown_to_docx.rs`
- `src-tauri/src/export/markdown_to_html.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)