### PR TITLE
fix(transcription): sync isDictating across MicButton instances via Zustand store

### DIFF
--- a/src/hooks/__tests__/useSpeechRecognition-sync.test.ts
+++ b/src/hooks/__tests__/useSpeechRecognition-sync.test.ts
@@ -1,0 +1,249 @@
+// @vitest-environment jsdom
+/**
+ * Tests for multi-instance synchronisation of useSpeechRecognition.
+ *
+ * Bug report: issue #213 — audio pipeline broken.
+ *
+ * Root cause: useSpeechRecognition maintains local React state (`isDictating`)
+ * that is independent per hook instance. Multiple components mount MicButton
+ * (Toolbar + StatusTray), each calling useSpeechRecognition(), creating
+ * independent instances. When instance A starts dictation, instance B still
+ * has isDictating=false locally, so:
+ *   - Clicking instance B's MicButton starts a second dictation instead of
+ *     stopping the first.
+ *   - Instance B's finalText never changes, so text is never inserted into
+ *     the editor from that instance.
+ *   - The status bar (which reads store state) disagrees with the MicButton
+ *     icons (which read local state).
+ *
+ * Fix: useSpeechRecognition must derive its returned `isDictating` from the
+ * Zustand store, not from local React state, so all instances share the same
+ * truth about whether dictation is currently active.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import '@/test/tauri-mock';
+import { renderHook, act } from '@testing-library/react';
+import { setMockInvokeHandler, emitMockEvent } from '@/test/tauri-mock';
+import { useSpeechRecognition } from '@/hooks/useSpeechRecognition';
+import { useRecordingStore } from '@/stores/recording-store';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function resetStore() {
+  useRecordingStore.setState({
+    isRecording: false,
+    isDictating: false,
+    recordingSource: 'microphone',
+    recordingStartTime: null,
+    transcriptionProgress: 0,
+    availableModels: [],
+    activeDownloads: {},
+    defaultModel: 'base',
+    speechLanguage: 'en',
+    lastUsedSource: 'microphone',
+  });
+}
+
+function setupDefaultHandlers() {
+  setMockInvokeHandler('list_whisper_models', () => [
+    { name: 'base', size_bytes: 142000000, downloaded: true, path: '/models/base.bin' },
+  ]);
+  setMockInvokeHandler('start_dictation', () => undefined);
+  setMockInvokeHandler('stop_dictation', () => undefined);
+  setMockInvokeHandler('download_whisper_model', () => undefined);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useSpeechRecognition — multi-instance sync (issue #213)', () => {
+  beforeEach(() => {
+    resetStore();
+    setupDefaultHandlers();
+    // No Web Speech API — always use whisper path
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (window as any).webkitSpeechRecognition;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (window as any).SpeechRecognition;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // AC1: Status bar and mic icon reflect the SAME recording state
+  // The store is the single source of truth. When instance A starts dictation,
+  // instance B must immediately see isDictating=true without having called
+  // startDictation itself.
+  // -------------------------------------------------------------------------
+
+  it('instance B reflects isDictating=true when instance A starts dictation', async () => {
+    // Simulate instance A (e.g. Toolbar MicButton)
+    const instanceA = renderHook(() => useSpeechRecognition());
+    // Simulate instance B (e.g. StatusTray MicButton) — mounted independently
+    const instanceB = renderHook(() => useSpeechRecognition());
+
+    // Instance A starts dictation
+    await act(async () => {
+      await instanceA.result.current.startDictation();
+    });
+
+    // Instance A should report isDictating=true (already tested elsewhere)
+    expect(instanceA.result.current.isDictating).toBe(true);
+
+    // Instance B must also report isDictating=true — it reads the shared store,
+    // not its own local state. This is the bug: currently returns false.
+    expect(instanceB.result.current.isDictating).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // AC2: Clicking mic icon while recording is active STOPS it, does not restart.
+  // If instance B sees isDictating=true (above test), then calling stopDictation
+  // via instance B must actually stop the dictation.
+  // -------------------------------------------------------------------------
+
+  it('instance B stopDictation stops the session started by instance A', async () => {
+    const stopDictationSpy = vi.fn(() => Promise.resolve());
+    setMockInvokeHandler('stop_dictation', stopDictationSpy);
+
+    const instanceA = renderHook(() => useSpeechRecognition());
+    const instanceB = renderHook(() => useSpeechRecognition());
+
+    // Instance A starts dictation
+    await act(async () => {
+      await instanceA.result.current.startDictation();
+    });
+
+    expect(instanceA.result.current.isDictating).toBe(true);
+    expect(instanceB.result.current.isDictating).toBe(true);
+
+    // Instance B stops dictation (user clicks the StatusTray mic button)
+    await act(async () => {
+      await instanceB.result.current.stopDictation();
+    });
+
+    // Both instances must report isDictating=false
+    expect(instanceA.result.current.isDictating).toBe(false);
+    expect(instanceB.result.current.isDictating).toBe(false);
+
+    // The backend stop command must have been called exactly once
+    expect(stopDictationSpy).toHaveBeenCalledTimes(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // AC3: After stopping, both indicators return to non-recording state.
+  // Store isDictating must be false after stopDictation.
+  // -------------------------------------------------------------------------
+
+  it('store isDictating is false after stopDictation via any instance', async () => {
+    const instanceA = renderHook(() => useSpeechRecognition());
+    const instanceB = renderHook(() => useSpeechRecognition());
+
+    await act(async () => {
+      await instanceA.result.current.startDictation();
+    });
+
+    // Verify store is updated
+    expect(useRecordingStore.getState().isDictating).toBe(true);
+
+    // Stop via instance B
+    await act(async () => {
+      await instanceB.result.current.stopDictation();
+    });
+
+    // Store must be updated to false
+    expect(useRecordingStore.getState().isDictating).toBe(false);
+
+    // Both hook instances must read the updated store
+    expect(instanceA.result.current.isDictating).toBe(false);
+    expect(instanceB.result.current.isDictating).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // AC4: No spurious auto-start.
+  // A freshly mounted hook instance must NOT report isDictating=true unless
+  // the store already has isDictating=true (e.g. from a genuine in-progress
+  // dictation). After resetStore() the store has isDictating=false.
+  // -------------------------------------------------------------------------
+
+  it('freshly mounted instance reports isDictating=false when store is idle', () => {
+    // Store is reset to idle by beforeEach
+    expect(useRecordingStore.getState().isDictating).toBe(false);
+
+    const { result } = renderHook(() => useSpeechRecognition());
+
+    // Must be false — no auto-start
+    expect(result.current.isDictating).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // AC5: Transcribed text is inserted at cursor position.
+  // The finalText returned by any instance must update when dictation-result
+  // events arrive, even if that instance did not call startDictation.
+  //
+  // Specifically: instance A started dictation; the backend emits
+  // dictation-result events. Instance B must also accumulate the finalText
+  // so that its MicButton can insert the text into the editor.
+  //
+  // Note: in the post-fix architecture, text insertion is handled by a single
+  // shared callback or by the hook reporting the latest text from the store,
+  // not by each instance maintaining independent finalText. This test verifies
+  // that at minimum, instance A (the one that started dictation) has finalText
+  // populated after the event — the insertion-at-cursor is covered by the
+  // MicButton useEffect watching finalText.
+  // -------------------------------------------------------------------------
+
+  it('finalText is populated after dictation-result text event for the starting instance', async () => {
+    const { result } = renderHook(() => useSpeechRecognition());
+
+    await act(async () => {
+      await result.current.startDictation();
+    });
+
+    expect(result.current.isDictating).toBe(true);
+
+    // Backend emits partial text
+    await act(async () => {
+      emitMockEvent('dictation-result', { text: 'hello world', is_final: false });
+    });
+
+    expect(result.current.finalText).toContain('hello world');
+
+    // Backend signals end of dictation
+    await act(async () => {
+      emitMockEvent('dictation-result', { text: '', is_final: true });
+    });
+
+    // Dictation ended — isDictating must be false and text preserved
+    expect(result.current.isDictating).toBe(false);
+    expect(result.current.finalText).toContain('hello world');
+  });
+
+  // -------------------------------------------------------------------------
+  // Edge case: instance B must not start a new dictation session when it
+  // calls stopDictation while isDictating=false (e.g. after already stopped).
+  // -------------------------------------------------------------------------
+
+  it('calling stopDictation on idle instance does not call stop_dictation backend', async () => {
+    const stopDictationSpy = vi.fn(() => Promise.resolve());
+    setMockInvokeHandler('stop_dictation', stopDictationSpy);
+
+    const { result } = renderHook(() => useSpeechRecognition());
+
+    // Store is idle — no dictation running
+    expect(result.current.isDictating).toBe(false);
+
+    // Calling stop when idle should be a no-op
+    await act(async () => {
+      await result.current.stopDictation();
+    });
+
+    // Backend should NOT be called when there is nothing to stop
+    expect(stopDictationSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useSpeechRecognition.ts
+++ b/src/hooks/useSpeechRecognition.ts
@@ -50,7 +50,9 @@ interface SpeechRecognitionHook {
 }
 
 export function useSpeechRecognition(): SpeechRecognitionHook {
-  const [isDictating, setIsDictating] = useState(false);
+  // isDictating is derived from the Zustand store so all mounted instances
+  // (Toolbar MicButton, StatusTray MicButton, etc.) stay in sync.
+  const isDictating = useRecordingStore((s) => s.isDictating);
   const [interimText, setInterimText] = useState('');
   const [finalText, setFinalText] = useState('');
   // Track whether Web Speech API actually works (WKWebView has the constructor but blocks the service)
@@ -117,13 +119,11 @@ export function useSpeechRecognition(): SpeechRecognitionHook {
           if (event.payload.error) {
             log.error('transcription', 'Dictation error event', { error: event.payload.error });
             toast.error(event.payload.error);
-            setIsDictating(false);
             storeStopDictating();
             return;
           }
           if (event.payload.is_final) {
             log.info('transcription', 'Dictation finished');
-            setIsDictating(false);
             storeStopDictating();
           } else if (event.payload.text) {
             setFinalText((prev) => prev + ' ' + event.payload.text);
@@ -147,7 +147,6 @@ export function useSpeechRecognition(): SpeechRecognitionHook {
         return;
       }
       log.info('transcription', 'Whisper dictation started successfully', { model: defaultModel });
-      setIsDictating(true);
       storeStartDictating();
     } catch (err) {
       // Only report error if this generation is still current
@@ -210,19 +209,16 @@ export function useSpeechRecognition(): SpeechRecognitionHook {
             log.error('transcription', `Web Speech API error: ${event.error}`);
             toast.error(`Speech recognition error: ${event.error}`);
           }
-          setIsDictating(false);
           storeStopDictating();
         };
 
         recognition.onend = () => {
-          setIsDictating(false);
           storeStopDictating();
           recognitionRef.current = null;
         };
 
         recognition.start();
         recognitionRef.current = recognition;
-        setIsDictating(true);
         storeStartDictating();
       } catch {
         // Expected: Web Speech API start() throws in WKWebView — fall back to whisper-rs
@@ -266,7 +262,6 @@ export function useSpeechRecognition(): SpeechRecognitionHook {
       }
     }
 
-    setIsDictating(false);
     storeStopDictating();
   }, [isDictating, storeStopDictating]);
 


### PR DESCRIPTION
Fixes #213

## Summary

`useSpeechRecognition` previously maintained `isDictating` as local React state, creating an independent copy per hook instance. Since both the Toolbar and StatusTray each mount `<MicButton>` (which calls `useSpeechRecognition()`), two independent instances existed with no shared awareness of each other's state.

When the Toolbar's MicButton started dictation, the StatusTray's MicButton still had `isDictating=false` locally — so clicking it would start a second dictation session instead of stopping the first. The status bar red dot (reading Zustand store state, which was correctly updated) disagreed with both MicButton icons.

**Fix:** Read `isDictating` from the Zustand `useRecordingStore` via a selector instead of local `useState`. All instances now share the same single source of truth. The redundant `setIsDictating(true/false)` local-state calls are removed since `storeStartDictating()`/`storeStopDictating()` already update the store.

## Red tests added

- `src/hooks/__tests__/useSpeechRecognition-sync.test.ts::instance B reflects isDictating=true when instance A starts dictation` — verifies all mounted instances see the updated store state
- `src/hooks/__tests__/useSpeechRecognition-sync.test.ts::instance B stopDictation stops the session started by instance A` — verifies the toggle routes to stop (not start) when store says active
- `src/hooks/__tests__/useSpeechRecognition-sync.test.ts::store isDictating is false after stopDictation via any instance` — verifies store is cleared after stop from any instance
- `src/hooks/__tests__/useSpeechRecognition-sync.test.ts::freshly mounted instance reports isDictating=false when store is idle` — AC1: no spurious auto-start
- `src/hooks/__tests__/useSpeechRecognition-sync.test.ts::finalText is populated after dictation-result text event for the starting instance` — AC5: transcribed text arrives in hook state for insertion
- `src/hooks/__tests__/useSpeechRecognition-sync.test.ts::calling stopDictation on idle instance does not call stop_dictation backend` — edge: idle stop is a no-op

## Green implementation

- `src/hooks/useSpeechRecognition.ts` — replace `const [isDictating, setIsDictating] = useState(false)` with `const isDictating = useRecordingStore((s) => s.isDictating)`; remove 8 redundant `setIsDictating()` call sites

## Refactor

Skipped — implementation is already minimal (11 lines changed total, 3 added / 8 removed).

## Decisions made

- **Local state vs store state:** `interimText`, `finalText`, and `webSpeechWorks` remain as local `useState` because they are per-instance transient UI state. `isDictating` is the only field that needed cross-instance synchronisation. — No ambiguity in the spec; this matches the existing architecture where `storeStartDictating`/`storeStopDictating` were already keeping the store in sync, just redundantly alongside local state.

## Verification

- [x] Red tests were red before implementation (3 failing before fix)
- [x] All 6 red tests now green
- [x] `pnpm test` passes (281 files, 5098 tests)
- [x] `pnpm typecheck` clean
- [x] No unrelated files modified (2 files: hook + test)

## Notes for reviewer

- The `stopDictation` path: when instance B (which never called `startDictation`) now calls `stopDictation` while the store says `isDictating=true`, it will proceed past the early-return guard. It won't have `recognitionRef.current` or `unlistenRef.current` set (those are per-instance), so it takes the Whisper path: calls `tauriApi.stopDictation()` (which signals the backend) and calls `storeStopDictating()`. Instance A's `unlistenRef` is still live but will be cleaned up when instance A processes the resulting `dictation-result { is_final: true }` event that the backend emits after stop. This is correct behavior.
- `finalText` accumulation remains per-instance (stays in `useState`). The MicButton that initiated dictation will accumulate text and insert it via its `useEffect` watching `finalText`. This covers the "text insertion" acceptance criterion. A deeper fix (sharing finalText via the store) would require more invasive changes and is out of scope per the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the `aw-tdd` skill.