### PR TITLE
fix(editor): align toolbar/shortcuts now work on embedded blocks (image, chart, drawing, linkPreview)

### DIFF
--- a/src/components/editor/Toolbar.tsx
+++ b/src/components/editor/Toolbar.tsx
@@ -398,7 +398,7 @@ export function Toolbar({ editor, onImageInsert, viewMode = "wysiwyg", onToggleV
                       "cursor-pointer gap-2 text-xs",
                       editor.isActive({ textAlign: "left" }) && "bg-[var(--color-accent-primary)] text-[oklch(100%_0_0)]",
                     )}
-                    onClick={() => editor.chain().focus().setTextAlign("left").run()}
+                    onClick={() => editor.chain().focus().command(({ commands }) => commands.setEmbeddedBlockAlign("left") || commands.setTextAlign("left")).run()}
                   >
                     <AlignLeft className="size-4 shrink-0" strokeWidth={1.5} />
                     Align left
@@ -408,7 +408,7 @@ export function Toolbar({ editor, onImageInsert, viewMode = "wysiwyg", onToggleV
                       "cursor-pointer gap-2 text-xs",
                       editor.isActive({ textAlign: "center" }) && "bg-[var(--color-accent-primary)] text-[oklch(100%_0_0)]",
                     )}
-                    onClick={() => editor.chain().focus().setTextAlign("center").run()}
+                    onClick={() => editor.chain().focus().command(({ commands }) => commands.setEmbeddedBlockAlign("center") || commands.setTextAlign("center")).run()}
                   >
                     <AlignCenter className="size-4 shrink-0" strokeWidth={1.5} />
                     Align center
@@ -418,7 +418,7 @@ export function Toolbar({ editor, onImageInsert, viewMode = "wysiwyg", onToggleV
                       "cursor-pointer gap-2 text-xs",
                       editor.isActive({ textAlign: "right" }) && "bg-[var(--color-accent-primary)] text-[oklch(100%_0_0)]",
                     )}
-                    onClick={() => editor.chain().focus().setTextAlign("right").run()}
+                    onClick={() => editor.chain().focus().command(({ commands }) => commands.setEmbeddedBlockAlign("right") || commands.setTextAlign("right")).run()}
                   >
                     <AlignRight className="size-4 shrink-0" strokeWidth={1.5} />
                     Align right
@@ -734,7 +734,7 @@ export function Toolbar({ editor, onImageInsert, viewMode = "wysiwyg", onToggleV
 
           {/* Alignment */}
           <ToolbarButton
-            onClick={() => editor.chain().focus().setTextAlign("left").run()}
+            onClick={() => editor.chain().focus().command(({ commands }) => commands.setEmbeddedBlockAlign("left") || commands.setTextAlign("left")).run()}
             active={editor.isActive({ textAlign: "left" })}
             title="Align left"
           >
@@ -742,7 +742,7 @@ export function Toolbar({ editor, onImageInsert, viewMode = "wysiwyg", onToggleV
           </ToolbarButton>
 
           <ToolbarButton
-            onClick={() => editor.chain().focus().setTextAlign("center").run()}
+            onClick={() => editor.chain().focus().command(({ commands }) => commands.setEmbeddedBlockAlign("center") || commands.setTextAlign("center")).run()}
             active={editor.isActive({ textAlign: "center" })}
             title="Align center"
           >
@@ -750,7 +750,7 @@ export function Toolbar({ editor, onImageInsert, viewMode = "wysiwyg", onToggleV
           </ToolbarButton>
 
           <ToolbarButton
-            onClick={() => editor.chain().focus().setTextAlign("right").run()}
+            onClick={() => editor.chain().focus().command(({ commands }) => commands.setEmbeddedBlockAlign("right") || commands.setTextAlign("right")).run()}
             active={editor.isActive({ textAlign: "right" })}
             title="Align right"
           >

--- a/src/components/editor/extensions/__tests__/embedded-block-align.test.ts
+++ b/src/components/editor/extensions/__tests__/embedded-block-align.test.ts
@@ -1,0 +1,240 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Tests for the EmbeddedBlockAlign Tiptap extension.
+ *
+ * The extension adds a `setEmbeddedBlockAlign(align)` command that sets the
+ * `align` (and conditionally `blockWidth`) attribute on embedded atom block
+ * nodes (image, chart, drawing, linkPreview) when one of those nodes is
+ * selected — either via NodeSelection or by cursor adjacency.
+ *
+ * Keyboard shortcuts Mod-Shift-l/e/r call this command first; if no embedded
+ * block is in scope they return false and fall through to TextAlign.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { Editor } from '@tiptap/core';
+import StarterKit from '@tiptap/starter-kit';
+import { NodeSelection } from '@tiptap/pm/state';
+import TextAlign from '@tiptap/extension-text-align';
+import { EmbeddedBlockAlign } from '../embedded-block-align';
+
+// ---------------------------------------------------------------------------
+// Minimal stub nodes for image, chart, drawing, linkPreview
+// We don't need full extension behaviour — just schema nodes with align/blockWidth attrs
+// ---------------------------------------------------------------------------
+
+import { Node as TiptapNode } from '@tiptap/core';
+
+const StubImage = TiptapNode.create({
+  name: 'image',
+  group: 'block',
+  atom: true,
+  addAttributes() {
+    return {
+      src: { default: '' },
+      align: { default: null },
+      blockWidth: { default: null },
+    };
+  },
+  parseHTML() { return [{ tag: 'img' }]; },
+  renderHTML({ HTMLAttributes }) { return ['img', HTMLAttributes]; },
+});
+
+const StubChart = TiptapNode.create({
+  name: 'chart',
+  group: 'block',
+  atom: true,
+  addAttributes() {
+    return {
+      chartId: { default: null },
+      align: { default: null },
+      blockWidth: { default: null },
+    };
+  },
+  parseHTML() { return [{ tag: 'div[data-type="chart"]' }]; },
+  renderHTML({ HTMLAttributes }) { return ['div', mergeStub({ 'data-type': 'chart' }, HTMLAttributes)]; },
+});
+
+const StubDrawing = TiptapNode.create({
+  name: 'drawing',
+  group: 'block',
+  atom: true,
+  addAttributes() {
+    return {
+      drawingId: { default: null },
+      align: { default: null },
+      blockWidth: { default: null },
+    };
+  },
+  parseHTML() { return [{ tag: 'div[data-type="drawing"]' }]; },
+  renderHTML({ HTMLAttributes }) { return ['div', mergeStub({ 'data-type': 'drawing' }, HTMLAttributes)]; },
+});
+
+const StubLinkPreview = TiptapNode.create({
+  name: 'linkPreview',
+  group: 'block',
+  atom: true,
+  addAttributes() {
+    return {
+      href: { default: '' },
+      align: { default: null },
+      blockWidth: { default: null },
+    };
+  },
+  parseHTML() { return [{ tag: 'div[data-type="link-preview"]' }]; },
+  renderHTML({ HTMLAttributes }) { return ['div', mergeStub({ 'data-type': 'link-preview' }, HTMLAttributes)]; },
+});
+
+function mergeStub(base: Record<string, string>, attrs: Record<string, unknown>): Record<string, unknown> {
+  return { ...base, ...attrs };
+}
+
+// ---------------------------------------------------------------------------
+// Editor lifecycle helpers
+// ---------------------------------------------------------------------------
+
+const editors: Editor[] = [];
+
+afterEach(() => {
+  while (editors.length > 0) {
+    editors.pop()?.destroy();
+  }
+});
+
+function createEditor(): Editor {
+  const editor = new Editor({
+    extensions: [
+      StarterKit,
+      TextAlign.configure({ types: ['heading', 'paragraph'] }),
+      StubImage,
+      StubChart,
+      StubDrawing,
+      StubLinkPreview,
+      EmbeddedBlockAlign,
+    ],
+  });
+  editors.push(editor);
+  return editor;
+}
+
+/** Insert a node of the given type as the sole doc content and select it (NodeSelection). */
+function insertAndSelectNode(editor: Editor, nodeName: string, attrs: Record<string, unknown> = {}): void {
+  // Use setContent with JSON to ensure the node is in the document
+  editor.commands.setContent({ type: 'doc', content: [{ type: nodeName, attrs }] });
+
+  // Find the node's position by traversal
+  let nodePos = -1;
+  editor.state.doc.descendants((node, pos) => {
+    if (node.type.name === nodeName) {
+      nodePos = pos;
+      return false;
+    }
+  });
+  if (nodePos === -1) throw new Error(`Node "${nodeName}" not found in document after setContent`);
+
+  const tr = editor.state.tr.setSelection(NodeSelection.create(editor.state.doc, nodePos));
+  editor.view.dispatch(tr);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('EmbeddedBlockAlign extension', () => {
+  describe('command registration', () => {
+    it('registers setEmbeddedBlockAlign command on the editor', () => {
+      const editor = createEditor();
+      expect(typeof editor.commands.setEmbeddedBlockAlign).toBe('function');
+    });
+  });
+
+  describe('setEmbeddedBlockAlign on NodeSelection', () => {
+    it.each([
+      ['image', { src: 'test.png' }],
+      ['chart', { chartId: 'chart-1' }],
+      ['drawing', { drawingId: 'draw-1' }],
+      ['linkPreview', { href: 'https://example.com' }],
+    ])('sets align on %s node when it is NodeSelected', (nodeName, attrs) => {
+      const editor = createEditor();
+      insertAndSelectNode(editor, nodeName, attrs);
+
+      const result = editor.commands.setEmbeddedBlockAlign('center');
+      expect(result).toBe(true);
+
+      // Find the node in the document and check its align attribute
+      let foundAlign: string | null = null;
+      editor.state.doc.descendants((node) => {
+        if (node.type.name === nodeName) {
+          foundAlign = node.attrs.align as string | null;
+        }
+      });
+      expect(foundAlign).toBe('center');
+    });
+
+    it.each([
+      ['image', { src: 'test.png' }],
+      ['chart', { chartId: 'chart-1' }],
+      ['drawing', { drawingId: 'draw-1' }],
+      ['linkPreview', { href: 'https://example.com' }],
+    ])('sets blockWidth=75 when %s node has no blockWidth', (nodeName, attrs) => {
+      const editor = createEditor();
+      insertAndSelectNode(editor, nodeName, attrs);
+
+      editor.commands.setEmbeddedBlockAlign('right');
+
+      let foundBlockWidth: number | null = null;
+      editor.state.doc.descendants((node) => {
+        if (node.type.name === nodeName) {
+          foundBlockWidth = node.attrs.blockWidth as number | null;
+        }
+      });
+      expect(foundBlockWidth).toBe(75);
+    });
+
+    it('preserves existing blockWidth when already set', () => {
+      const editor = createEditor();
+      insertAndSelectNode(editor, 'chart', { chartId: 'c1', blockWidth: 50 });
+
+      editor.commands.setEmbeddedBlockAlign('center');
+
+      let foundBlockWidth: number | null = null;
+      editor.state.doc.descendants((node) => {
+        if (node.type.name === 'chart') {
+          foundBlockWidth = node.attrs.blockWidth as number | null;
+        }
+      });
+      expect(foundBlockWidth).toBe(50);
+    });
+  });
+
+  describe('setEmbeddedBlockAlign returns false for non-embedded selections', () => {
+    it('returns false when cursor is in a paragraph (no embedded block)', () => {
+      const editor = createEditor();
+      editor.commands.setContent('<p>Hello</p>');
+      // Cursor is in paragraph by default — no embedded block
+      const result = editor.commands.setEmbeddedBlockAlign('center');
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('align values', () => {
+    it('sets align to "left"', () => {
+      const editor = createEditor();
+      insertAndSelectNode(editor, 'chart', { chartId: 'c1' });
+      editor.commands.setEmbeddedBlockAlign('left');
+      let found: string | null = null;
+      editor.state.doc.descendants((n) => { if (n.type.name === 'chart') found = n.attrs.align; });
+      expect(found).toBe('left');
+    });
+
+    it('sets align to "right"', () => {
+      const editor = createEditor();
+      insertAndSelectNode(editor, 'chart', { chartId: 'c1' });
+      editor.commands.setEmbeddedBlockAlign('right');
+      let found: string | null = null;
+      editor.state.doc.descendants((n) => { if (n.type.name === 'chart') found = n.attrs.align; });
+      expect(found).toBe('right');
+    });
+  });
+});

--- a/src/components/editor/extensions/embedded-block-align.ts
+++ b/src/components/editor/extensions/embedded-block-align.ts
@@ -1,0 +1,101 @@
+import { Extension } from "@tiptap/core";
+import { NodeSelection } from "@tiptap/pm/state";
+
+/** Node types that support `align` and `blockWidth` attributes. */
+const EMBEDDED_BLOCK_TYPES = new Set([
+  "image",
+  "chart",
+  "drawing",
+  "linkPreview",
+]);
+
+declare module "@tiptap/core" {
+  interface Commands<ReturnType> {
+    embeddedBlockAlign: {
+      /**
+       * Set the `align` attribute on the embedded block node that is currently
+       * selected (NodeSelection) or adjacent to the cursor (TextSelection).
+       *
+       * Returns `false` when no embedded block is in scope so keyboard shortcuts
+       * fall through to TextAlign for ordinary heading/paragraph text.
+       */
+      setEmbeddedBlockAlign: (align: string) => ReturnType;
+    };
+  }
+}
+
+export const EmbeddedBlockAlign = Extension.create({
+  name: "embeddedBlockAlign",
+
+  addCommands() {
+    return {
+      setEmbeddedBlockAlign:
+        (align: string) =>
+        ({ state, dispatch }) => {
+          const { selection } = state;
+
+          // --- NodeSelection: user clicked the block directly ---
+          if (selection instanceof NodeSelection) {
+            const { node, from } = selection;
+            if (!EMBEDDED_BLOCK_TYPES.has(node.type.name)) return false;
+
+            if (dispatch) {
+              const patch: Record<string, unknown> = { align };
+              if (node.attrs.blockWidth == null) patch.blockWidth = 75;
+              const tr = state.tr.setNodeMarkup(from, undefined, {
+                ...node.attrs,
+                ...patch,
+              });
+              dispatch(tr);
+            }
+            return true;
+          }
+
+          // --- TextSelection: check if cursor is adjacent to an embedded block ---
+          const { $from } = selection;
+
+          // Node immediately after the cursor
+          const nodeAfter = $from.nodeAfter;
+          if (nodeAfter && EMBEDDED_BLOCK_TYPES.has(nodeAfter.type.name)) {
+            if (dispatch) {
+              const pos = $from.pos;
+              const patch: Record<string, unknown> = { align };
+              if (nodeAfter.attrs.blockWidth == null) patch.blockWidth = 75;
+              const tr = state.tr.setNodeMarkup(pos, undefined, {
+                ...nodeAfter.attrs,
+                ...patch,
+              });
+              dispatch(tr);
+            }
+            return true;
+          }
+
+          // Node immediately before the cursor
+          const nodeBefore = $from.nodeBefore;
+          if (nodeBefore && EMBEDDED_BLOCK_TYPES.has(nodeBefore.type.name)) {
+            if (dispatch) {
+              const pos = $from.pos - nodeBefore.nodeSize;
+              const patch: Record<string, unknown> = { align };
+              if (nodeBefore.attrs.blockWidth == null) patch.blockWidth = 75;
+              const tr = state.tr.setNodeMarkup(pos, undefined, {
+                ...nodeBefore.attrs,
+                ...patch,
+              });
+              dispatch(tr);
+            }
+            return true;
+          }
+
+          return false;
+        },
+    };
+  },
+
+  addKeyboardShortcuts() {
+    return {
+      "Mod-Shift-l": () => this.editor.commands.setEmbeddedBlockAlign("left"),
+      "Mod-Shift-e": () => this.editor.commands.setEmbeddedBlockAlign("center"),
+      "Mod-Shift-r": () => this.editor.commands.setEmbeddedBlockAlign("right"),
+    };
+  },
+});

--- a/src/components/editor/extensions/index.ts
+++ b/src/components/editor/extensions/index.ts
@@ -74,3 +74,4 @@ export type { TableHeaderMenuEventDetail } from './table-header-menu';
 export { TableOfContents } from './toc';
 export type { TocHeading } from './toc';
 export { scanHeadings } from './toc';
+export { EmbeddedBlockAlign } from './embedded-block-align';

--- a/src/hooks/useEditor.ts
+++ b/src/hooks/useEditor.ts
@@ -23,7 +23,7 @@ import CodeBlockLowlight from "@tiptap/extension-code-block-lowlight";
 import { common, createLowlight } from "lowlight";
 import { Markdown } from "tiptap-markdown";
 import { SlashCommand } from "@/components/editor/extensions/slash-command";
-import { AISuggestion, InlineDiff, CommentMark, GhostText, TagHighlight, TagSuggestion, MentionHighlight, MentionSuggestion, DateHighlight, DateSuggestion, SearchHighlight, Drawing, Chart, MermaidBlock, LinkPreview, TableOfContents } from "@/components/editor/extensions";
+import { AISuggestion, InlineDiff, CommentMark, GhostText, TagHighlight, TagSuggestion, MentionHighlight, MentionSuggestion, DateHighlight, DateSuggestion, SearchHighlight, Drawing, Chart, MermaidBlock, LinkPreview, TableOfContents, EmbeddedBlockAlign } from "@/components/editor/extensions";
 import { PageBreaks } from "@/components/editor/extensions/page-breaks";
 import { LinkClick } from "@/components/editor/extensions/link-click";
 import { SendToAI } from "@/components/editor/extensions/send-to-ai";
@@ -98,6 +98,7 @@ export function useEditor({ content, onUpdate, editable = true, documentDir }: U
       TextAlign.configure({
         types: ["heading", "paragraph"],
       }),
+      EmbeddedBlockAlign,
       TextStyle,
       Color,
       ThemedHighlight.configure({


### PR DESCRIPTION
## Summary

Fixes #220 — toolbar alignment buttons (left/center/right) and `Cmd+Shift+L/E/R` keyboard shortcuts had no effect when an embedded block node (image, chart, drawing, or link preview card) was selected.

### Root cause

The `TextAlign` extension only targets `["heading", "paragraph"]` nodes. Clicking an alignment button while a chart/drawing/image/linkPreview had focus silently did nothing. Expanding `TextAlign` to cover these types is permanently forbidden — a prior attempt caused a 3 s→12 s streaming-hydrate regression on large documents (reverted in `ba4fe785`).

### Approach

New `EmbeddedBlockAlign` Tiptap extension (`src/components/editor/extensions/embedded-block-align.ts`):

- Registers a `setEmbeddedBlockAlign(align)` command that inspects the current selection:
  - **NodeSelection** on an embedded block → sets `align` (and `blockWidth = 75` when unset, matching the `BlockSizeControls` pattern) via `tr.setNodeMarkup`.
  - **TextSelection** with cursor adjacent to an embedded block → same treatment on the neighbouring node.
  - Otherwise → returns `false` so keyboard shortcuts fall through to `TextAlign`.
- Binds `Mod-Shift-l/e/r` to `setEmbeddedBlockAlign`. The extension is registered **after** `TextAlign` in `useEditor.ts`, giving it keyboard-shortcut priority over TextAlign for these chords.
- Toolbar alignment buttons (`Toolbar.tsx`) updated with `command(({ commands }) => commands.setEmbeddedBlockAlign(dir) || commands.setTextAlign(dir))` — embedded block wins if selected, text align wins otherwise.

### Tests

13 unit tests in `src/components/editor/extensions/__tests__/embedded-block-align.test.ts` cover:
- Command registered on editor
- Sets `align` on all four node types via NodeSelection
- Sets `blockWidth = 75` when not already set
- Preserves existing `blockWidth`
- Returns `false` for plain paragraph selections

## Test plan

- [ ] All 281 unit test files pass (`pnpm test`)
- [ ] TypeScript type check passes (`pnpm typecheck`)
- [ ] Manual: click inside a chart → click Align Right → chart shifts right
- [ ] Manual: click inside a drawing → press `Cmd+Shift+E` → drawing centers
- [ ] Manual: click inside an image → click Align Center → image centers
- [ ] Manual: click inside a link preview card → press `Cmd+Shift+R` → card aligns right
- [ ] Manual: cursor in a heading/paragraph → `Cmd+Shift+E` → text centers (TextAlign still works)
- [ ] Manual: `blockWidth` appears on the block when first aligned (matching BlockSizeControls behaviour)

## Decisions made

- Used `Extension` (not `Node`) since this adds a command/keymap with no schema changes.
- Extension is added after `TextAlign` in `useEditor.ts` so Tiptap resolves keyboard shortcut conflicts in favour of `EmbeddedBlockAlign` (later = higher priority).
- `workers/worker-extensions.ts` not modified — this extension has no schema impact and the worker only needs parse-compatible extensions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)