### PR TITLE
fix(editor): align embedded blocks via toolbar and Cmd+Shift+L/E/R

### DIFF
--- a/src/components/editor/Toolbar.tsx
+++ b/src/components/editor/Toolbar.tsx
@@ -398,7 +398,11 @@ export function Toolbar({ editor, onImageInsert, viewMode = "wysiwyg", onToggleV
                       "cursor-pointer gap-2 text-xs",
                       editor.isActive({ textAlign: "left" }) && "bg-[var(--color-accent-primary)] text-[oklch(100%_0_0)]",
                     )}
-                    onClick={() => editor.chain().focus().setTextAlign("left").run()}
+                    onClick={() => {
+                      if (!editor.chain().focus().setEmbeddedBlockAlign("left").run()) {
+                        editor.chain().focus().setTextAlign("left").run();
+                      }
+                    }}
                   >
                     <AlignLeft className="size-4 shrink-0" strokeWidth={1.5} />
                     Align left
@@ -408,7 +412,11 @@ export function Toolbar({ editor, onImageInsert, viewMode = "wysiwyg", onToggleV
                       "cursor-pointer gap-2 text-xs",
                       editor.isActive({ textAlign: "center" }) && "bg-[var(--color-accent-primary)] text-[oklch(100%_0_0)]",
                     )}
-                    onClick={() => editor.chain().focus().setTextAlign("center").run()}
+                    onClick={() => {
+                      if (!editor.chain().focus().setEmbeddedBlockAlign("center").run()) {
+                        editor.chain().focus().setTextAlign("center").run();
+                      }
+                    }}
                   >
                     <AlignCenter className="size-4 shrink-0" strokeWidth={1.5} />
                     Align center
@@ -418,7 +426,11 @@ export function Toolbar({ editor, onImageInsert, viewMode = "wysiwyg", onToggleV
                       "cursor-pointer gap-2 text-xs",
                       editor.isActive({ textAlign: "right" }) && "bg-[var(--color-accent-primary)] text-[oklch(100%_0_0)]",
                     )}
-                    onClick={() => editor.chain().focus().setTextAlign("right").run()}
+                    onClick={() => {
+                      if (!editor.chain().focus().setEmbeddedBlockAlign("right").run()) {
+                        editor.chain().focus().setTextAlign("right").run();
+                      }
+                    }}
                   >
                     <AlignRight className="size-4 shrink-0" strokeWidth={1.5} />
                     Align right
@@ -734,7 +746,11 @@ export function Toolbar({ editor, onImageInsert, viewMode = "wysiwyg", onToggleV
 
           {/* Alignment */}
           <ToolbarButton
-            onClick={() => editor.chain().focus().setTextAlign("left").run()}
+            onClick={() => {
+              if (!editor.chain().focus().setEmbeddedBlockAlign("left").run()) {
+                editor.chain().focus().setTextAlign("left").run();
+              }
+            }}
             active={editor.isActive({ textAlign: "left" })}
             title="Align left"
           >
@@ -742,7 +758,11 @@ export function Toolbar({ editor, onImageInsert, viewMode = "wysiwyg", onToggleV
           </ToolbarButton>
 
           <ToolbarButton
-            onClick={() => editor.chain().focus().setTextAlign("center").run()}
+            onClick={() => {
+              if (!editor.chain().focus().setEmbeddedBlockAlign("center").run()) {
+                editor.chain().focus().setTextAlign("center").run();
+              }
+            }}
             active={editor.isActive({ textAlign: "center" })}
             title="Align center"
           >
@@ -750,7 +770,11 @@ export function Toolbar({ editor, onImageInsert, viewMode = "wysiwyg", onToggleV
           </ToolbarButton>
 
           <ToolbarButton
-            onClick={() => editor.chain().focus().setTextAlign("right").run()}
+            onClick={() => {
+              if (!editor.chain().focus().setEmbeddedBlockAlign("right").run()) {
+                editor.chain().focus().setTextAlign("right").run();
+              }
+            }}
             active={editor.isActive({ textAlign: "right" })}
             title="Align right"
           >

--- a/src/components/editor/extensions/__tests__/embedded-block-align.test.ts
+++ b/src/components/editor/extensions/__tests__/embedded-block-align.test.ts
@@ -1,0 +1,271 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Unit tests for the EmbeddedBlockAlign Tiptap Extension.
+ *
+ * Red-test list (must fail before implementation):
+ *  1. setEmbeddedBlockAlign sets align on a NodeSelection-focused image node.
+ *  2. setEmbeddedBlockAlign sets align on a NodeSelection-focused chart node.
+ *  3. setEmbeddedBlockAlign sets align on a NodeSelection-focused drawing node.
+ *  4. setEmbeddedBlockAlign sets align on a NodeSelection-focused linkPreview node.
+ *  5. setEmbeddedBlockAlign sets blockWidth=75 when blockWidth is currently null.
+ *  6. setEmbeddedBlockAlign preserves an existing blockWidth value.
+ *  7. setEmbeddedBlockAlign returns false for a text selection (falls through).
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { Editor, Node, mergeAttributes } from '@tiptap/core';
+import StarterKit from '@tiptap/starter-kit';
+import { NodeSelection } from '@tiptap/pm/state';
+import { EmbeddedBlockAlign } from '../embedded-block-align';
+
+// ---------------------------------------------------------------------------
+// Minimal shims for embedded block node types — same name + attribute schema
+// as the production extensions, no React/Tauri dependencies.
+// ---------------------------------------------------------------------------
+
+const ImageShim = Node.create({
+  name: 'image',
+  group: 'block',
+  atom: true,
+  addAttributes() {
+    return {
+      src: { default: '' },
+      align: { default: null as string | null },
+      blockWidth: { default: null as number | null },
+    };
+  },
+  parseHTML() {
+    return [{ tag: 'img' }];
+  },
+  renderHTML({ HTMLAttributes }) {
+    return ['img', mergeAttributes(HTMLAttributes)];
+  },
+});
+
+const ChartShim = Node.create({
+  name: 'chart',
+  group: 'block',
+  atom: true,
+  addAttributes() {
+    return {
+      chartJson: { default: '{}' },
+      align: { default: null as string | null },
+      blockWidth: { default: null as number | null },
+    };
+  },
+  parseHTML() {
+    return [{ tag: 'div[data-chart-json]' }];
+  },
+  renderHTML({ HTMLAttributes }) {
+    return ['div', mergeAttributes(HTMLAttributes, { 'data-type': 'chart' })];
+  },
+});
+
+const DrawingShim = Node.create({
+  name: 'drawing',
+  group: 'block',
+  atom: true,
+  addAttributes() {
+    return {
+      drawingJson: { default: '{}' },
+      align: { default: null as string | null },
+      blockWidth: { default: null as number | null },
+    };
+  },
+  parseHTML() {
+    return [{ tag: 'div[data-drawing-json]' }];
+  },
+  renderHTML({ HTMLAttributes }) {
+    return ['div', mergeAttributes(HTMLAttributes, { 'data-type': 'drawing' })];
+  },
+});
+
+const LinkPreviewShim = Node.create({
+  name: 'linkPreview',
+  group: 'block',
+  atom: true,
+  addAttributes() {
+    return {
+      url: { default: '' },
+      align: { default: null as string | null },
+      blockWidth: { default: null as number | null },
+    };
+  },
+  parseHTML() {
+    return [{ tag: 'div[data-link-preview]' }];
+  },
+  renderHTML({ HTMLAttributes }) {
+    return ['div', mergeAttributes(HTMLAttributes, { 'data-type': 'linkPreview' })];
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Editor lifecycle helpers
+// ---------------------------------------------------------------------------
+
+const editors: Editor[] = [];
+
+afterEach(() => {
+  while (editors.length > 0) {
+    editors.pop()?.destroy();
+  }
+});
+
+function createEditor(jsonContent: object): Editor {
+  const el = document.createElement('div');
+  const editor = new Editor({
+    element: el,
+    extensions: [
+      StarterKit,
+      ImageShim,
+      ChartShim,
+      DrawingShim,
+      LinkPreviewShim,
+      EmbeddedBlockAlign,
+    ],
+    content: jsonContent as never,
+    editable: true,
+  });
+  editors.push(editor);
+  return editor;
+}
+
+/** Place a NodeSelection on the first top-level node of a given type. */
+function selectBlock(editor: Editor, typeName: string): void {
+  const { doc } = editor.state;
+  let pos: number | null = null;
+  doc.forEach((node, offset) => {
+    if (pos === null && node.type.name === typeName) {
+      pos = offset;
+    }
+  });
+  if (pos === null) throw new Error(`No node of type '${typeName}' found in doc`);
+  const sel = NodeSelection.create(doc, pos);
+  editor.view.dispatch(editor.state.tr.setSelection(sel));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('EmbeddedBlockAlign — setEmbeddedBlockAlign', () => {
+  it('sets align on a NodeSelection-focused image node', () => {
+    const editor = createEditor({
+      type: 'doc',
+      content: [
+        { type: 'image', attrs: { src: 'test.png', align: null, blockWidth: null } },
+        { type: 'paragraph', content: [{ type: 'text', text: 'hello' }] },
+      ],
+    });
+
+    selectBlock(editor, 'image');
+    const ran = editor.chain().focus().setEmbeddedBlockAlign('center').run();
+
+    expect(ran).toBe(true);
+    const node = editor.state.doc.firstChild!;
+    expect(node.type.name).toBe('image');
+    expect(node.attrs.align).toBe('center');
+  });
+
+  it('sets align on a NodeSelection-focused chart node', () => {
+    const editor = createEditor({
+      type: 'doc',
+      content: [
+        { type: 'chart', attrs: { chartJson: '{}', align: null, blockWidth: null } },
+        { type: 'paragraph', content: [{ type: 'text', text: 'hello' }] },
+      ],
+    });
+
+    selectBlock(editor, 'chart');
+    const ran = editor.chain().focus().setEmbeddedBlockAlign('right').run();
+
+    expect(ran).toBe(true);
+    const node = editor.state.doc.firstChild!;
+    expect(node.type.name).toBe('chart');
+    expect(node.attrs.align).toBe('right');
+  });
+
+  it('sets align on a NodeSelection-focused drawing node', () => {
+    const editor = createEditor({
+      type: 'doc',
+      content: [
+        { type: 'drawing', attrs: { drawingJson: '{}', align: null, blockWidth: null } },
+        { type: 'paragraph', content: [{ type: 'text', text: 'hello' }] },
+      ],
+    });
+
+    selectBlock(editor, 'drawing');
+    const ran = editor.chain().focus().setEmbeddedBlockAlign('left').run();
+
+    expect(ran).toBe(true);
+    const node = editor.state.doc.firstChild!;
+    expect(node.type.name).toBe('drawing');
+    expect(node.attrs.align).toBe('left');
+  });
+
+  it('sets align on a NodeSelection-focused linkPreview node', () => {
+    const editor = createEditor({
+      type: 'doc',
+      content: [
+        { type: 'linkPreview', attrs: { url: 'https://example.com', align: null, blockWidth: null } },
+        { type: 'paragraph', content: [{ type: 'text', text: 'hello' }] },
+      ],
+    });
+
+    selectBlock(editor, 'linkPreview');
+    const ran = editor.chain().focus().setEmbeddedBlockAlign('center').run();
+
+    expect(ran).toBe(true);
+    const node = editor.state.doc.firstChild!;
+    expect(node.type.name).toBe('linkPreview');
+    expect(node.attrs.align).toBe('center');
+  });
+
+  it('sets blockWidth to 75 when blockWidth is currently null', () => {
+    const editor = createEditor({
+      type: 'doc',
+      content: [
+        { type: 'chart', attrs: { chartJson: '{}', align: null, blockWidth: null } },
+        { type: 'paragraph', content: [{ type: 'text', text: 'hello' }] },
+      ],
+    });
+
+    selectBlock(editor, 'chart');
+    editor.chain().focus().setEmbeddedBlockAlign('center').run();
+
+    const node = editor.state.doc.firstChild!;
+    expect(node.attrs.blockWidth).toBe(75);
+  });
+
+  it('preserves an existing blockWidth when setting align', () => {
+    const editor = createEditor({
+      type: 'doc',
+      content: [
+        { type: 'chart', attrs: { chartJson: '{}', align: 'left', blockWidth: 50 } },
+        { type: 'paragraph', content: [{ type: 'text', text: 'hello' }] },
+      ],
+    });
+
+    selectBlock(editor, 'chart');
+    editor.chain().focus().setEmbeddedBlockAlign('right').run();
+
+    const node = editor.state.doc.firstChild!;
+    expect(node.attrs.blockWidth).toBe(50);
+  });
+
+  it('returns false for a plain paragraph selection (falls through to TextAlign)', () => {
+    const editor = createEditor({
+      type: 'doc',
+      content: [
+        { type: 'paragraph', content: [{ type: 'text', text: 'hello' }] },
+      ],
+    });
+
+    // Place cursor inside the paragraph (TextSelection)
+    editor.commands.setTextSelection(1);
+    const ran = editor.chain().focus().setEmbeddedBlockAlign('center').run();
+
+    expect(ran).toBe(false);
+  });
+});

--- a/src/components/editor/extensions/embedded-block-align.ts
+++ b/src/components/editor/extensions/embedded-block-align.ts
@@ -1,0 +1,110 @@
+import { Extension } from "@tiptap/core";
+import { NodeSelection } from "@tiptap/pm/state";
+
+/**
+ * The four embedded block node types that carry their own `align` attribute.
+ * All four also carry `blockWidth`. This list is checked by
+ * `setEmbeddedBlockAlign` to decide whether the current selection targets an
+ * embedded block (handle it here) or a text node (return false, fall through
+ * to `TextAlign`).
+ *
+ * MUST NOT add these types to `TextAlign.addGlobalAttributes`. That approach
+ * was tried and reverted (commit ba4fe785) — it inflated every node's attr set
+ * and slowed `streamingHydrate`'s `setContent` from ~3 s to ~12 s on a 494 KB
+ * document (a 4x regression).
+ */
+const EMBEDDED_BLOCK_TYPES = new Set(["image", "chart", "drawing", "linkPreview"]);
+
+/** Default block width applied when `blockWidth` is null on first alignment. */
+const DEFAULT_BLOCK_WIDTH = 75;
+
+declare module "@tiptap/core" {
+  interface Commands<ReturnType> {
+    embeddedBlockAlign: {
+      /**
+       * Set the `align` attribute on the currently focused embedded block
+       * (image / chart / drawing / linkPreview). Returns `false` when the
+       * selection is NOT on an embedded block, allowing callers to fall
+       * through to `TextAlign.setTextAlign`.
+       */
+      setEmbeddedBlockAlign: (align: "left" | "center" | "right") => ReturnType;
+    };
+  }
+}
+
+export const EmbeddedBlockAlign = Extension.create({
+  name: "embeddedBlockAlign",
+
+  addCommands() {
+    return {
+      setEmbeddedBlockAlign:
+        (align: "left" | "center" | "right") =>
+        ({ state, dispatch }) => {
+          const { selection } = state;
+
+          let targetPos: number | null = null;
+          let targetNode = null as ReturnType<typeof state.doc.nodeAt> | null;
+
+          if (selection instanceof NodeSelection) {
+            // NodeSelection: the user clicked on (or tabbed to) an atom block.
+            const node = selection.node;
+            if (EMBEDDED_BLOCK_TYPES.has(node.type.name)) {
+              targetPos = selection.from;
+              targetNode = node;
+            }
+          } else {
+            // TextSelection: cursor is adjacent to an atom block (e.g. the
+            // user pressed the keyboard shortcut while the cursor is in the
+            // gap just before or after the block). Check $from.nodeBefore and
+            // $from.nodeAfter.
+            const { $from } = selection;
+            const nodeBefore = $from.nodeBefore;
+            const nodeAfter = $from.nodeAfter;
+
+            if (nodeBefore && EMBEDDED_BLOCK_TYPES.has(nodeBefore.type.name)) {
+              targetPos = $from.pos - nodeBefore.nodeSize;
+              targetNode = nodeBefore;
+            } else if (nodeAfter && EMBEDDED_BLOCK_TYPES.has(nodeAfter.type.name)) {
+              targetPos = $from.pos;
+              targetNode = nodeAfter;
+            }
+          }
+
+          if (targetPos === null || targetNode === null) {
+            // Not an embedded block — caller should fall through to TextAlign.
+            return false;
+          }
+
+          if (dispatch) {
+            const newAttrs = {
+              ...targetNode.attrs,
+              align,
+              // Apply a default width so the block doesn't span 100% when
+              // centred or right-aligned. Preserve any explicitly-set width.
+              blockWidth: targetNode.attrs.blockWidth ?? DEFAULT_BLOCK_WIDTH,
+            };
+            dispatch(
+              state.tr.setNodeMarkup(targetPos, undefined, newAttrs),
+            );
+          }
+          return true;
+        },
+    };
+  },
+
+  addKeyboardShortcuts() {
+    return {
+      // These mirror TextAlign's default shortcuts for left / center / right.
+      // Registering them here (AFTER TextAlign in useEditor.ts's extension
+      // array) gives this handler HIGHER priority. When the focused node is an
+      // embedded block, we handle it and stop propagation; otherwise we return
+      // `false` so Tiptap continues to TextAlign's handler.
+      "Mod-Shift-l": () =>
+        this.editor.chain().focus().setEmbeddedBlockAlign("left").run() || false,
+      "Mod-Shift-e": () =>
+        this.editor.chain().focus().setEmbeddedBlockAlign("center").run() || false,
+      "Mod-Shift-r": () =>
+        this.editor.chain().focus().setEmbeddedBlockAlign("right").run() || false,
+    };
+  },
+});

--- a/src/components/editor/extensions/index.ts
+++ b/src/components/editor/extensions/index.ts
@@ -74,3 +74,4 @@ export type { TableHeaderMenuEventDetail } from './table-header-menu';
 export { TableOfContents } from './toc';
 export type { TocHeading } from './toc';
 export { scanHeadings } from './toc';
+export { EmbeddedBlockAlign } from './embedded-block-align';

--- a/src/hooks/useEditor.ts
+++ b/src/hooks/useEditor.ts
@@ -23,7 +23,7 @@ import CodeBlockLowlight from "@tiptap/extension-code-block-lowlight";
 import { common, createLowlight } from "lowlight";
 import { Markdown } from "tiptap-markdown";
 import { SlashCommand } from "@/components/editor/extensions/slash-command";
-import { AISuggestion, InlineDiff, CommentMark, GhostText, TagHighlight, TagSuggestion, MentionHighlight, MentionSuggestion, DateHighlight, DateSuggestion, SearchHighlight, Drawing, Chart, MermaidBlock, LinkPreview, TableOfContents } from "@/components/editor/extensions";
+import { AISuggestion, InlineDiff, CommentMark, GhostText, TagHighlight, TagSuggestion, MentionHighlight, MentionSuggestion, DateHighlight, DateSuggestion, SearchHighlight, Drawing, Chart, MermaidBlock, LinkPreview, TableOfContents, EmbeddedBlockAlign } from "@/components/editor/extensions";
 import { PageBreaks } from "@/components/editor/extensions/page-breaks";
 import { LinkClick } from "@/components/editor/extensions/link-click";
 import { SendToAI } from "@/components/editor/extensions/send-to-ai";
@@ -98,6 +98,12 @@ export function useEditor({ content, onUpdate, editable = true, documentDir }: U
       TextAlign.configure({
         types: ["heading", "paragraph"],
       }),
+      // EmbeddedBlockAlign MUST appear after TextAlign — Tiptap resolves
+      // keyboard shortcuts in reverse extension registration order, so
+      // EmbeddedBlockAlign's Mod-Shift-l/e/r handlers fire first. When the
+      // selection is not on an embedded block they return false, which lets
+      // TextAlign's handlers run.
+      EmbeddedBlockAlign,
       TextStyle,
       Color,
       ThemedHighlight.configure({

--- a/src/perf/streaming-hydrate.perf.test.ts
+++ b/src/perf/streaming-hydrate.perf.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Regression guard for the streamingHydrate performance budget.
+ *
+ * Context: The naive fix for issue #220 (toolbar alignment on embedded blocks)
+ * is to expand TextAlign.addGlobalAttributes to include image/chart/drawing/
+ * linkPreview node types. That approach was tried and reverted in commit
+ * ba4fe785 because it inflated each node's attr set and slowed setContent from
+ * ~3 s to ~12 s on a 494 KB book. The correct fix is a custom Extension that
+ * only touches the selection when invoked — zero per-node schema overhead.
+ *
+ * This test feeds the 100KB fixture through parseMarkdownToProseMirrorJson and
+ * then streamingHydrate, asserting that the hydration step finishes within the
+ * budget. A 4x regression (the kind caused by the forbidden approach) would
+ * immediately fail this test even on the text-only fixture.
+ *
+ * This test is a REGRESSION GUARD, not a new-feature test — it must be GREEN
+ * both before and after the EmbeddedBlockAlign implementation.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { Editor } from '@tiptap/core';
+import StarterKit from '@tiptap/starter-kit';
+import TextAlign from '@tiptap/extension-text-align';
+import { Table } from '@tiptap/extension-table';
+import { TableRow } from '@tiptap/extension-table-row';
+import { TableCell } from '@tiptap/extension-table-cell';
+import { TableHeader } from '@tiptap/extension-table-header';
+import TaskList from '@tiptap/extension-task-list';
+import TaskItem from '@tiptap/extension-task-item';
+import { TextStyle } from '@tiptap/extension-text-style';
+import Color from '@tiptap/extension-color';
+import Highlight from '@tiptap/extension-highlight';
+import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight';
+import { common, createLowlight } from 'lowlight';
+import UniqueID from '@tiptap/extension-unique-id';
+import Subscript from '@tiptap/extension-subscript';
+import Superscript from '@tiptap/extension-superscript';
+import { Node, mergeAttributes } from '@tiptap/core';
+import { benchmark, setupJSDOM } from './harness';
+import { parseMarkdownToProseMirrorJson } from '@/workers/markdown-parse.core';
+import { streamingHydrate } from '@/lib/markdown';
+
+// ---------------------------------------------------------------------------
+// jsdom bootstrap
+// ---------------------------------------------------------------------------
+
+beforeAll(() => {
+  setupJSDOM();
+  // requestAnimationFrame is needed by streamingHydrate between chunks.
+  // jsdom provides a real-ish rAF that fires via microtask/timeout — wire it
+  // if it's missing so the streaming loop can run to completion in tests.
+  if (typeof globalThis.requestAnimationFrame === 'undefined') {
+    globalThis.requestAnimationFrame = (cb: FrameRequestCallback) => {
+      const id = setTimeout(() => cb(performance.now()), 0);
+      return id as unknown as number;
+    };
+    globalThis.cancelAnimationFrame = (id: number) => clearTimeout(id);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Minimal React-free shims for embedded block nodes (same schema as production)
+// ---------------------------------------------------------------------------
+
+const lowlight = createLowlight(common);
+
+const DrawingShim = Node.create({
+  name: 'drawing',
+  group: 'block',
+  atom: true,
+  addAttributes() {
+    return {
+      drawingId: { default: null },
+      width: { default: null },
+      height: { default: 600 },
+      drawingJson: { default: null },
+      blockWidth: { default: null },
+      align: { default: null },
+    };
+  },
+  parseHTML() { return [{ tag: 'div[data-drawing-json]' }]; },
+  renderHTML({ HTMLAttributes }) {
+    return ['div', mergeAttributes(HTMLAttributes, { 'data-type': 'drawing' })];
+  },
+});
+
+const ChartShim = Node.create({
+  name: 'chart',
+  group: 'block',
+  atom: true,
+  addAttributes() {
+    return {
+      chartId: { default: null },
+      width: { default: null },
+      height: { default: 300 },
+      chartJson: { default: null },
+      blockWidth: { default: null },
+      align: { default: null },
+    };
+  },
+  parseHTML() { return [{ tag: 'div[data-chart-json]' }]; },
+  renderHTML({ HTMLAttributes }) {
+    return ['div', mergeAttributes(HTMLAttributes, { 'data-type': 'chart' })];
+  },
+});
+
+const LinkPreviewShim = Node.create({
+  name: 'linkPreview',
+  group: 'block',
+  atom: true,
+  addAttributes() {
+    return {
+      url: { default: '' },
+      title: { default: null },
+      description: { default: null },
+      siteName: { default: null },
+      imageUrl: { default: null },
+      faviconUrl: { default: null },
+      blockWidth: { default: null },
+      align: { default: null },
+    };
+  },
+  parseHTML() { return [{ tag: 'div[data-link-preview]' }]; },
+  renderHTML({ HTMLAttributes }) {
+    return ['div', mergeAttributes(HTMLAttributes, { 'data-type': 'linkPreview' })];
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Fixture + editor factory
+// ---------------------------------------------------------------------------
+
+const fixturesDir = join(__dirname, '../../tests/fixtures/perf');
+const fixture100KB = readFileSync(join(fixturesDir, 'perf-100kb.md'), 'utf-8');
+
+function createHydrateEditor(): Editor {
+  const el = document.createElement('div');
+  return new Editor({
+    element: el,
+    extensions: [
+      StarterKit.configure({ codeBlock: false }),
+      TextAlign.configure({ types: ['heading', 'paragraph'] }),
+      TextStyle,
+      Color,
+      Highlight.configure({ multicolor: true }),
+      CodeBlockLowlight.configure({ lowlight }),
+      Table.configure({ resizable: false }),
+      TableRow,
+      TableCell,
+      TableHeader,
+      TaskList,
+      TaskItem.configure({ nested: true }),
+      Subscript,
+      Superscript,
+      UniqueID.configure({ types: ['heading', 'paragraph'] }),
+      DrawingShim,
+      ChartShim,
+      LinkPreviewShim,
+    ],
+    content: '',
+    editable: true,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark — streamingHydrate on the 100KB fixture
+// ---------------------------------------------------------------------------
+
+// Budget: ~1500ms for 100KB in jsdom.
+// Rationale: The forbidden TextAlign.addGlobalAttributes expansion caused a
+// ~4x slowdown on 494 KB. Even on 100 KB text-only content, a 4x regression
+// would push past this budget (text-only baseline is well under 400ms).
+// The 1.5x CI multiplier gives a ceiling of 2250ms.
+const STREAM_BUDGET_MS = 1500;
+
+describe('streamingHydrate performance regression guard', () => {
+  it(`streams 100KB fixture within ${STREAM_BUDGET_MS}ms`, async () => {
+    // Parse once outside the benchmark loop — we're measuring hydration, not parse.
+    const { doc, annotations, nodeIds, tableMetadata } =
+      parseMarkdownToProseMirrorJson(fixture100KB);
+
+    const editor = createHydrateEditor();
+
+    const result = await benchmark(
+      'streamingHydrate 100KB',
+      async () => {
+        const controller = new AbortController();
+        const out = await streamingHydrate(
+          editor,
+          doc,
+          { annotations, nodeIds, tableMetadata },
+          controller.signal,
+        );
+        // Prevent dead-code elimination — touch the result.
+        if (out.ms < 0) throw new Error('unreachable');
+      },
+      STREAM_BUDGET_MS,
+    );
+
+    editor.destroy();
+    expect(result.passed).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `EmbeddedBlockAlign` — a custom Tiptap `Extension` (NOT `TextAlign.addGlobalAttributes` expansion) with a `setEmbeddedBlockAlign(align)` command that inspects the selection for `image`, `chart`, `drawing`, or `linkPreview` nodes and sets their `align` attribute via `tr.setNodeMarkup`
- `Cmd+Shift+L/E/R` keyboard shortcuts try embedded block alignment first; return `false` (fall through to TextAlign) when no embedded block is in scope
- Toolbar alignment buttons updated with the same fallthrough pattern for both the pill-dropdown variant and the inline toolbar variant
- `EmbeddedBlockAlign` registered AFTER `TextAlign` in `useEditor.ts` so its keymap handlers fire first (Tiptap resolves in reverse registration order)
- `blockWidth` defaults to 75 on first alignment (when currently null) so centred/right-aligned blocks don't span 100% width
- New `src/perf/streaming-hydrate.perf.test.ts` regression guard asserts `streamingHydrate` on the 100KB fixture stays within 1500ms — catches the forbidden 4x regression if `TextAlign.addGlobalAttributes` expansion is re-introduced

## Decisions made

- **Custom Extension, not addGlobalAttributes**: The forbidden approach was tried in the alpha.0 branch and reverted — it inflated every node's attr set and caused a ~4x streamingHydrate slowdown (3s → 12s on 494KB). `EmbeddedBlockAlign` adds zero per-node schema overhead.
- **Keymap priority via registration order**: Registering AFTER `TextAlign` gives higher priority. The keyboard shortcuts return `false` for non-embedded-block selections so TextAlign's handlers still fire for paragraphs/headings.
- **TextSelection adjacent-block detection**: `$from.nodeBefore` / `$from.nodeAfter` handles the case where the cursor is in the gap adjacent to an embedded block when the keyboard shortcut is pressed.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 281/281 test files, 5100/5100 tests pass
- [x] 7 new unit tests in `embedded-block-align.test.ts` (RED before implementation, GREEN after)
- [x] `streaming-hydrate.perf.test.ts` regression guard (GREEN both before and after — confirms no setContent regression)
- [ ] Manual: Insert chart/drawing/image/link-preview → click block → press Cmd+Shift+E → block should centre-align
- [ ] Manual: Insert paragraph → press Cmd+Shift+E → paragraph should centre-align (TextAlign fallthrough)
- [ ] Manual: Use toolbar alignment buttons with embedded block selected — both pill-dropdown and inline toolbar variants

Fixes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)