### PR TITLE
chore(deps): upgrade lucide-react from 1.8.0 to 1.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "jszip": "^3.10.1",
     "linkedom": "^0.18.12",
     "lowlight": "^3.3.0",
-    "lucide-react": "^1.8.0",
+    "lucide-react": "^1.16.0",
     "mammoth": "^1.12.0",
     "markdown-it": "^14.1.1",
     "markdown-it-sub": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -244,8 +244,8 @@ importers:
         specifier: ^3.3.0
         version: 3.3.0
       lucide-react:
-        specifier: ^1.8.0
-        version: 1.8.0(react@19.2.5)
+        specifier: ^1.16.0
+        version: 1.16.0(react@19.2.5)
       mammoth:
         specifier: ^1.12.0
         version: 1.12.0
@@ -4570,8 +4570,8 @@ packages:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
 
-  lucide-react@1.8.0:
-    resolution: {integrity: sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw==}
+  lucide-react@1.16.0:
+    resolution: {integrity: sha512-dYwyPzb4MEKpGUmNYk3WKWPnMrHs3FKM+q94kAnJrcDIqqn1hq2xY8scaS2ovsOCM5D51ey2gaRG3PBb1vgoYQ==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -10489,7 +10489,7 @@ snapshots:
 
   lru-cache@7.18.3: {}
 
-  lucide-react@1.8.0(react@19.2.5):
+  lucide-react@1.16.0(react@19.2.5):
     dependencies:
       react: 19.2.5
 

--- a/src/lib/__tests__/lucide-react-version.test.ts
+++ b/src/lib/__tests__/lucide-react-version.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import path from 'path';
+
+// Regression-lock for issue #230: lucide-react must be at 1.16.0.
+// This test fails if someone downgrades the package or if the bump was not applied.
+
+const repoRoot = path.resolve(__dirname, '..', '..', '..');
+const pkgPath = path.join(repoRoot, 'package.json');
+
+interface PackageJson {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+}
+
+function loadPackageJson(): PackageJson {
+  return JSON.parse(readFileSync(pkgPath, 'utf8')) as PackageJson;
+}
+
+describe('lucide-react dependency version', () => {
+  it('is pinned to ^1.16.0 in package.json', () => {
+    const pkg = loadPackageJson();
+    const version =
+      pkg.dependencies?.['lucide-react'] ??
+      pkg.devDependencies?.['lucide-react'];
+    expect(version).toBeDefined();
+    // Accept exact "1.16.0" or caret "^1.16.0" — either satisfies the bump.
+    const semverBase = version?.replace(/^\^/, '');
+    const [major, minor] = (semverBase ?? '').split('.').map(Number);
+    expect(major).toBe(1);
+    expect(minor).toBeGreaterThanOrEqual(16);
+  });
+});


### PR DESCRIPTION
Resolves #230

## Summary

Upgrades `lucide-react` from 1.8.0 to 1.16.0 (8 minor versions). Lucide did not rename any icons between these versions — `pnpm typecheck` passes cleanly with no import fixes required. Adds a regression-lock test (`src/lib/__tests__/lucide-react-version.test.ts`) to prevent silent downgrades.

## Red tests added

- `src/lib/__tests__/lucide-react-version.test.ts::lucide-react dependency version > is pinned to ^1.16.0 in package.json` — asserts the minor version is ≥ 16; was red (minor=8) before the bump, green after.

## Green implementation

- `package.json`: bumped `lucide-react` from `^1.8.0` to `^1.16.0`
- `pnpm-lock.yaml`: updated lockfile to reflect the new resolved version

## Refactor

Skipped — implementation is already minimal (one-line version bump).

## Decisions made

- Accepted the caret range `^1.16.0` (pnpm's default when using `pnpm add lucide-react@1.16.0`) rather than pinning an exact version. Lucide uses a stable icon-name policy; `^1.16.0` keeps us current within the minor line. If a future minor renames an icon, `pnpm typecheck` will catch it.

## Verification

- [x] Red tests were red before implementation (minor version 8 < 16)
- [x] All red tests now green
- [x] `pnpm test` passes (full suite: 281 test files, 5096 tests)
- [x] `pnpm typecheck` clean (no missing or renamed icon imports)
- [x] No unrelated files modified (only `package.json`, `pnpm-lock.yaml`, and the new test file)

## Notes for reviewer

All 86 lucide-react import sites in `src/` compile without errors — Lucide's commitment to not renaming existing icons held between 1.8 and 1.16. The acceptance criterion "App launches and renders all lucide-icon chrome without console warnings" requires manual QA (sidebar file icons, toolbar buttons, chat panel, StatusBar/StatusTray, Agent Orb Bot glyph, settings dialog).

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the `aw-tdd` skill.