### PR TITLE
chore(deps): upgrade notify 7 → 8 and notify-debouncer-full 0.4 → 0.7 (#242)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3501,11 +3501,11 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.10.2"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
+checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.11.0",
  "inotify-sys",
  "libc",
 ]
@@ -3526,15 +3526,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -4303,12 +4294,11 @@ dependencies = [
 
 [[package]]
 name = "notify"
-version = "7.0.0"
+version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c533b4c39709f9ba5005d8002048266593c1cfaf3c5f0739d5b8ab0c6c504009"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
  "bitflags 2.11.0",
- "filetime",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -4317,14 +4307,14 @@ dependencies = [
  "mio",
  "notify-types",
  "walkdir",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "notify-debouncer-full"
-version = "0.4.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcf855483228259b2353f89e99df35fc639b2b2510d1166e4858e3f67ec1afb"
+checksum = "c02b49179cfebc9932238d04d6079912d26de0379328872846118a0fa0dbb302"
 dependencies = [
  "file-id",
  "log",
@@ -4349,11 +4339,11 @@ dependencies = [
 
 [[package]]
 name = "notify-types"
-version = "1.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585d3cb5e12e01aed9e8a1f70d5c6b5e86fe2a6e48fc8cd0b3e0b8df6f6eb174"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "instant",
+ "bitflags 2.11.0",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -61,8 +61,8 @@ serde_norway = "0.9"
 parking_lot = "0.12"
 
 # Filesystem watcher (Phase 5)
-notify = { version = "7", features = ["macos_fsevent"] }
-notify-debouncer-full = "0.4"
+notify = { version = "8", features = ["macos_fsevent"] }
+notify-debouncer-full = "0.7"
 
 # iCloud sync (Phase 5.5)
 fs_extra = "1.3"

--- a/src-tauri/src/commands/watcher.rs
+++ b/src-tauri/src/commands/watcher.rs
@@ -571,4 +571,173 @@ mod tests {
             .any(|(p, _)| p == normal_str.as_ref());
         assert!(in_reindex, "normal file must appear in reindex entries");
     }
+
+    // ── Regression guards for the notify v8 upgrade ────────────────────────────
+    // These tests cover acceptance-criteria behaviours that were not explicitly
+    // tested before the upgrade.  They must pass on both notify v7 and v8.
+
+    #[test]
+    fn process_watcher_events_filters_git_internals() {
+        // Events inside .git/ must be silently dropped from file-changed-batch.
+        let mut self_writes: HashMap<PathBuf, Instant> = HashMap::new();
+
+        let git_path = PathBuf::from("/Users/test/project/.git/COMMIT_EDITMSG");
+        let normal_path = PathBuf::from("/Users/test/project/README.md");
+
+        let events = vec![
+            DebouncedEvent::new(
+                notify::Event {
+                    kind: notify::EventKind::Modify(notify::event::ModifyKind::Data(
+                        notify::event::DataChange::Content,
+                    )),
+                    paths: vec![git_path.clone()],
+                    attrs: Default::default(),
+                },
+                Instant::now(),
+            ),
+            DebouncedEvent::new(
+                notify::Event {
+                    kind: notify::EventKind::Modify(notify::event::ModifyKind::Data(
+                        notify::event::DataChange::Content,
+                    )),
+                    paths: vec![normal_path.clone()],
+                    attrs: Default::default(),
+                },
+                Instant::now(),
+            ),
+        ];
+
+        let result = process_watcher_events(events, &mut self_writes);
+
+        let git_str = git_path.to_string_lossy();
+        let git_in_changes = result.file_changes.iter().any(|e| e.path == git_str);
+        assert!(!git_in_changes, ".git/ internals must not appear in file-changed-batch");
+
+        // The normal README.md must still reach the reindex queue.
+        let normal_str = normal_path.to_string_lossy();
+        let normal_in_reindex = result
+            .reindex_entries
+            .iter()
+            .any(|(p, _)| p == normal_str.as_ref());
+        assert!(normal_in_reindex, "non-git files must appear in reindex entries");
+    }
+
+    #[test]
+    fn process_watcher_events_filters_ds_store() {
+        // .DS_Store events must never reach the frontend.
+        let mut self_writes: HashMap<PathBuf, Instant> = HashMap::new();
+
+        let ds_path = PathBuf::from("/Users/test/project/.DS_Store");
+        let normal_path = PathBuf::from("/Users/test/project/note.md");
+
+        let events = vec![
+            DebouncedEvent::new(
+                notify::Event {
+                    kind: notify::EventKind::Modify(notify::event::ModifyKind::Data(
+                        notify::event::DataChange::Content,
+                    )),
+                    paths: vec![ds_path.clone()],
+                    attrs: Default::default(),
+                },
+                Instant::now(),
+            ),
+            DebouncedEvent::new(
+                notify::Event {
+                    kind: notify::EventKind::Modify(notify::event::ModifyKind::Data(
+                        notify::event::DataChange::Content,
+                    )),
+                    paths: vec![normal_path.clone()],
+                    attrs: Default::default(),
+                },
+                Instant::now(),
+            ),
+        ];
+
+        let result = process_watcher_events(events, &mut self_writes);
+
+        let ds_str = ds_path.to_string_lossy();
+        let ds_in_changes = result.file_changes.iter().any(|e| e.path == ds_str);
+        assert!(!ds_in_changes, ".DS_Store must not appear in file-changed-batch");
+
+        let normal_str = normal_path.to_string_lossy();
+        let normal_in_reindex = result
+            .reindex_entries
+            .iter()
+            .any(|(p, _)| p == normal_str.as_ref());
+        assert!(normal_in_reindex, "non-DS_Store files must appear in reindex entries");
+    }
+
+    #[test]
+    fn process_watcher_events_reclassifies_modify_as_delete_for_nonexistent_file() {
+        // macOS FSEvents quirk: file deletions sometimes arrive as Modify events.
+        // process_watcher_events() must reclassify them as Delete when path no longer exists.
+        // We use a path we know does not exist on disk.
+        let mut self_writes: HashMap<PathBuf, Instant> = HashMap::new();
+        let ghost_path = PathBuf::from("/tmp/notesage_ghost_file_that_does_not_exist_xyz.md");
+
+        // Ensure the path really doesn't exist
+        assert!(!ghost_path.exists(), "test assumes path does not exist");
+
+        let events = vec![DebouncedEvent::new(
+            notify::Event {
+                kind: notify::EventKind::Modify(notify::event::ModifyKind::Data(
+                    notify::event::DataChange::Content,
+                )),
+                paths: vec![ghost_path.clone()],
+                attrs: Default::default(),
+            },
+            Instant::now(),
+        )];
+
+        let result = process_watcher_events(events, &mut self_writes);
+
+        // The Modify event must have been reclassified as Delete.
+        let ghost_str = ghost_path.to_string_lossy();
+        let delete_event = result
+            .file_changes
+            .iter()
+            .find(|e| e.path == ghost_str.as_ref());
+        assert!(
+            delete_event.is_some(),
+            "reclassified delete must appear in file-changed-batch"
+        );
+        assert_eq!(
+            delete_event.unwrap().kind,
+            FileChangeKind::Delete,
+            "modify on nonexistent file must be reclassified as Delete (macOS FSEvents quirk)"
+        );
+    }
+
+    #[test]
+    fn process_watcher_events_self_write_suppresses_file_changed_batch_not_reindex() {
+        // A self-written file must NOT appear in file_changes but MUST still appear
+        // in reindex_entries so the SQLite index stays current.
+        let mut self_writes: HashMap<PathBuf, Instant> = HashMap::new();
+        let self_written = PathBuf::from("/tmp/notesage_self_written_test_xyz.md");
+        // Mark the path as a self-write
+        self_writes.insert(self_written.clone(), Instant::now());
+
+        let events = vec![DebouncedEvent::new(
+            notify::Event {
+                kind: notify::EventKind::Modify(notify::event::ModifyKind::Data(
+                    notify::event::DataChange::Content,
+                )),
+                paths: vec![self_written.clone()],
+                attrs: Default::default(),
+            },
+            Instant::now(),
+        )];
+
+        let result = process_watcher_events(events, &mut self_writes);
+
+        let self_str = self_written.to_string_lossy();
+        let in_changes = result.file_changes.iter().any(|e| e.path == self_str);
+        assert!(!in_changes, "self-write must be suppressed from file-changed-batch");
+
+        let in_reindex = result
+            .reindex_entries
+            .iter()
+            .any(|(p, _)| p == self_str.as_ref());
+        assert!(in_reindex, "self-write must still appear in reindex_entries for SQLite");
+    }
 }


### PR DESCRIPTION
Resolves #242

## Summary

Bumps `notify` from 7.0.0 to 8.2.0 and `notify-debouncer-full` from 0.4.0 to 0.7.0, keeping the filesystem watcher on a current, supported release. The notify v8 API is backward-compatible for all patterns used in `watcher.rs` — no logic changes were needed.

**Note on version:** The issue targets `notify 9.x`, but as of 2026-05-15 `notify 9.0.0` has not been released as stable (only `9.0.0-rc.4` exists on crates.io). This PR upgrades to the latest stable `8.x` line instead. Reviewers can request a follow-up bump to `9.0.0` once it reaches GA.

## Red tests added

- `src/commands/watcher.rs::process_watcher_events_filters_git_internals` — .git/ internals must not reach file-changed-batch
- `src/commands/watcher.rs::process_watcher_events_filters_ds_store` — .DS_Store must not reach file-changed-batch
- `src/commands/watcher.rs::process_watcher_events_reclassifies_modify_as_delete_for_nonexistent_file` — macOS FSEvents quirk: Modify on deleted file reclassified as Delete
- `src/commands/watcher.rs::process_watcher_events_self_write_suppresses_file_changed_batch_not_reindex` — self-write suppressed from frontend batch but still reindexed in SQLite

These are regression guards (expected green before implementation per the additive-changes exception, as they test existing code paths). All 13 watcher tests pass with both notify v7 and v8.

## Green implementation

- `src-tauri/Cargo.toml` — `notify` bumped from `"7"` to `"8"`, `notify-debouncer-full` from `"0.4"` to `"0.7"`.
- `src-tauri/Cargo.lock` — resolved `notify 7.0.0 → 8.2.0`, `notify-debouncer-full 0.4.0 → 0.7.0`, `notify-types 1.0.1 → 2.1.0`, `inotify 0.10.2 → 0.11.1`.
- `src-tauri/src/commands/watcher.rs` — four new regression-guard unit tests added in `#[cfg(test)]`.

## Refactor

Skipped — the upgrade required no logic changes.

## Decisions made

- Upgraded to `notify 8.x` (8.2.0 stable) rather than `9.x` (pre-release only) | Chose 8.x | No stable 9.0.0 exists on crates.io as of the implementation date; using a pre-release in production code is risky. Reviewer can escalate to 9.x once it is GA.
- `notify-debouncer-full 0.7.0` paired with `notify 8.x` | Chose 0.7 | Latest stable `notify-debouncer-full` that resolves against `notify = "8"`.

## Verification

- [x] Red tests were red before implementation (regression guards — additive changes exception applies; 4 new test functions; all 9 pre-existing tests plus 4 new tests pass with v7)
- [x] All red tests now green (13/13 watcher tests pass with notify v8)
- [x] `cargo test` passes (680 tests; 2 pre-existing macOS-only font test failures on Linux CI — confirmed present before this change)
- [x] `pnpm test` passes (5095/5095 frontend tests)
- [x] `pnpm typecheck` clean
- [x] No unrelated files modified

## Notes for reviewer

- The 2 failing Rust tests (`commands::fonts::tests::contains_known_system_fonts` and `commands::fonts::tests::second_call_is_cached`) are pre-existing Linux CI failures unrelated to this change — they look for macOS-specific fonts (Helvetica) that don't exist in the runner environment. Confirmed by running `cargo test` with `notify v7` and observing the same failures.
- If the project wants to bump to `notify 9.x` once it reaches stable, the change will be equally trivial — the API remained fully backward-compatible across v7 → v8 → (projected) v9.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the `aw-tdd` skill.