### PR TITLE
chore(deps): bump rusqlite 0.34 → 0.39

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2110,6 +2110,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "font-kit"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2826,7 +2832,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -2834,14 +2840,17 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -3900,9 +3909,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.32.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbb8270bb4060bd76c6e96f20c52d80620f1d82a3470885694e41e0f81ef6fe7"
+checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
 dependencies = [
  "cc",
  "pkg-config",
@@ -6013,10 +6022,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
-name = "rusqlite"
-version = "0.34.0"
+name = "rsqlite-vfs"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e34486da88d8e051c7c0e23c3f15fd806ea8546260aa2fec247e97242ec143"
+checksum = "a8a1f2315036ef6b1fbacd1972e8ee7688030b0a2121edfc2a6550febd41574d"
+dependencies = [
+ "hashbrown 0.16.1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
 dependencies = [
  "bitflags 2.11.0",
  "fallible-iterator",
@@ -6024,6 +6043,7 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+ "sqlite-wasm-rs",
 ]
 
 [[package]]
@@ -6747,6 +6767,18 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "sqlite-wasm-rs"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b2c760607300407ddeaee518acf28c795661b7108c75421303dbefb237d3a36"
+dependencies = [
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "stable_deref_trait"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -51,7 +51,7 @@ comrak = { version = "0.50.0", default-features = false, features = ["syntect"] 
 regex = "1"
 
 # SQLite document index (Phase 10)
-rusqlite = { version = "0.34", features = ["bundled"] }
+rusqlite = { version = "0.39", features = ["bundled"] }
 sha2 = "0.10"
 
 # Skills & Agents Platform (Phase 7)

--- a/src-tauri/src/index/queries.rs
+++ b/src-tauri/src/index/queries.rs
@@ -115,7 +115,7 @@ pub fn query_tags(conn: &Connection, query: Option<&str>) -> Result<Vec<IndexedT
     while let Some(row) = rows.next().map_err(|e| e.to_string())? {
         results.push(IndexedTag {
             tag: row.get(0).map_err(|e| e.to_string())?,
-            file_count: row.get(1).map_err(|e| e.to_string())?,
+            file_count: row.get::<_, i64>(1).map_err(|e| e.to_string())? as usize,
         });
     }
 
@@ -170,7 +170,7 @@ pub fn query_mentions(conn: &Connection, query: Option<&str>) -> Result<Vec<Inde
     while let Some(row) = rows.next().map_err(|e| e.to_string())? {
         results.push(IndexedMention {
             mention: row.get(0).map_err(|e| e.to_string())?,
-            file_count: row.get(1).map_err(|e| e.to_string())?,
+            file_count: row.get::<_, i64>(1).map_err(|e| e.to_string())? as usize,
         });
     }
 
@@ -267,7 +267,7 @@ pub fn query_research(
                 row.get::<_, String>(2)?,
                 row.get::<_, String>(3)?,
                 row.get::<_, String>(4)?,
-                row.get::<_, usize>(5)?,
+                row.get::<_, i64>(5).map(|v| v as usize)?,
                 row.get::<_, Option<String>>(6)?,
                 row.get::<_, i64>(7)?,
             ))
@@ -369,7 +369,7 @@ pub fn query_tasks(
                 file_name: row.get(1)?,
                 text: row.get(2)?,
                 done: row.get::<_, i32>(3)? != 0,
-                position: row.get(4)?,
+                position: row.get::<_, i64>(4).map(|v| v as usize)?,
                 context_before: row.get(5)?,
                 context_after: row.get(6)?,
                 project_name,
@@ -404,8 +404,8 @@ pub fn query_goals(conn: &Connection) -> Result<Vec<IndexedGoal>, String> {
                 file_name: row.get(1)?,
                 title: row.get(2)?,
                 template: row.get(3)?,
-                total_tasks: row.get(4)?,
-                completed_tasks: row.get(5)?,
+                total_tasks: row.get::<_, i64>(4).map(|v| v as usize)?,
+                completed_tasks: row.get::<_, i64>(5).map(|v| v as usize)?,
                 project_name,
             })
         })
@@ -541,27 +541,27 @@ fn build_fts_query(input: &str) -> String {
 /// Get index statistics.
 pub fn query_stats(conn: &Connection) -> Result<IndexStats, String> {
     let file_count: usize = conn
-        .query_row("SELECT COUNT(*) FROM files", [], |row| row.get(0))
-        .map_err(|e| e.to_string())?;
+        .query_row("SELECT COUNT(*) FROM files", [], |row| row.get::<_, i64>(0))
+        .map_err(|e| e.to_string())? as usize;
     let tag_count: usize = conn
-        .query_row("SELECT COUNT(DISTINCT tag) FROM tags", [], |row| row.get(0))
-        .map_err(|e| e.to_string())?;
+        .query_row("SELECT COUNT(DISTINCT tag) FROM tags", [], |row| row.get::<_, i64>(0))
+        .map_err(|e| e.to_string())? as usize;
     let mention_count: usize = conn
-        .query_row("SELECT COUNT(DISTINCT mention) FROM mentions", [], |row| row.get(0))
-        .map_err(|e| e.to_string())?;
+        .query_row("SELECT COUNT(DISTINCT mention) FROM mentions", [], |row| row.get::<_, i64>(0))
+        .map_err(|e| e.to_string())? as usize;
     let task_count: usize = conn
-        .query_row("SELECT COUNT(*) FROM tasks", [], |row| row.get(0))
-        .map_err(|e| e.to_string())?;
+        .query_row("SELECT COUNT(*) FROM tasks", [], |row| row.get::<_, i64>(0))
+        .map_err(|e| e.to_string())? as usize;
     let goal_count: usize = conn
-        .query_row("SELECT COUNT(*) FROM goals", [], |row| row.get(0))
-        .map_err(|e| e.to_string())?;
+        .query_row("SELECT COUNT(*) FROM goals", [], |row| row.get::<_, i64>(0))
+        .map_err(|e| e.to_string())? as usize;
     let indexed_at: u64 = conn
         .query_row(
             "SELECT COALESCE(MAX(indexed_at), 0) FROM files",
             [],
-            |row| row.get(0),
+            |row| row.get::<_, i64>(0),
         )
-        .map_err(|e| e.to_string())?;
+        .map_err(|e| e.to_string())? as u64;
 
     Ok(IndexStats {
         file_count,


### PR DESCRIPTION
## Summary

Bumps `rusqlite` from `0.34` to `0.39` (and the underlying `libsqlite3-sys` from `0.32` to `0.37`). The `bundled` feature is preserved — the app still ships with its own SQLite and has no system SQLite dependency.

**Breaking API change fixed:** rusqlite 0.39 removed `FromSql` implementations for `usize` and `u64` (SQLite's native integer type is signed 64-bit). All `row.get()` calls in the document index query layer that previously targeted `usize` or `u64` fields now retrieve `i64` and cast to the required Rust type. The 12 affected call-sites are all in `src/index/queries.rs`.

## Decisions made

- Cast direction: `i64 as usize` and `i64 as u64`. Values retrieved from SQLite COUNT / position / word_count columns are always non-negative and small enough that the truncating cast is safe for the column semantics used.
- Struct field types (`usize`, `u64`) preserved unchanged — only the SQLite retrieval layer changed, keeping the public API stable for callers.

## Test plan

- [x] `cargo check --lib` — zero errors after fix (12 errors before)
- [x] `cargo test --lib -- index` — 75 index tests pass
- [x] `cargo test --lib` — 676 pass, 2 fail (pre-existing macOS font-enumeration tests that require Helvetica; fail on Linux CI before and after this change)
- [x] `pnpm test` — 5095 frontend tests pass
- [x] `pnpm typecheck` — no type errors
- [x] Only `Cargo.toml`, `Cargo.lock`, `src/index/queries.rs` modified

Resolves #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)