### PR TITLE
feat(ci): add real Tauri E2E job to CI and gate alpha cut on it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -294,6 +294,46 @@ jobs:
       contents: write
 
     steps:
+      - name: Verify real-E2E passed on main within 24h
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Gate the alpha cut on a recent green real-E2E run on main.
+            // A Tauri framework bump can only ship automatically when the
+            // real-app test suite confirmed the main branch is healthy.
+            const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+
+            const { data: { workflow_runs } } = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'test.yml',
+              branch: 'main',
+              status: 'completed',
+              per_page: 10,
+            });
+
+            for (const run of workflow_runs) {
+              if (run.updated_at < oneDayAgo) break;
+
+              const { data: { jobs } } = await github.rest.actions.listJobsForWorkflowRun({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: run.id,
+              });
+
+              const realE2EJob = jobs.find(j => j.name === 'Real Tauri E2E Tests');
+              if (realE2EJob?.conclusion === 'success') {
+                core.info(`✓ Real E2E passed on main (workflow run #${run.id}, ${run.updated_at})`);
+                return;
+              }
+            }
+
+            core.setFailed(
+              'No successful real-E2E run found on main within the last 24h. ' +
+              'Ensure "Real Tauri E2E Tests" in the Tests workflow passed on main ' +
+              'before cutting an alpha release. Re-run the Tests workflow on main manually if needed.'
+            );
+
       - uses: actions/checkout@v6
 
       - name: Download alpha release assets

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
 name: Tests
 
 on:
+  push:
+    branches: [main]   # post-merge regression catch + triggers real-E2E on main
   pull_request:
     branches: [main]
   workflow_dispatch: # Manual trigger from GitHub Actions UI
@@ -157,3 +159,72 @@ jobs:
       - name: Run Rust tests
         working-directory: src-tauri
         run: cargo test
+
+  real-e2e-tests:
+    name: Real Tauri E2E Tests
+    runs-on: macos-latest
+    # Only run on push to main, workflow_dispatch, and workflow_call (e.g. release).
+    # Excluded from pull_request events — the full Tauri build is too expensive
+    # for every PR. Real-app regressions are caught post-merge on main and at
+    # release time via workflow_call from release.yml.
+    if: github.event_name != 'pull_request'
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Set whisper.cpp build flags
+        run: |
+          echo "CMAKE_C_FLAGS=-march=armv8.2-a+dotprod+fp16" >> $GITHUB_ENV
+          echo "CMAKE_CXX_FLAGS=-march=armv8.2-a+dotprod+fp16" >> $GITHUB_ENV
+
+      - name: Create sidecar placeholder
+        run: |
+          mkdir -p src-tauri/binaries/lib
+          touch src-tauri/binaries/llama-server-aarch64-apple-darwin
+          chmod +x src-tauri/binaries/llama-server-aarch64-apple-darwin
+
+      - name: Install frontend dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Cache tauri-driver binary
+        id: cache-tauri-driver
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/tauri-driver
+          key: ${{ runner.os }}-tauri-driver-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install tauri-driver
+        if: steps.cache-tauri-driver.outputs.cache-hit != 'true'
+        run: cargo install tauri-driver
+
+      - name: Run real Tauri E2E tests
+        run: pnpm test:e2e-real-full
+
+      - name: Upload real-E2E logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: real-e2e-logs
+          path: |
+            /tmp/notesage-e2e-tauri.log
+            /tmp/notesage-e2e-driver.log
+          retention-days: 14

--- a/src/lib/__tests__/real-e2e-ci.test.ts
+++ b/src/lib/__tests__/real-e2e-ci.test.ts
@@ -1,0 +1,152 @@
+// Regression-lock tests for real Tauri E2E CI plumbing (issue #254).
+//
+// Verifies that:
+// 1. test.yml has a push-to-main trigger so real-E2E runs after every merge.
+// 2. test.yml has a `real-e2e-tests` job that runs on macos-latest.
+// 3. The job is excluded from pull_request events (too expensive).
+// 4. The job installs tauri-driver with cargo + actions/cache.
+// 5. The job runs `pnpm test:e2e-real-full`.
+// 6. The job uploads logs on failure for triage.
+// 7. release.yml's alpha-cut step verifies the real-E2E run on main
+//    was green within 24h.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { parse as parseYaml } from 'yaml';
+
+interface StepYaml {
+  uses?: string;
+  run?: string;
+  if?: string;
+  with?: Record<string, unknown>;
+  name?: string;
+  [key: string]: unknown;
+}
+
+interface JobYaml {
+  'runs-on'?: string;
+  if?: string;
+  steps?: StepYaml[];
+  needs?: string | string[];
+  [key: string]: unknown;
+}
+
+interface OnPushYaml {
+  branches?: string[];
+  tags?: string[];
+}
+
+interface WorkflowOnYaml {
+  push?: OnPushYaml;
+  pull_request?: { branches?: string[] };
+  workflow_dispatch?: unknown;
+  workflow_call?: unknown;
+  [key: string]: unknown;
+}
+
+interface WorkflowYaml {
+  on: WorkflowOnYaml;
+  jobs: Record<string, JobYaml>;
+}
+
+function loadWorkflow(name: string): WorkflowYaml {
+  const path = resolve(__dirname, '../../../.github/workflows', `${name}.yml`);
+  return parseYaml(readFileSync(path, 'utf-8')) as WorkflowYaml;
+}
+
+function hasStepWith(steps: StepYaml[], predicate: (s: StepYaml) => boolean): boolean {
+  return steps.some(predicate);
+}
+
+describe('Real E2E CI plumbing (#254)', () => {
+  describe('test.yml — triggers', () => {
+    const wf = loadWorkflow('test');
+
+    it('has a push trigger on the main branch', () => {
+      const pushOn = wf.on?.push;
+      expect(pushOn).toBeDefined();
+      expect(pushOn?.branches).toContain('main');
+    });
+  });
+
+  describe('test.yml — real-e2e-tests job', () => {
+    const wf = loadWorkflow('test');
+    const job = wf.jobs?.['real-e2e-tests'];
+
+    it('has a real-e2e-tests job', () => {
+      expect(job).toBeDefined();
+    });
+
+    it('runs on macos-latest', () => {
+      expect(job?.['runs-on']).toBe('macos-latest');
+    });
+
+    it('is excluded from pull_request events via an if condition', () => {
+      // The job must have an `if:` that prevents it running on pull_request
+      // so costly real-app builds do not run on every PR.
+      const condition = job?.if ?? '';
+      expect(condition).toMatch(/pull_request/);
+    });
+
+    it('has an actions/cache step keyed on tauri-driver', () => {
+      const steps = job?.steps ?? [];
+      const cacheStep = steps.find(
+        (s) =>
+          typeof s.uses === 'string' &&
+          s.uses.startsWith('actions/cache') &&
+          JSON.stringify(s.with ?? {}).toLowerCase().includes('tauri-driver'),
+      );
+      expect(cacheStep).toBeDefined();
+    });
+
+    it('installs tauri-driver via cargo install', () => {
+      const steps = job?.steps ?? [];
+      expect(
+        hasStepWith(steps, (s) =>
+          typeof s.run === 'string' && s.run.includes('cargo install tauri-driver'),
+        ),
+      ).toBe(true);
+    });
+
+    it('runs pnpm test:e2e-real-full', () => {
+      const steps = job?.steps ?? [];
+      expect(
+        hasStepWith(steps, (s) =>
+          typeof s.run === 'string' && s.run.includes('pnpm test:e2e-real-full'),
+        ),
+      ).toBe(true);
+    });
+
+    it('uploads logs or report artifact on failure', () => {
+      const steps = job?.steps ?? [];
+      const uploadStep = steps.find(
+        (s) =>
+          typeof s.uses === 'string' &&
+          s.uses.startsWith('actions/upload-artifact') &&
+          (s.if === 'failure()' || String(s.if ?? '').includes('failure')),
+      );
+      expect(uploadStep).toBeDefined();
+    });
+  });
+
+  describe('release.yml — alpha-cut gate', () => {
+    const wf = loadWorkflow('release');
+    const alphaJob = wf.jobs?.['update-latest-alpha'];
+
+    it('update-latest-alpha job exists', () => {
+      expect(alphaJob).toBeDefined();
+    });
+
+    it('has a step that verifies the real-E2E run on main within 24h', () => {
+      const steps = alphaJob?.steps ?? [];
+      // The step should reference 'real' (as in real-e2e) and '24' (hours) in
+      // either its name or its script body.
+      const gatestep = steps.find((s) => {
+        const body = JSON.stringify(s).toLowerCase();
+        return body.includes('real') && body.includes('24');
+      });
+      expect(gatestep).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
Resolves #254

## Summary

Adds a `real-e2e-tests` job to `.github/workflows/test.yml` that runs `pnpm test:e2e-real-full` on `macos-latest`. The job is excluded from `pull_request` events (the full Tauri build is too expensive for every PR) and runs on push to `main`, `workflow_dispatch`, and `workflow_call` (triggered by `release.yml` on tag push). `tauri-driver` is installed via `cargo install` with `actions/cache` keyed on `Cargo.lock`. Tauri app logs and driver logs are uploaded as an artifact on failure for triage.

Updates `release.yml` so the alpha-cut job (`update-latest-alpha`) verifies the most recent real-E2E run on the `main` branch was green within the last 24 h before updating the rolling `latest-alpha` pointer. This closes the test-surface gap that forced framework-level PRs (Tauri bumps, watcher changes) into the manual-review bucket.

## Red tests added

- `src/lib/__tests__/real-e2e-ci.test.ts::has a push trigger on the main branch` — test.yml must fire on push to main
- `src/lib/__tests__/real-e2e-ci.test.ts::has a real-e2e-tests job` — job must exist in test.yml
- `src/lib/__tests__/real-e2e-ci.test.ts::runs on macos-latest` — real Tauri E2E requires macOS
- `src/lib/__tests__/real-e2e-ci.test.ts::is excluded from pull_request events via an if condition` — cost gate
- `src/lib/__tests__/real-e2e-ci.test.ts::has an actions/cache step keyed on tauri-driver` — cache tauri-driver binary
- `src/lib/__tests__/real-e2e-ci.test.ts::installs tauri-driver via cargo install` — install when cache miss
- `src/lib/__tests__/real-e2e-ci.test.ts::runs pnpm test:e2e-real-full` — runs the orchestrator script
- `src/lib/__tests__/real-e2e-ci.test.ts::uploads logs or report artifact on failure` — triage artifact on failure
- `src/lib/__tests__/real-e2e-ci.test.ts::has a step that verifies the real-E2E run on main within 24h` — alpha-cut gate

## Green implementation

- `.github/workflows/test.yml` — added `push: branches: [main]` trigger; added `real-e2e-tests` job with `if: github.event_name != 'pull_request'`, Rust toolchain, `actions/cache` for tauri-driver, `cargo install tauri-driver`, sidecar placeholder, `pnpm test:e2e-real-full`, and log upload on failure
- `.github/workflows/release.yml` — added "Verify real-E2E passed on main within 24h" `github-script` step as the first step of `update-latest-alpha`; checks the GitHub API for a successful `Real Tauri E2E Tests` job in the last 10 completed `test.yml` runs on `main` within the past 24 h; fails with actionable message if not found
- `src/lib/__tests__/real-e2e-ci.test.ts` — new regression-lock test file (9 new behavior tests)

## Refactor

Skipped — implementation is already minimal; each step has a single responsibility.

## Decisions made

- **PR trigger deferred** | Not added | Per the proposed answers from aw-slice: "Deferred — not part of acceptance criteria." On-push-to-main and release-tag (via workflow_call) are sufficient to close the test-surface gap.
- **Job location** | `test.yml` (not a new file) | Per aw-slice proposed answer: "New job goes into the existing `test.yml` so the alpha-cut gate can reference it by job name without cross-workflow orchestration."
- **tauri-driver cache key** | `runner.os + hashFiles('**/Cargo.lock')` | Invalidates on Rust dependency changes, which is the most likely source of tauri-driver version changes. Mirrors the `Swatinem/rust-cache` approach already in the repo.
- **Alpha-cut gate strategy** | Check last 24h via GitHub API, fail with message if not green | Per aw-slice proposed answer. Re-triggering the workflow automatically adds significant complexity; the actionable failure message tells the operator exactly what to do (re-run Tests on main manually). The 24h window is wide enough to not require rerunning just because you merged a few hours ago.
- **Log artifact path** | `/tmp/notesage-e2e-tauri.log` and `/tmp/notesage-e2e-driver.log` | These are the paths `scripts/run-real-e2e.sh` writes to. The `wdio` spec reporter outputs to stdout, which GitHub Actions captures natively; no dedicated wdio report directory exists.

## Verification

- [x] Red tests were red before implementation
- [x] All red tests now green
- [x] `pnpm test` passes (281 files, 5105 tests)
- [x] `pnpm typecheck` clean
- [x] No unrelated files modified (only `.github/workflows/test.yml`, `.github/workflows/release.yml`, `src/lib/__tests__/real-e2e-ci.test.ts`)

## Notes for reviewer

- The `real-e2e-tests` job is currently excluded from `pull_request` events. If you want it on PRs too (accepting the cost), remove the `if:` condition from the job.
- The alpha-cut gate checks the last 10 completed workflow runs on `main` within 24h. If you cut alphas faster than every 24h without a new main merge, the gate will fail — increase the window or remove the time constraint.
- The real-E2E job will also run as part of the release workflow (via `workflow_call`) for every release tag, so stable releases also gate on the real-app suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the `aw-tdd` skill.