### PR TITLE
fix(editor): anchor image hover toolbar to image's own corner, not page edge

### DIFF
--- a/src/components/editor/extensions/__tests__/local-image-hover.test.ts
+++ b/src/components/editor/extensions/__tests__/local-image-hover.test.ts
@@ -221,4 +221,48 @@ describe('LocalImage NodeView — hover toolbar', () => {
     const btn50 = dom.querySelector<HTMLElement>('[data-width="50"]')!;
     expect(btn50.classList.contains('active')).toBe(true);
   });
+
+  // --- Toolbar positioning: relative to image, not to the full-width wrapper (#258) ---
+
+  it('toolbar position is relative to the image container, not the full-width wrapper', () => {
+    // Bug: the outer wrapper uses display:block which stretches to full content-column
+    // width. The absolutely-positioned toolbar's right:8px then measures from the
+    // far-right edge of the page, not from the image's right edge.
+    //
+    // Fix: the toolbar must be a child of a `position: relative` container that
+    // wraps ONLY the image (e.g. display:inline-block), so right:8px measures
+    // from the image's right edge regardless of the image's width preset.
+    const { dom } = buildNodeView(mockImageNode({ blockWidth: 25 }));
+    const toolbar = dom.querySelector<HTMLElement>('[data-testid="image-block-size-toolbar"]')!;
+
+    // Walk up from toolbar to find its nearest `position: relative` ancestor.
+    let relativeAncestor: HTMLElement | null = toolbar.parentElement;
+    while (relativeAncestor && relativeAncestor !== dom.parentElement) {
+      if (window.getComputedStyle(relativeAncestor).position === 'relative' ||
+          relativeAncestor.style.position === 'relative') break;
+      relativeAncestor = relativeAncestor.parentElement;
+    }
+
+    // The positioning context must NOT be the outer block wrapper (dom itself),
+    // because that element spans the full content column regardless of blockWidth.
+    // It must be a shrink-wrapped inner container (e.g. display:inline-block).
+    expect(relativeAncestor).not.toBeNull();
+    expect(relativeAncestor).not.toBe(dom);
+
+    // The inner container must use a layout that shrinks to the image's own width
+    // (inline-block, fit-content, or equivalent) — NOT a full-width block.
+    const display = relativeAncestor!.style.display;
+    const width = relativeAncestor!.style.width;
+    const isShrinkWrapped =
+      display === 'inline-block' ||
+      width === 'fit-content' ||
+      width === '-moz-fit-content' ||
+      display === 'inline-flex' ||
+      display === 'inline-grid';
+    expect(
+      isShrinkWrapped,
+      `Expected toolbar's positioning context to shrink-wrap the image (got display="${display}", width="${width}"). ` +
+      `A full-width display:block wrapper causes the toolbar to float to the page's right edge for partial-width images.`,
+    ).toBe(true);
+  });
 });

--- a/src/components/editor/extensions/local-image.ts
+++ b/src/components/editor/extensions/local-image.ts
@@ -126,11 +126,26 @@ export const LocalImage = Image.extend({
       // that it fires in production WebKit/Tauri builds. An earlier attempt
       // used an editor-level mouseover plugin which fired in JSDOM/dev but
       // not in production (event-listener target divergence).
+      //
+      // Two-layer structure (fixes toolbar positioning for partial-width images, #258):
+      //   wrapper (display: block) — ProseMirror block-node container, full column width.
+      //     Alignment (left / center / right) is applied via text-align here so that
+      //     the inline-block inner container is positioned within the column correctly.
+      //   inner (display: inline-block, position: relative) — shrink-wraps to the image's
+      //     own width, so the absolutely-positioned toolbar's right:8px measures from the
+      //     image's right edge, not the far-right edge of the page.
       let currentNode = node;
 
       const wrapper = document.createElement("div");
       wrapper.className = "image-block-wrapper";
-      wrapper.style.cssText = "position: relative; display: block; line-height: 0;";
+      // display:block keeps ProseMirror happy (block-level node in the doc model).
+      // line-height:0 prevents the inline-baseline gap below the inner container.
+      wrapper.style.cssText = "display: block; line-height: 0;";
+
+      // The inner container shrink-wraps the image so the absolutely-positioned
+      // toolbar anchors to the image's corner, not the full-column wrapper.
+      const inner = document.createElement("div");
+      inner.style.cssText = "display: inline-block; position: relative; line-height: 0;";
 
       const img = document.createElement("img");
       img.className = "rounded-lg max-w-full block";
@@ -239,8 +254,9 @@ export const LocalImage = Image.extend({
         toolbar.appendChild(btn);
       }
 
-      wrapper.appendChild(img);
-      wrapper.appendChild(toolbar);
+      inner.appendChild(img);
+      inner.appendChild(toolbar);
+      wrapper.appendChild(inner);
 
       // Direct DOM listeners — not a plugin-level listener so they fire in
       // production WebKit builds where delegated editor events may not reach
@@ -265,23 +281,21 @@ export const LocalImage = Image.extend({
         if (blockWidth != null) {
           img.style.width = `${blockWidth}%`;
           img.style.height = "auto";
+          // Alignment is expressed as text-align on the outer wrapper so the
+          // inline-block inner container (which shrink-wraps the image) is
+          // positioned within the column correctly. The img itself stays as a
+          // block inside the inner container.
           if (align === "center") {
-            img.style.marginLeft = "auto";
-            img.style.marginRight = "auto";
-            img.style.display = "block";
+            wrapper.style.textAlign = "center";
           } else if (align === "right") {
-            img.style.marginLeft = "auto";
-            img.style.marginRight = "0";
-            img.style.display = "block";
+            wrapper.style.textAlign = "right";
           } else {
-            img.style.marginLeft = "0";
-            img.style.marginRight = "auto";
-            img.style.display = "block";
+            wrapper.style.textAlign = "left";
           }
         } else {
           img.style.removeProperty("width");
-          img.style.removeProperty("margin-left");
-          img.style.removeProperty("margin-right");
+          img.style.removeProperty("height");
+          wrapper.style.removeProperty("text-align");
         }
 
         // Update active state on width buttons


### PR DESCRIPTION
Fixes #258

## Summary

The image hover toolbar was positioned relative to the full-width `display: block` wrapper div, causing it to float to the far-right edge of the content column instead of the bottom-right corner of the image. This made the toolbar visually disconnected from the image for any width preset below 100%.

The fix introduces a two-layer DOM structure: the outer wrapper stays `display: block` (ProseMirror block-node model compatibility), while a new inner container uses `display: inline-block; position: relative` to shrink-wrap the image. The toolbar's `right: 8px` now measures from the image's right edge at every width preset (25/50/75/100%) and every alignment (left/center/right).

## Red tests added

- `src/components/editor/extensions/__tests__/local-image-hover.test.ts::toolbar position is relative to the image container, not the full-width wrapper` — asserts that the toolbar's nearest `position: relative` ancestor is a shrink-wrapped `inline-block` container, not the full-width outer `block` wrapper; fails with the old `display: block` wrapper and passes after the fix.

## Green implementation

- `src/components/editor/extensions/local-image.ts` — Added inner `<div display:inline-block; position:relative>` container that wraps the `<img>` and toolbar. Outer wrapper keeps `display: block` for ProseMirror. Alignment (left/center/right) now expressed as `text-align` on the outer wrapper so the inline-block inner container is positioned within the column correctly.
- `src/components/editor/extensions/__tests__/local-image-hover.test.ts` — Added regression test verifying the shrink-wrapped inner container is the toolbar's positioning context.

## Refactor

Skipped — the two-layer structure is the minimal implementation.

## Decisions made

- **`display: inline-block` vs `width: fit-content`** — Used `display: inline-block` for the inner container because it works across all browsers (including older WebKit) without a separate `width: fit-content` declaration. The outer wrapper alignment was changed from `margin-left/margin-right` on the `img` to `text-align` on the wrapper, which correctly positions an inline-block child.
- **Branch base: `claude/bug-219-image-hover-toolbar`** — This fix builds on the hover toolbar code from PR #222 (issue #219). The current `main` branch does not have the toolbar code yet, so the fix must be layered on top of that PR's branch. When PR #222 merges, this PR can be rebased onto `main`.

## Verification

- [x] Red tests were red before implementation
- [x] All red tests now green
- [x] `pnpm test` passes (full suite — 5107 tests across 281 files)
- [x] `pnpm typecheck` clean
- [x] No unrelated files modified

## Notes for reviewer

- This PR is based on `claude/bug-219-image-hover-toolbar` (PR #222), not `main`. It should be rebased onto `main` after PR #222 merges.
- The `text-align` approach for alignment works because the outer wrapper is a block element with a known width (full content column), and `text-align: center/right` aligns inline/inline-block children within it. This is a standard CSS centering technique that avoids the `margin: auto` pattern which doesn't work when the container shrinks to the child's width.
- The `line-height: 0` on both the outer and inner containers prevents the inline-baseline gap (a 3–5px gap that appears below inline-block elements due to the default text baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the `aw-tdd` skill.