### PR TITLE
chore(release): generate release notes from docs/history/, not git log

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,18 +46,23 @@ jobs:
       - name: Generate release notes
         id: release_notes
         run: |
-          # Find previous tag
-          PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
-          if [ -z "$PREV_TAG" ]; then
-            COMMITS=$(git log --oneline --pretty="format:- %s" HEAD)
-          else
-            COMMITS=$(git log --oneline --pretty="format:- %s" "${PREV_TAG}..HEAD")
+          VERSION=${{ steps.get_version.outputs.VERSION }}
+          HISTORY_FILE=$(ls docs/history/*-release-v${VERSION}.md 2>/dev/null | head -1)
+
+          if [ -z "$HISTORY_FILE" ]; then
+            echo "::error::No history file found at docs/history/*-release-v${VERSION}.md — release notes required before tag."
+            exit 1
           fi
 
-          # Write to file for multi-line output
-          echo "## Changes" > /tmp/release_notes.md
-          echo "" >> /tmp/release_notes.md
-          echo "$COMMITS" >> /tmp/release_notes.md
+          # Extract user-facing content: everything between "## Changes" and
+          # "## Under the hood" (or end of file). The stop condition fires ONLY
+          # on "## Under the hood" — sections like "## Known issues" and
+          # "## Known limitations" are user-facing and must be included.
+          awk '
+            /^## Changes/{found=1; next}
+            found && /^## Under the hood/{exit}
+            found{print}
+          ' "$HISTORY_FILE" > /tmp/release_notes.md
 
           # Set as output using delimiter
           echo "notes<<NOTES_EOF" >> $GITHUB_OUTPUT

--- a/src/lib/__tests__/release-workflow-history-notes.test.ts
+++ b/src/lib/__tests__/release-workflow-history-notes.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Regression-lock tests for release.yml — history-file release notes (#268).
+ *
+ * The release workflow must generate release notes from docs/history/ files,
+ * not from a git log commit dump. This set of tests locks in the correct
+ * behaviour to prevent regression.
+ *
+ * Key constraints:
+ *   - "Generate release notes" step reads docs/history/*-release-v{tag}.md
+ *   - No git log or commit-dump fallback
+ *   - awk stop pattern stops ONLY at "## Under the hood" — NOT at
+ *     "## Known issues" / "## Known limitations" (those are user-facing)
+ *   - Hard-fails with required error message when no history file found
+ *   - tauri-action step receives releaseBody from the release_notes output
+ *
+ * @vitest-environment node
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { parse as parseYaml } from 'yaml';
+
+interface Step {
+  name?: string;
+  id?: string;
+  uses?: string;
+  run?: string;
+  with?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+interface Job {
+  steps?: Step[];
+  outputs?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+interface Workflow {
+  jobs: Record<string, Job>;
+}
+
+const RELEASE_YML_PATH = resolve(__dirname, '../../../.github/workflows/release.yml');
+const RELEASE_YML = readFileSync(RELEASE_YML_PATH, 'utf-8');
+
+function loadReleaseWorkflow(): Workflow {
+  return parseYaml(RELEASE_YML) as Workflow;
+}
+
+function findStepByName(workflow: Workflow, stepName: string): Step | undefined {
+  for (const job of Object.values(workflow.jobs)) {
+    for (const step of job.steps ?? []) {
+      if (step.name === stepName) return step;
+    }
+  }
+  return undefined;
+}
+
+function findTauriActionStep(workflow: Workflow): Step | undefined {
+  for (const job of Object.values(workflow.jobs)) {
+    for (const step of job.steps ?? []) {
+      if (typeof step.uses === 'string' && step.uses.includes('tauri-apps/tauri-action')) {
+        return step;
+      }
+    }
+  }
+  return undefined;
+}
+
+describe('release.yml — history-file release notes (#268)', () => {
+  const wf = loadReleaseWorkflow();
+
+  describe('"Generate release notes" step reads from docs/history/, not git log', () => {
+    const step = findStepByName(wf, 'Generate release notes');
+
+    it('step exists in the workflow', () => {
+      expect(step).toBeDefined();
+    });
+
+    it('does not use git log to generate release notes', () => {
+      expect(step?.run).not.toMatch(/git\s+log/);
+    });
+
+    it('does not use git describe to find the previous tag', () => {
+      expect(step?.run).not.toMatch(/git\s+describe/);
+    });
+
+    it('does not reference PREV_TAG (commit-dump fallback variable)', () => {
+      expect(step?.run).not.toMatch(/PREV_TAG/);
+    });
+
+    it('reads from docs/history/ directory', () => {
+      expect(step?.run).toMatch(/docs\/history\//);
+    });
+
+    it('matches docs/history/*-release-v{tag}.md pattern', () => {
+      expect(step?.run).toMatch(/release-v/);
+    });
+  });
+
+  describe('awk stop pattern stops only at "## Under the hood"', () => {
+    const step = findStepByName(wf, 'Generate release notes');
+
+    it('does NOT include "Known issues" in the awk stop pattern', () => {
+      // "## Known issues" is a user-facing section that must be included
+      // in the extracted release notes, not treated as a stop boundary.
+      const awkStopPattern = extractAwkStopPattern(step?.run ?? '');
+      expect(awkStopPattern).not.toMatch(/Known issues/);
+    });
+
+    it('does NOT include "Known limitations" in the awk stop pattern', () => {
+      // "## Known limitations" is also user-facing and must be included.
+      const awkStopPattern = extractAwkStopPattern(step?.run ?? '');
+      expect(awkStopPattern).not.toMatch(/Known limitations/);
+    });
+
+    it('stop pattern fires on "## Under the hood"', () => {
+      expect(step?.run).toMatch(/Under the hood/);
+    });
+  });
+
+  describe('hard-fail when no matching history file found', () => {
+    const step = findStepByName(wf, 'Generate release notes');
+
+    it('exits with non-zero status when no history file is found', () => {
+      expect(step?.run).toMatch(/exit 1/);
+    });
+
+    it('prints the required error message when no history file is found', () => {
+      expect(step?.run).toMatch(/No history file found/);
+      expect(step?.run).toMatch(/docs\/history\/\*-release-v/);
+    });
+  });
+
+  describe('GitHub release body and latest.json notes receive history-file content', () => {
+    it('create-release job exposes release_notes as a job output', () => {
+      const createReleaseJob = wf.jobs['create-release'];
+      expect(createReleaseJob?.outputs).toBeDefined();
+      const outputs = createReleaseJob?.outputs ?? {};
+      const hasReleaseNotes = Object.values(outputs).some(
+        v => typeof v === 'string' && v.includes('release_notes')
+      );
+      expect(hasReleaseNotes).toBe(true);
+    });
+
+    it('tauri-action step passes releaseBody derived from the release_notes output', () => {
+      const tauriStep = findTauriActionStep(wf);
+      expect(tauriStep).toBeDefined();
+      const releaseBody = tauriStep?.with?.releaseBody;
+      expect(releaseBody).toBeDefined();
+      expect(String(releaseBody ?? '')).toMatch(/release_notes/);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract all awk patterns that act as stop conditions in the step's run script.
+ * Looks for lines matching `found && /pattern/{exit}` style patterns.
+ */
+function extractAwkStopPattern(runScript: string): string {
+  // Match the awk command block if present
+  const awkMatch = runScript.match(/awk\s+['"]([^'"]+)['"]/s);
+  if (awkMatch) return awkMatch[1];
+
+  // Also check for heredoc-style awk
+  const heredocMatch = runScript.match(/awk\s+'([^']+)'/s);
+  if (heredocMatch) return heredocMatch[1];
+
+  // Return the whole script so the test can inspect it
+  return runScript;
+}


### PR DESCRIPTION
Resolves #268

## Summary

Replaces the \`git log\` commit-dump fallback in the release workflow's \"Generate release notes\" step with an awk extraction from \`docs/history/*-release-v{tag}.md\`. The extracted content is passed to both the GitHub release body and the \`tauri-action\` \`releaseBody\` field (for \`latest.json\`).

Key fix vs PR #269: the awk stop condition fires **only** on \`## Under the hood\`, not on \`## Known issues\` / \`## Known limitations\`. Those are user-facing sections that must be included in the release notes.

## Red tests added

- \`release-workflow-history-notes.test.ts::does not use git log to generate release notes\` — confirms no git log invocation
- \`release-workflow-history-notes.test.ts::does not use git describe to find the previous tag\` — confirms no git describe fallback
- \`release-workflow-history-notes.test.ts::does not reference PREV_TAG (commit-dump fallback variable)\` — confirms no PREV_TAG variable
- \`release-workflow-history-notes.test.ts::reads from docs/history/ directory\` — confirms docs/history/ is read
- \`release-workflow-history-notes.test.ts::matches docs/history/*-release-v{tag}.md pattern\` — confirms correct file pattern
- \`release-workflow-history-notes.test.ts::does NOT include "Known issues" in the awk stop pattern\` — confirms Known issues is NOT a stop boundary
- \`release-workflow-history-notes.test.ts::does NOT include "Known limitations" in the awk stop pattern\` — confirms Known limitations is NOT a stop boundary
- \`release-workflow-history-notes.test.ts::stop pattern fires on "## Under the hood"\` — confirms correct stop boundary
- \`release-workflow-history-notes.test.ts::exits with non-zero status when no history file is found\` — confirms hard-fail
- \`release-workflow-history-notes.test.ts::prints the required error message when no history file is found\` — confirms required error text
- \`release-workflow-history-notes.test.ts::create-release job exposes release_notes as a job output\` — confirms job output wiring
- \`release-workflow-history-notes.test.ts::tauri-action step passes releaseBody derived from the release_notes output\` — confirms latest.json notes wiring
- \`release-workflow-history-notes.test.ts::step exists in the workflow\` — baseline existence check

## Green implementation

- \`.github/workflows/release.yml\`: replaced the \`PREV_TAG\` + \`git log\` block with an awk extraction from \`docs/history/*-release-v\${VERSION}.md\`. Stop condition only fires on \`/^## Under the hood/\`. Hard-fails with \`exit 1\` + \`::error::\` annotation when no matching file exists.
- \`src/lib/__tests__/release-workflow-history-notes.test.ts\`: new test file locking in the correct behaviour.

## Refactor

Skipped — implementation is already minimal (18 lines replacing 16).

## Decisions made

- **Stop boundary is ONLY \`## Under the hood\`** | Chosen: `found && /^## Under the hood/{exit}` | The spec says "everything between \`## Changes\` and \`## Under the hood\`, or end of file". \`## Known issues\` and \`## Known limitations\` fall inside that range. PR #269 used \`/^## (Under the hood|Known issues|Known limitations)/\` which incorrectly truncated all four recent release files.
- **No fallback when history file missing** | Chosen: hard-fail with \`exit 1\` | The spec says "Hard-fail the workflow when no matching history file is found." No soft fallback.

## Verification

- [x] Red tests were red before implementation (8 tests failed against the old git-log step)
- [x] All red tests now green (13/13 pass)
- [x] \`pnpm test\` passes (full suite: 5134 tests across 284 files)
- [x] \`pnpm typecheck\` clean
- [x] No unrelated files modified (only \`.github/workflows/release.yml\` and the new test file)

## Notes for reviewer

The 5 tests that were already green before implementation are:
- \`step exists in the workflow\` — the step existed before (with wrong content)
- \`does NOT include Known issues/limitations in the stop pattern\` — no awk existed yet, so no stop pattern existed, so these trivially passed
- \`create-release job exposes release_notes as a job output\` — already wired before
- \`tauri-action step passes releaseBody\` — already wired before (PR #203 fix)

The 8 tests that were red covered: git-log removal, docs/history/ reading, correct awk stop pattern, and hard-fail behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the \`aw-tdd\` skill.