### PR TITLE
fix(release): patch latest.json URLs to be tag-specific before publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,6 +264,63 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # tauri-action@v0 generates latest.json with `releases/latest/download/`
+      # URLs when tagName is omitted. For prereleases, `releases/latest` resolves
+      # to the most recent *stable* release — not the prerelease — so alpha users
+      # "update" to a stale stable build, restart, see the prerelease still
+      # advertised, and loop forever (issue #271). tagName cannot be restored to
+      # tauri-action because passing it alongside releaseId triggers a second
+      # createRelease call (orphan-draft issue #203). Fix: patch latest.json to
+      # use tag-specific `releases/download/{tag}/` URLs before publishing.
+      - name: Patch latest.json to use tag-specific asset URLs
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          RELEASE_ID="${{ needs.create-release.outputs.release_id }}"
+
+          # Find the latest.json asset in the draft release
+          ASSET_JSON=$(gh api "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}/assets" \
+            --jq '.[] | select(.name == "latest.json") | {id: .id, url: .url}')
+
+          if [ -z "${ASSET_JSON}" ]; then
+            echo "::warning::latest.json not found in release assets — skipping patch"
+            exit 0
+          fi
+
+          ASSET_ID=$(echo "${ASSET_JSON}" | jq -r '.id')
+          ASSET_API_URL=$(echo "${ASSET_JSON}" | jq -r '.url')
+
+          # Download latest.json raw content via the API
+          curl -fsSL \
+            -H "Accept: application/octet-stream" \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            "${ASSET_API_URL}" \
+            -o /tmp/latest.json
+
+          # Skip if the URL is already tag-specific (idempotent)
+          if ! grep -q "releases/latest/download/" /tmp/latest.json; then
+            echo "✓ latest.json already has tag-specific URLs — no patch needed"
+            exit 0
+          fi
+
+          echo "Patching releases/latest/download/ → releases/download/${TAG}/ in latest.json"
+
+          # Patch: releases/latest/download/ → releases/download/{tag}/
+          sed "s|releases/latest/download/|releases/download/${TAG}/|g" \
+            /tmp/latest.json > /tmp/latest.json.tmp && mv /tmp/latest.json.tmp /tmp/latest.json
+
+          echo "Patched latest.json:"
+          cat /tmp/latest.json
+
+          # Delete the old asset and re-upload the patched version
+          gh api -X DELETE "repos/${GITHUB_REPOSITORY}/releases/assets/${ASSET_ID}"
+          gh release upload "${TAG}" /tmp/latest.json \
+            --repo "${GITHUB_REPOSITORY}" \
+            --clobber
+
+          echo "✓ Patched latest.json: releases/latest/download/ → releases/download/${TAG}/"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Publish Release
         uses: actions/github-script@v7
         with:
@@ -274,6 +331,36 @@ jobs:
               release_id: ${{ needs.create-release.outputs.release_id }},
               draft: false
             })
+
+      # Regression guard: fail the workflow run if latest.json still contains
+      # releases/latest/download/ after patching + publishing. This catches any
+      # future regression before alpha users receive an update.
+      - name: Verify latest.json has tag-specific URLs
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+
+          # Download latest.json from the now-published release
+          mkdir -p /tmp/verify
+          gh release download "${TAG}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --pattern "latest.json" \
+            --dir /tmp/verify 2>/dev/null || {
+            echo "::warning::Could not download latest.json from published release — skipping verification"
+            exit 0
+          }
+
+          echo "Verifying latest.json content:"
+          cat /tmp/verify/latest.json
+
+          # Fail if the wrong URL pattern is still present
+          if grep -q "releases/latest/download/" /tmp/verify/latest.json; then
+            echo "::error::latest.json contains releases/latest/download/ — infinite update loop risk! (issue #271)"
+            exit 1
+          fi
+
+          echo "✓ latest.json verified: no releases/latest/download/ URLs found"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # Rolling pointer for the in-app alpha-channel auto-updater. The app
   # (`src/hooks/useAutoUpdate.ts`) hits a static URL for the alpha channel:

--- a/src/lib/__tests__/release-workflow-url.test.ts
+++ b/src/lib/__tests__/release-workflow-url.test.ts
@@ -1,0 +1,107 @@
+// Regression-lock for the latest.json URL fix in release.yml (#271).
+//
+// Root cause: tauri-action@v0 generates latest.json with
+//   `releases/latest/download/...` URLs when tagName is omitted.
+// For prereleases, `releases/latest` resolves to the most recent *stable*
+// release — not the prerelease — so installed alpha builds "update" to a
+// stale stable build, restart, see the prerelease still advertised, and loop.
+//
+// The existing orphan-draft regression lock (release-workflow.test.ts) prevents
+// restoring tagName to tauri-action (passing tagName alongside releaseId causes
+// tauri-action to attempt a second createRelease call, producing an
+// already_exists error or orphan draft). So the fix is to post-process
+// latest.json in the publish-release job: patch the URL before publication,
+// then verify after publication.
+//
+// These tests assert the publish-release job contains those two steps.
+// They catch drift at PR-review time rather than at production-incident time.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { parse as parseYaml } from 'yaml';
+
+interface Step {
+  name?: string;
+  uses?: string;
+  with?: Record<string, unknown>;
+  run?: string;
+  [key: string]: unknown;
+}
+
+interface Job {
+  steps?: Step[];
+  [key: string]: unknown;
+}
+
+interface Workflow {
+  jobs: Record<string, Job>;
+}
+
+function loadReleaseWorkflow(): Workflow {
+  const path = resolve(__dirname, '../../../.github/workflows/release.yml');
+  return parseYaml(readFileSync(path, 'utf-8')) as Workflow;
+}
+
+/** Return all text content of a step — either run script or github-script body. */
+function stepText(step: Step): string {
+  const script = step.with?.script;
+  return (step.run ?? (typeof script === 'string' ? script : '')) as string;
+}
+
+describe('release.yml — latest.json URL patch (#271 — no infinite update loop)', () => {
+  const wf = loadReleaseWorkflow();
+  const job = wf.jobs['publish-release']!;
+
+  const getPublishIdx = () => job.steps!.findIndex((s) => s.name === 'Publish Release');
+  const preSteps = () => job.steps!.slice(0, getPublishIdx());
+  const postSteps = () => job.steps!.slice(getPublishIdx() + 1);
+
+  it('"Publish Release" step exists in the publish-release job', () => {
+    expect(getPublishIdx()).toBeGreaterThanOrEqual(0);
+  });
+
+  it('publish-release has a step BEFORE "Publish Release" that patches latest.json URLs', () => {
+    // The step must contain logic that handles both the wrong URL pattern
+    // (releases/latest/download/) and the correct URL pattern (releases/download/)
+    const patchStep = preSteps().find((s) => {
+      const text = stepText(s);
+      return text.includes('latest.json') && text.includes('releases/latest/download/');
+    });
+    expect(
+      patchStep,
+      'Expected a step before "Publish Release" to patch latest.json — tauri-action generates ' +
+        'releases/latest/download/ URLs for prereleases, which causes the infinite update loop ' +
+        'described in issue #271. Add a patch step that replaces them with releases/download/{tag}/',
+    ).toBeDefined();
+  });
+
+  it('the pre-publish patch step replaces releases/latest/download/ with releases/download/{tag}/', () => {
+    const patchStep = preSteps().find((s) => {
+      const text = stepText(s);
+      return text.includes('releases/latest/download/') && text.includes('releases/download/');
+    });
+    expect(
+      patchStep,
+      'The patch step must replace the wrong URL pattern with a tag-specific one. ' +
+        'Expected both "releases/latest/download/" (the wrong pattern to find) and ' +
+        '"releases/download/" (the correct pattern to substitute) in the step script.',
+    ).toBeDefined();
+  });
+
+  it('publish-release has a step AFTER "Publish Release" that fails if releases/latest/download/ is in latest.json', () => {
+    const verifyStep = postSteps().find((s) => {
+      const text = stepText(s);
+      return (
+        text.includes('releases/latest/download/') &&
+        (text.includes('exit 1') || text.includes('setFailed') || text.includes('::error::'))
+      );
+    });
+    expect(
+      verifyStep,
+      'Expected a verification step after "Publish Release" that downloads latest.json and ' +
+        'fails the workflow if it contains releases/latest/download/ URLs. ' +
+        'This is the regression guard that catches the issue before users receive an update.',
+    ).toBeDefined();
+  });
+});


### PR DESCRIPTION
Fixes #271

## Summary

`tauri-action@v0` generates `latest.json` with `releases/latest/download/` URLs when `tagName` is omitted from the step. For prereleases, `releases/latest` resolves to the most recent *stable* release — not the prerelease — so installed alpha builds "update" to a stale stable build, restart, see the prerelease still advertised, and loop forever. This was hit in production twice (v0.44.0-alpha.3 and v0.45.0-alpha.0), each requiring a manual manifest patch.

`tagName` cannot be restored to the `tauri-action` step because passing it alongside `releaseId` triggers a second `createRelease` call, producing the orphan-draft issue (#203) that is regression-locked by `release-workflow.test.ts`. The fix is to post-process `latest.json` in the `publish-release` job.

## Red tests added

- `src/lib/__tests__/release-workflow-url.test.ts::publish-release has a step BEFORE "Publish Release" that patches latest.json URLs` — verifies the patch step exists before publishing
- `src/lib/__tests__/release-workflow-url.test.ts::the pre-publish patch step replaces releases/latest/download/ with releases/download/{tag}/` — verifies the replacement pattern is correct
- `src/lib/__tests__/release-workflow-url.test.ts::publish-release has a step AFTER "Publish Release" that fails if releases/latest/download/ is in latest.json` — verifies the regression guard step exists

## Green implementation

- `.github/workflows/release.yml` — Added two new steps to `publish-release`:
  1. **"Patch latest.json to use tag-specific asset URLs"** (before "Publish Release"): downloads `latest.json` from the draft release via `gh api`, replaces `releases/latest/download/` with `releases/download/${GITHUB_REF_NAME}/` using `sed`, deletes the old asset, and re-uploads the patched version. Idempotent — skips if the URL is already correct.
  2. **"Verify latest.json has tag-specific URLs"** (after "Publish Release"): downloads `latest.json` from the published release and fails the job (`exit 1`) if `releases/latest/download/` is still present.

## Refactor

Skipped — implementation already minimal.

## Decisions made

- **Approach: post-process rather than restore `tagName`** — The existing `release-workflow.test.ts` regression lock explicitly asserts `tagName` must NOT be on the `tauri-action` step (because it would trigger a second `createRelease` call). Post-processing `latest.json` is the only approach that fixes the URL without violating that constraint.
- **Idempotency guard in patch step** — Added `if ! grep -q "releases/latest/download/"` check so the step is a no-op for stable releases or any future tauri-action version that might fix the URL itself.
- **Placement in `publish-release`** — Patching before publication ensures `update-latest-alpha` (which downloads the published assets) also gets the correct `latest.json` for the rolling `latest-alpha` release. No changes to `update-latest-alpha` needed.
- **`GH_TOKEN` for shell steps** — The `publish-release` job already had `contents: write` at the workflow level; the new steps explicitly pass `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` to the `gh` CLI calls.

## Verification

- [x] Red tests were red before implementation
- [x] All red tests now green
- [x] `pnpm test` passes (full suite: 285 test files, 5135 tests)
- [x] `pnpm typecheck` clean
- [x] No unrelated files modified (only `.github/workflows/release.yml` + new test file)

## Notes for reviewer

- The `update-latest-alpha` job is unchanged (acceptance criteria). It downloads all assets from the published release including the now-patched `latest.json`.
- The verify step is intentionally lenient: it warns (instead of failing) if `latest.json` cannot be downloaded — this handles edge cases where the release publish takes a moment to be visible via `gh release download`. This avoids false CI failures on network latency.
- The orphan-draft regression test (`release-workflow.test.ts::tauri-action step does NOT pass tagName`) still passes — `tagName` is not added to the `tauri-action` step.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the `aw-tdd` skill.