### PR TITLE
feat(ci): add post-merge real-app performance tracking job (#286)

### DIFF
--- a/.github/workflows/test-perf-e2e.yml
+++ b/.github/workflows/test-perf-e2e.yml
@@ -1,0 +1,122 @@
+name: Real-App Performance Tracking (post-merge)
+
+# Runs only on push to main — NOT on pull_request events.
+# A failure here does not block PR merges; this job is for trend tracking only.
+on:
+  push:
+    branches: [main]
+
+jobs:
+  perf-e2e:
+    name: Real-App Performance E2E
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Set whisper.cpp build flags
+        run: |
+          echo "CMAKE_C_FLAGS=-march=armv8.2-a+dotprod+fp16" >> $GITHUB_ENV
+          echo "CMAKE_CXX_FLAGS=-march=armv8.2-a+dotprod+fp16" >> $GITHUB_ENV
+
+      - name: Create sidecar placeholder
+        run: |
+          mkdir -p src-tauri/binaries/lib
+          touch src-tauri/binaries/llama-server-aarch64-apple-darwin
+          chmod +x src-tauri/binaries/llama-server-aarch64-apple-darwin
+
+      - name: Install frontend dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Cache tauri-webdriver binary
+        id: cache-tauri-webdriver
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/tauri-webdriver
+          key: ${{ runner.os }}-tauri-webdriver-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install tauri-webdriver
+        if: steps.cache-tauri-webdriver.outputs.cache-hit != 'true'
+        run: cargo install tauri-webdriver
+
+      - name: Run performance E2E tests
+        # continue-on-error so the artifact upload step always runs even when
+        # timing assertions fail on the slower shared CI macOS runner.
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+
+          # Start Tauri app in background
+          pnpm tauri:test > /tmp/notesage-perf-tauri.log 2>&1 &
+          TAURI_PID=$!
+          trap "kill $TAURI_PID 2>/dev/null || true; pkill -f tauri-webdriver 2>/dev/null || true" EXIT
+
+          # Wait for plugin endpoint (port 4445)
+          echo "Waiting for WebDriver plugin on port 4445..."
+          for i in $(seq 1 300); do
+            if curl -sf http://localhost:4445/status > /dev/null 2>&1; then
+              echo "WebDriver plugin ready (${i}s)"
+              break
+            fi
+            if ! kill -0 "$TAURI_PID" 2>/dev/null; then
+              echo "Tauri app exited unexpectedly"
+              tail -30 /tmp/notesage-perf-tauri.log
+              exit 1
+            fi
+            sleep 2
+          done
+
+          # Start tauri-webdriver bridge
+          tauri-webdriver > /tmp/notesage-perf-driver.log 2>&1 &
+          DRIVER_PID=$!
+
+          # Wait for tauri-webdriver (port 4444)
+          echo "Waiting for tauri-webdriver on port 4444..."
+          for i in $(seq 1 15); do
+            if curl -sf http://localhost:4444/status > /dev/null 2>&1; then
+              echo "tauri-webdriver ready (${i}s)"
+              break
+            fi
+            sleep 1
+          done
+
+          # Run only the performance spec
+          pnpm wdio run wdio.conf.ts --spec ./e2e-real/tests/performance.test.ts
+
+      - name: Upload performance results artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-e2e-results-${{ github.sha }}
+          path: perf-results.json
+          retention-days: 14
+          if-no-files-found: warn
+
+      - name: Upload Tauri and driver logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-e2e-logs-${{ github.sha }}
+          path: |
+            /tmp/notesage-perf-tauri.log
+            /tmp/notesage-perf-driver.log
+          retention-days: 14

--- a/e2e-real/tests/performance.test.ts
+++ b/e2e-real/tests/performance.test.ts
@@ -10,12 +10,17 @@
  *   Terminal 3: pnpm test:e2e-real
  */
 
+import * as fs from 'fs';
 import * as path from 'path';
 import { waitForElement, openFile, getEditorText } from '../helpers/actions';
 import { measureAction } from '../helpers/timing';
 import { ensureCleanState, ensureProjectOpen } from '../helpers/setup';
 
 const TEST_PROJECT = path.resolve(process.cwd(), 'e2e-real/fixtures/test-project');
+
+// Accumulate timing results across all tests and write to perf-results.json
+// in the after() hook so the CI workflow can upload it as a structured artifact.
+const timingResults: Record<string, number> = {};
 
 describe('Performance', function () {
     // These tests involve large documents and multiple file operations —
@@ -38,6 +43,18 @@ describe('Performance', function () {
     after(async () => {
         // Restore the default window size in case a test changed it
         await browser.setWindowSize(1200, 800);
+
+        // Write collected timing measurements to perf-results.json so the
+        // CI workflow can upload it as a structured artifact for trend tracking.
+        const output = {
+            timestamp: new Date().toISOString(),
+            commit_sha: process.env.GITHUB_SHA ?? 'local',
+            runner_name: process.env.RUNNER_NAME ?? 'local',
+            measurements: timingResults,
+        };
+        const outPath = path.resolve(process.cwd(), 'perf-results.json');
+        fs.writeFileSync(outPath, JSON.stringify(output, null, 2));
+        console.log(`[perf] Results written to perf-results.json`);
     });
 
     // -------------------------------------------------------------------
@@ -49,6 +66,7 @@ describe('Performance', function () {
         });
 
         console.log(`[perf] Large document load time: ${duration.toFixed(0)}ms`);
+        timingResults['large_doc_load_ms'] = duration;
         expect(duration).toBeLessThan(3000);
 
         // Verify some expected content actually rendered
@@ -112,6 +130,9 @@ describe('Performance', function () {
 
         console.log(`[perf] Keystroke latencies (ms): ${latencies.map((l) => l.toFixed(1)).join(', ')}`);
         console.log(`[perf] Keystroke avg: ${avg.toFixed(1)}ms, min: ${min.toFixed(1)}ms, max: ${max.toFixed(1)}ms`);
+        timingResults['keystroke_avg_ms'] = avg;
+        timingResults['keystroke_min_ms'] = min;
+        timingResults['keystroke_max_ms'] = max;
 
         expect(avg).toBeLessThan(100);
     });
@@ -221,6 +242,7 @@ describe('Performance', function () {
         });
 
         console.log(`[perf] Rapid tab switching (${files.length} tabs x 2 rounds): ${duration.toFixed(0)}ms`);
+        timingResults['tab_switching_total_ms'] = duration;
 
         // Wait for the last tab switch to settle
         await browser.pause(500);

--- a/src/lib/__tests__/perf-e2e-ci.test.ts
+++ b/src/lib/__tests__/perf-e2e-ci.test.ts
@@ -1,0 +1,152 @@
+// Regression-lock tests for the post-merge real-app performance tracking
+// CI job (issue #286).
+//
+// Verifies that:
+// 1. test-perf-e2e.yml exists and triggers ONLY on push to main — not pull_request.
+// 2. The workflow runs on macos-latest with the real Tauri build.
+// 3. The workflow uploads a timing-results artifact with at least 14 days retention.
+// 4. All specs in e2e-real/tests/performance.test.ts are un-skipped
+//    (no .skip / xdescribe / xit markers).
+//
+// A job failure in test-perf-e2e.yml must NOT block PR merges — this is guaranteed
+// structurally by the workflow having no pull_request trigger (criterion 1 above).
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { readFileSync, existsSync } from 'fs';
+import { resolve } from 'path';
+import { parse as parseYaml } from 'yaml';
+
+interface StepYaml {
+  uses?: string;
+  run?: string;
+  if?: string;
+  name?: string;
+  with?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+interface JobYaml {
+  'runs-on'?: string;
+  steps?: StepYaml[];
+  [key: string]: unknown;
+}
+
+interface OnPushYaml {
+  branches?: string[];
+}
+
+interface WorkflowOnYaml {
+  push?: OnPushYaml;
+  pull_request?: unknown;
+  [key: string]: unknown;
+}
+
+interface WorkflowYaml {
+  on: WorkflowOnYaml;
+  jobs: Record<string, JobYaml>;
+}
+
+const WORKFLOW_PATH = resolve(__dirname, '../../../.github/workflows/test-perf-e2e.yml');
+const PERF_TEST_PATH = resolve(__dirname, '../../../e2e-real/tests/performance.test.ts');
+
+describe('Post-merge perf E2E CI (#286)', () => {
+  describe('test-perf-e2e.yml — existence', () => {
+    it('the workflow file exists', () => {
+      expect(existsSync(WORKFLOW_PATH)).toBe(true);
+    });
+  });
+
+  describe('test-perf-e2e.yml — trigger configuration', () => {
+    let wf: WorkflowYaml;
+
+    beforeEach(() => {
+      wf = parseYaml(readFileSync(WORKFLOW_PATH, 'utf-8')) as WorkflowYaml;
+    });
+
+    it('triggers on push to main branch', () => {
+      const pushOn = wf.on?.push;
+      expect(pushOn).toBeDefined();
+      expect(pushOn?.branches).toContain('main');
+    });
+
+    it('does NOT have a pull_request trigger', () => {
+      // A pull_request trigger would make the job run on PRs and could
+      // block merge if timing assertions fail on the slower CI runners.
+      expect(wf.on?.pull_request).toBeUndefined();
+    });
+  });
+
+  describe('test-perf-e2e.yml — job configuration', () => {
+    let wf: WorkflowYaml;
+
+    beforeEach(() => {
+      wf = parseYaml(readFileSync(WORKFLOW_PATH, 'utf-8')) as WorkflowYaml;
+    });
+
+    it('has at least one job', () => {
+      expect(Object.keys(wf.jobs).length).toBeGreaterThan(0);
+    });
+
+    it('runs on macos-latest', () => {
+      const jobNames = Object.keys(wf.jobs);
+      const firstJob = wf.jobs[jobNames[0]];
+      expect(firstJob?.['runs-on']).toBe('macos-latest');
+    });
+
+    it('has a step that runs the performance test spec', () => {
+      const jobNames = Object.keys(wf.jobs);
+      const firstJob = wf.jobs[jobNames[0]];
+      const steps = firstJob?.steps ?? [];
+      const hasPerformanceSpec = steps.some(
+        (s) =>
+          typeof s.run === 'string' &&
+          s.run.includes('performance.test.ts'),
+      );
+      expect(hasPerformanceSpec).toBe(true);
+    });
+
+    it('uploads a timing-results artifact with at least 14 days retention', () => {
+      const jobNames = Object.keys(wf.jobs);
+      const firstJob = wf.jobs[jobNames[0]];
+      const steps = firstJob?.steps ?? [];
+      const uploadStep = steps.find(
+        (s) =>
+          typeof s.uses === 'string' &&
+          s.uses.startsWith('actions/upload-artifact'),
+      );
+      expect(uploadStep).toBeDefined();
+      const retentionDays = (uploadStep?.with?.['retention-days'] as number) ?? 0;
+      expect(retentionDays).toBeGreaterThanOrEqual(14);
+    });
+  });
+
+  describe('e2e-real/tests/performance.test.ts — no skipped specs', () => {
+    let source: string;
+
+    beforeEach(() => {
+      source = readFileSync(PERF_TEST_PATH, 'utf-8');
+    });
+
+    it('has no it.skip() calls', () => {
+      expect(source).not.toMatch(/\bit\.skip\s*\(/);
+    });
+
+    it('has no xit() calls', () => {
+      expect(source).not.toMatch(/\bxit\s*\(/);
+    });
+
+    it('has no describe.skip() calls', () => {
+      expect(source).not.toMatch(/\bdescribe\.skip\s*\(/);
+    });
+
+    it('has no xdescribe() calls', () => {
+      expect(source).not.toMatch(/\bxdescribe\s*\(/);
+    });
+
+    it('writes timing results to a JSON file', () => {
+      // The test must write timing results to a JSON file so the CI
+      // workflow can upload it as a structured artifact.
+      expect(source).toMatch(/perf-results\.json/);
+    });
+  });
+});


### PR DESCRIPTION
Resolves #286

## Summary

- Adds `.github/workflows/test-perf-e2e.yml` — fires **only on push to main** (never on `pull_request`), so timing assertion failures never block PR merges
- Runs `e2e-real/tests/performance.test.ts` against a real Tauri build on `macos-latest` with `continue-on-error: true`
- Uploads `perf-results.json` as a 14-day CI artifact for trend tracking (timestamp, commit SHA, runner name, all timing measurements)
- Extends `performance.test.ts` to collect timings into `timingResults` and serialize the JSON file in the `after()` hook
- Regression-lock tests in `src/lib/__tests__/perf-e2e-ci.test.ts` assert all structural invariants: trigger config, runner, spec wiring, artifact retention ≥ 14 days, no skip markers

## Decisions made

- **`continue-on-error: true`** on the run step — macOS CI runners are 2-3× slower than dev machines; timing assertions would produce flaky failures. The artifact upload step uses `if: always()` so data is captured even when assertions fail.
- **No `@wdio/json-reporter`** — it is not installed. Instead, the test file writes `perf-results.json` directly via `fs.writeFileSync` in the `after()` hook, which is simpler and avoids a new dependency.
- **`if-no-files-found: warn`** on the artifact upload — if the test run crashes before the `after()` hook fires, the upload step warns rather than failing the workflow, keeping the artifact step non-blocking.
- **14-day retention** — matches the existing `real-e2e-tests` logs artifact and satisfies the acceptance criterion.

## Test plan

- [x] New unit tests pass: `pnpm vitest run src/lib/__tests__/perf-e2e-ci.test.ts` — 12/12
- [x] Full test suite passes: `pnpm test` — 5143/5143
- [x] TypeScript passes: `pnpm typecheck`
- [x] Only 3 expected files modified (workflow, test file, perf spec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)