### PR TITLE
feat(ci): add post-merge real-app performance tracking job (#286)

### DIFF
--- a/.github/workflows/test-perf-e2e.yml
+++ b/.github/workflows/test-perf-e2e.yml
@@ -1,0 +1,121 @@
+name: Real-App Performance Tracking (post-merge)
+
+# Post-merge only — never runs on pull_request events so it cannot block PR merges.
+# Captures real WKWebView render cost, Tauri IPC round-trip latency, and
+# native window startup timing that synthetic unit benchmarks cannot measure.
+on:
+  push:
+    branches: [main]
+
+jobs:
+  perf-e2e:
+    name: Real-App Performance Benchmarks
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Set whisper.cpp build flags
+        run: |
+          echo "CMAKE_C_FLAGS=-march=armv8.2-a+dotprod+fp16" >> $GITHUB_ENV
+          echo "CMAKE_CXX_FLAGS=-march=armv8.2-a+dotprod+fp16" >> $GITHUB_ENV
+
+      - name: Create sidecar placeholder
+        run: |
+          mkdir -p src-tauri/binaries/lib
+          touch src-tauri/binaries/llama-server-aarch64-apple-darwin
+          chmod +x src-tauri/binaries/llama-server-aarch64-apple-darwin
+
+      - name: Install frontend dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Cache tauri-webdriver binary
+        id: cache-tauri-webdriver
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/tauri-webdriver
+          key: ${{ runner.os }}-tauri-webdriver-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install tauri-webdriver
+        if: steps.cache-tauri-webdriver.outputs.cache-hit != 'true'
+        run: cargo install tauri-webdriver
+
+      - name: Run real-app performance benchmarks
+        # continue-on-error keeps the artifact upload step from being skipped
+        # when a test fails or measurements exceed informal thresholds.
+        # Slow perf measurements are data, not build failures.
+        continue-on-error: true
+        run: |
+          # Run only the performance spec via the existing real-E2E infrastructure.
+          # The script handles: app start → tauri-webdriver bridge → wdio → cleanup.
+          bash -c '
+            set -euo pipefail
+            pkill -f "tauri-webdriver" 2>/dev/null || true
+            lsof -ti:1420,4444,4445 2>/dev/null | xargs kill 2>/dev/null || true
+            sleep 2
+
+            pnpm tauri:test > /tmp/notesage-perf-tauri.log 2>&1 &
+            TAURI_PID=$!
+            trap "kill $TAURI_PID 2>/dev/null; pkill -f tauri-webdriver 2>/dev/null; lsof -ti:1420 2>/dev/null | xargs kill 2>/dev/null; exit" EXIT INT TERM
+
+            echo "Waiting for WebDriver plugin (port 4445)..."
+            for i in $(seq 1 300); do
+              if curl -sf "http://localhost:4445/status" > /dev/null 2>&1; then
+                echo "Plugin ready after ${i}s"
+                break
+              fi
+              sleep 2
+            done
+
+            tauri-webdriver > /tmp/notesage-perf-driver.log 2>&1 &
+
+            echo "Waiting for tauri-webdriver (port 4444)..."
+            for i in $(seq 1 15); do
+              if curl -sf "http://localhost:4444/status" > /dev/null 2>&1; then
+                echo "Driver ready"
+                break
+              fi
+              sleep 1
+            done
+
+            pnpm wdio run wdio.conf.ts --spec ./e2e-real/tests/performance.test.ts
+          '
+
+      - name: Upload performance results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-e2e-results-${{ github.sha }}
+          path: perf-results.json
+          retention-days: 14
+          if-no-files-found: warn
+
+      - name: Upload app and driver logs on failure
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-e2e-logs-${{ github.sha }}
+          path: |
+            /tmp/notesage-perf-tauri.log
+            /tmp/notesage-perf-driver.log
+          retention-days: 14
+          if-no-files-found: ignore

--- a/e2e-real/tests/performance.test.ts
+++ b/e2e-real/tests/performance.test.ts
@@ -8,8 +8,12 @@
  *   Terminal 1: pnpm tauri:test
  *   Terminal 2: tauri-webdriver
  *   Terminal 3: pnpm test:e2e-real
+ *
+ * In CI this spec runs via `.github/workflows/test-perf-e2e.yml` (post-merge,
+ * push to main only). It does NOT run in the PR gate (`test.yml`).
  */
 
+import * as fs from 'fs';
 import * as path from 'path';
 import { waitForElement, openFile, getEditorText } from '../helpers/actions';
 import { measureAction } from '../helpers/timing';
@@ -17,13 +21,10 @@ import { ensureCleanState, ensureProjectOpen } from '../helpers/setup';
 
 const TEST_PROJECT = path.resolve(process.cwd(), 'e2e-real/fixtures/test-project');
 
-// SKIPPED 2026-05-16: per option A of the e2e-tests purpose decision —
-// e2e-real should be FUNCTIONAL only. Performance budgets in e2e tests
-// flake on shared CI runners (2-3x variance) and conceptually belong in
-// `src/perf/*.perf.test.ts` (with budget multipliers) OR in a dedicated
-// post-merge real-perf job (option C). This spec is suspended until the
-// option-C separate job exists. Tracked separately.
-describe.skip('Performance', function () {
+// Accumulated timing results — written to perf-results.json in after().
+const timingResults: Record<string, number> = {};
+
+describe('Performance', function () {
     // These tests involve large documents and multiple file operations —
     // give them generous timeouts.
     this.timeout(30000);
@@ -44,6 +45,17 @@ describe.skip('Performance', function () {
     after(async () => {
         // Restore the default window size in case a test changed it
         await browser.setWindowSize(1200, 800);
+
+        // Write timing measurements to perf-results.json for CI artifact upload.
+        const output = {
+            timestamp: new Date().toISOString(),
+            commitSha: process.env.GITHUB_SHA ?? 'local',
+            runner: process.env.RUNNER_NAME ?? 'local',
+            measurements: timingResults,
+        };
+        const outPath = path.resolve(process.cwd(), 'perf-results.json');
+        fs.writeFileSync(outPath, JSON.stringify(output, null, 2));
+        console.log(`[perf] Results written to ${outPath}`);
     });
 
     // -------------------------------------------------------------------
@@ -55,6 +67,7 @@ describe.skip('Performance', function () {
         });
 
         console.log(`[perf] Large document load time: ${duration.toFixed(0)}ms`);
+        timingResults['large-document-load-ms'] = duration;
         expect(duration).toBeLessThan(3000);
 
         // Verify some expected content actually rendered
@@ -118,6 +131,9 @@ describe.skip('Performance', function () {
 
         console.log(`[perf] Keystroke latencies (ms): ${latencies.map((l) => l.toFixed(1)).join(', ')}`);
         console.log(`[perf] Keystroke avg: ${avg.toFixed(1)}ms, min: ${min.toFixed(1)}ms, max: ${max.toFixed(1)}ms`);
+        timingResults['keystroke-avg-ms'] = avg;
+        timingResults['keystroke-max-ms'] = max;
+        timingResults['keystroke-min-ms'] = min;
 
         expect(avg).toBeLessThan(100);
     });
@@ -181,6 +197,7 @@ describe.skip('Performance', function () {
         const drift = Math.abs(scrollAfter - scrollBefore);
         const tolerance = Math.max(scrollBefore * 0.5, 200);
         console.log(`[perf] Scroll drift: ${drift}px (tolerance: ${tolerance}px)`);
+        timingResults['resize-scroll-drift-px'] = drift;
         expect(drift).toBeLessThan(tolerance);
 
         // Verify content is still rendered
@@ -227,6 +244,7 @@ describe.skip('Performance', function () {
         });
 
         console.log(`[perf] Rapid tab switching (${files.length} tabs x 2 rounds): ${duration.toFixed(0)}ms`);
+        timingResults['tab-switching-ms'] = duration;
 
         // Wait for the last tab switch to settle
         await browser.pause(500);

--- a/src/lib/__tests__/perf-e2e-ci.test.ts
+++ b/src/lib/__tests__/perf-e2e-ci.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Regression-lock tests for the post-merge real-app performance tracking CI job.
+ * Issue #286: Add post-merge real-app perf job (e2e-real-perf)
+ *
+ * These tests assert:
+ * 1. `e2e-real/tests/performance.test.ts` is NOT skipped (no `describe.skip`)
+ * 2. `.github/workflows/test-perf-e2e.yml` exists and has correct triggers
+ * 3. The workflow targets `macos-latest` and uses the real E2E infrastructure
+ * 4. Timing measurements are captured and uploaded as a CI artifact (≥14-day retention)
+ * 5. The job does NOT appear in `test.yml` (does not block PR merges)
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'fs';
+import { resolve } from 'path';
+
+const ROOT = resolve(__dirname, '../../..');
+
+const PERF_SPEC = resolve(ROOT, 'e2e-real/tests/performance.test.ts');
+const PERF_WORKFLOW = resolve(ROOT, '.github/workflows/test-perf-e2e.yml');
+const TEST_WORKFLOW = resolve(ROOT, '.github/workflows/test.yml');
+
+// ── Helper ────────────────────────────────────────────────────────────────────
+
+function readFile(path: string): string {
+  return readFileSync(path, 'utf-8');
+}
+
+// ── Performance spec — must NOT be skipped ────────────────────────────────────
+
+describe('e2e-real/tests/performance.test.ts — not skipped', () => {
+  it('file exists', () => {
+    expect(existsSync(PERF_SPEC)).toBe(true);
+  });
+
+  it('does not contain describe.skip', () => {
+    const content = readFile(PERF_SPEC);
+    // The top-level Performance suite must not be skipped
+    expect(content).not.toMatch(/describe\.skip\s*\(\s*['"]Performance['"]/);
+  });
+
+  it('does not contain the 6-line skip comment block from PR #291', () => {
+    const content = readFile(PERF_SPEC);
+    expect(content).not.toContain('SKIPPED 2026-05-16');
+  });
+});
+
+// ── test-perf-e2e.yml — must exist ───────────────────────────────────────────
+
+describe('.github/workflows/test-perf-e2e.yml — exists', () => {
+  it('file exists', () => {
+    expect(existsSync(PERF_WORKFLOW)).toBe(true);
+  });
+});
+
+// ── test-perf-e2e.yml — triggers ─────────────────────────────────────────────
+
+describe('.github/workflows/test-perf-e2e.yml — triggers', () => {
+  it('triggers on push to main', () => {
+    const content = readFile(PERF_WORKFLOW);
+    // Must have a push trigger scoped to main branch
+    expect(content).toMatch(/on:/);
+    expect(content).toMatch(/push:/);
+    expect(content).toMatch(/branches.*main|main.*branches/s);
+  });
+
+  it('does NOT have a pull_request trigger', () => {
+    const content = readFile(PERF_WORKFLOW);
+    // The workflow must not run on pull_request events
+    expect(content).not.toMatch(/^\s*pull_request\s*:/m);
+  });
+
+  it('does NOT have a workflow_call trigger (not a PR gate)', () => {
+    const content = readFile(PERF_WORKFLOW);
+    expect(content).not.toMatch(/workflow_call/);
+  });
+});
+
+// ── test-perf-e2e.yml — runner and infrastructure ────────────────────────────
+
+describe('.github/workflows/test-perf-e2e.yml — infrastructure', () => {
+  it('uses macos-latest runner', () => {
+    const content = readFile(PERF_WORKFLOW);
+    expect(content).toContain('macos-latest');
+  });
+
+  it('references tauri-webdriver (real E2E infrastructure)', () => {
+    const content = readFile(PERF_WORKFLOW);
+    expect(content).toContain('tauri-webdriver');
+  });
+
+  it('builds or runs the Tauri app (pnpm tauri:test or test:e2e-real)', () => {
+    const content = readFile(PERF_WORKFLOW);
+    const hasRealE2E =
+      content.includes('tauri:test') ||
+      content.includes('test:e2e-real') ||
+      content.includes('run-real-e2e');
+    expect(hasRealE2E).toBe(true);
+  });
+});
+
+// ── test-perf-e2e.yml — artifact upload ──────────────────────────────────────
+
+describe('.github/workflows/test-perf-e2e.yml — artifact upload', () => {
+  it('uploads an artifact', () => {
+    const content = readFile(PERF_WORKFLOW);
+    expect(content).toContain('upload-artifact');
+  });
+
+  it('artifact retention is at least 14 days', () => {
+    const content = readFile(PERF_WORKFLOW);
+    // Find retention-days: N and assert N >= 14
+    const match = content.match(/retention-days:\s*(\d+)/);
+    expect(match).not.toBeNull();
+    const days = parseInt(match![1], 10);
+    expect(days).toBeGreaterThanOrEqual(14);
+  });
+
+  it('artifact upload uses if: always() so it runs even on test failure', () => {
+    const content = readFile(PERF_WORKFLOW);
+    expect(content).toMatch(/if:\s*always\(\)/);
+  });
+});
+
+// ── test.yml — must NOT reference the new job (PR gate unchanged) ─────────────
+
+describe('.github/workflows/test.yml — PR gate unaffected', () => {
+  it('does not reference test-perf-e2e job', () => {
+    const content = readFile(TEST_WORKFLOW);
+    expect(content).not.toContain('test-perf-e2e');
+  });
+});


### PR DESCRIPTION
Resolves #286

## Summary

Adds a post-merge-only CI workflow (`test-perf-e2e.yml`) that runs the real Tauri E2E performance spec on `macos-latest` and uploads timing results as a 14-day artifact. This gives a way to track real-app perf trends over time without blocking PR merges.

Key fix over PR #288: PR #291 (commit `3854f94`) added `describe.skip` to `e2e-real/tests/performance.test.ts` after #288 was branched. This PR explicitly changes `describe.skip('Performance', ...)` back to `describe('Performance', ...)` as a visible diff — so the un-skip survives the merge instead of silently producing an empty artifact.

## Red tests added

- `src/lib/__tests__/perf-e2e-ci.test.ts::does not contain describe.skip` — asserts the Performance suite is not skipped
- `src/lib/__tests__/perf-e2e-ci.test.ts::does not contain the 6-line skip comment block from PR #291` — asserts skip comment removed
- `src/lib/__tests__/perf-e2e-ci.test.ts::file exists (.github/workflows/test-perf-e2e.yml)` — workflow must exist
- `src/lib/__tests__/perf-e2e-ci.test.ts::triggers on push to main` — only push trigger
- `src/lib/__tests__/perf-e2e-ci.test.ts::does NOT have a pull_request trigger` — must not block PR merges
- `src/lib/__tests__/perf-e2e-ci.test.ts::uses macos-latest runner` — correct runner
- `src/lib/__tests__/perf-e2e-ci.test.ts::references tauri-webdriver` — real E2E infra
- `src/lib/__tests__/perf-e2e-ci.test.ts::artifact retention is at least 14 days` — ≥14 days
- `src/lib/__tests__/perf-e2e-ci.test.ts::artifact upload uses if: always()` — runs on failure too

## Green implementation

- `.github/workflows/test-perf-e2e.yml` — new post-merge workflow: push to main only, macos-latest, full Tauri build, tauri-webdriver, runs only `performance.test.ts` spec, uploads `perf-results.json` with 14-day retention, `continue-on-error: true` so slow measurements don't fail the workflow
- `e2e-real/tests/performance.test.ts` — change `describe.skip('Performance'` → `describe('Performance'`; remove 6-line skip comment block from PR #291; add `import * as fs from 'fs'`; add module-level `timingResults` accumulator; per-test recording of load/keystroke/resize/tab-switch timings; `after()` hook writes `perf-results.json` with timestamp, commit SHA, runner name
- `src/lib/__tests__/perf-e2e-ci.test.ts` — 14 regression-lock tests

## Refactor

Skipped — implementation already minimal.

## Decisions made

- **Timing output format**: JSON artifact with `{ timestamp, commitSha, runner, measurements }` — matches the structure used in `docs/performance-baseline.md`, as specified in assumptions.
- **`continue-on-error: true` on the run step**: Slow measurements are data, not build failures — the job should upload the artifact even when a timing assertion fails.
- **Inline script vs run-real-e2e.sh**: Used an inline bash script in the workflow (same logic as `run-real-e2e.sh`) to run only the performance spec via `--spec` flag, rather than all specs. This avoids running functional tests in the perf job.
- **Two artifact uploads**: `perf-results.json` (the data) and tauri/driver logs (debugging aid) — both 14 days, both `if: always()`.

## Verification

- [x] Red tests were red before implementation (12 of 14 failing; 2 already-green regression guards)
- [x] All red tests now green (14/14)
- [x] `pnpm test` passes (285 files, 5145 tests)
- [x] `pnpm typecheck` clean
- [x] No unrelated files modified (3 files: workflow, performance spec, regression-lock tests)

## Notes for reviewer

- The `describe.skip` → `describe` change is the critical fix from PR #288. The diff makes it explicit and visible so there is no ambiguity about whether the un-skip survives merge.
- The performance tests have bare numeric literals in assertions (e.g., `toBeLessThan(3000)`) — this is intentional. The `no-bare-perf-budget.test.ts` scan covers `e2e/**/*.spec.ts` and `src/perf/**`, not `e2e-real/**` (tracking-only job, not a PR gate with a CI multiplier).
- The `continue-on-error: true` on the perf run step ensures the artifact is always uploaded, even when a test asserts `duration < 3000` and the CI runner is slow. Timing assertions in the performance spec serve as informal guidance, not hard gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the `aw-tdd` skill.