### PR TITLE
fix(aw-alpha-prep): bash pipeline instead of jq for prod_additions

### DIFF
--- a/.github/workflows/aw-alpha-prep.yml
+++ b/.github/workflows/aw-alpha-prep.yml
@@ -160,11 +160,19 @@ jobs:
           # ----- Tier C: oversized PRODUCTION diff -----
           # Size ceiling applies to production files only. A 600-line e2e spec
           # is not blast-radius — and shouldn't be size-throttled.
+          # Compute prod_additions in bash (not jq, because passing the regex
+          # through jq's JSON-string parser hits an "Invalid escape" error on
+          # the \. sequences).
           prod_additions=0
           if [[ -n "$prod_paths" ]]; then
-            # Pull additions per file from the .files[] array, summing only
-            # production paths.
-            prod_additions=$(echo "$pr_json" | jq --argjson tre "$(printf '"%s"' "$TEST_FILE_REGEX" | jq -R .)" -r '[.files[] | select(.path | test('"\"$TEST_FILE_REGEX\""'; "x") | not) | .additions] | add // 0')
+            prod_additions=$(echo "$pr_json" \
+              | jq -r '.files[] | "\(.additions) \(.path)"' \
+              | while read -r adds path; do
+                  if ! echo "$path" | grep -qE "$TEST_FILE_REGEX"; then
+                    echo "$adds"
+                  fi
+                done \
+              | awk '{ s += $1 } END { print s+0 }')
           fi
           echo "  production additions: $prod_additions / $additions total"
 


### PR DESCRIPTION
Re-applies the jq escape fix on top of current main. Closed #292 was DIRTY against post-#291 main; this is the same fix rebased cleanly.

Closes a regression in aw-alpha-prep that crashed on PR #274 (first mixed-file PR to hit the jq line).