### PR TITLE
chore(deps): upgrade notify 7 → 9.0.0-rc.4 and notify-debouncer-full 0.4 → 0.8.0-rc.2

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2264,15 +2264,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
-name = "fsevent-sys"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3527,11 +3518,11 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.10.2"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
+checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.11.1",
  "inotify-sys",
  "libc",
 ]
@@ -3552,15 +3543,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -4377,33 +4359,35 @@ dependencies = [
 
 [[package]]
 name = "notify"
-version = "7.0.0"
+version = "9.0.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c533b4c39709f9ba5005d8002048266593c1cfaf3c5f0739d5b8ab0c6c504009"
+checksum = "b44b771d4dd781ef14c84078693e67495da6b47f609f72e8a4da8420a861240e"
 dependencies = [
  "bitflags 2.11.1",
- "filetime",
- "fsevent-sys",
  "inotify",
  "kqueue",
  "libc",
  "log",
  "mio",
  "notify-types",
+ "objc2-core-foundation",
+ "objc2-core-services",
  "walkdir",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
+ "xxhash-rust",
 ]
 
 [[package]]
 name = "notify-debouncer-full"
-version = "0.4.0"
+version = "0.8.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcf855483228259b2353f89e99df35fc639b2b2510d1166e4858e3f67ec1afb"
+checksum = "9c9b3ca8dc01d924371a57d93be72fb7ca2c937f861f2f128926d967dab25182"
 dependencies = [
  "file-id",
  "log",
  "notify",
  "notify-types",
+ "rustc-hash",
  "walkdir",
 ]
 
@@ -4423,11 +4407,11 @@ dependencies = [
 
 [[package]]
 name = "notify-types"
-version = "1.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585d3cb5e12e01aed9e8a1f70d5c6b5e86fe2a6e48fc8cd0b3e0b8df6f6eb174"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "instant",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -4610,6 +4594,16 @@ checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
 dependencies = [
  "objc2",
  "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-services"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583300ad934cba24ff5292aee751ecc070f7ca6b39a574cc21b7b5e588e06a0b"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -9901,6 +9895,12 @@ name = "xmp-writer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9440ea3e5aeabb0ac63af70daf835274065238cdd0cec83418f417eae38bacee"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yaml-rust"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -61,8 +61,8 @@ serde_norway = "0.9"
 parking_lot = "0.12"
 
 # Filesystem watcher (Phase 5)
-notify = { version = "7", features = ["macos_fsevent"] }
-notify-debouncer-full = "0.4"
+notify = { version = "9.0.0-rc.4", features = ["macos_fsevent"] }
+notify-debouncer-full = "0.8.0-rc.2"
 
 # iCloud sync (Phase 5.5)
 fs_extra = "1.3"

--- a/src-tauri/src/commands/watcher.rs
+++ b/src-tauri/src/commands/watcher.rs
@@ -517,6 +517,161 @@ mod tests {
         );
     }
 
+    /// Regression guard: `.git/` internals must not reach `file-changed-batch`.
+    #[test]
+    fn process_watcher_events_filters_git_internals() {
+        let mut self_writes: HashMap<PathBuf, Instant> = HashMap::new();
+
+        let events = vec![
+            // A file inside a .git directory (e.g. index, COMMIT_EDITMSG)
+            DebouncedEvent::new(
+                notify::Event {
+                    kind: notify::EventKind::Modify(notify::event::ModifyKind::Data(
+                        notify::event::DataChange::Content,
+                    )),
+                    paths: vec![PathBuf::from("/home/user/project/.git/COMMIT_EDITMSG")],
+                    attrs: Default::default(),
+                },
+                Instant::now(),
+            ),
+            // A .git directory itself
+            DebouncedEvent::new(
+                notify::Event {
+                    kind: notify::EventKind::Modify(notify::event::ModifyKind::Data(
+                        notify::event::DataChange::Content,
+                    )),
+                    paths: vec![PathBuf::from("/home/user/project/.git")],
+                    attrs: Default::default(),
+                },
+                Instant::now(),
+            ),
+        ];
+
+        let result = process_watcher_events(events, &mut self_writes);
+
+        assert!(
+            result.file_changes.is_empty(),
+            ".git internals must not appear in file-changed-batch"
+        );
+        // Reindex entries should also be empty (git internals are dropped before reindex)
+        assert!(
+            result.reindex_entries.is_empty(),
+            ".git internals must not appear in reindex entries"
+        );
+    }
+
+    /// Regression guard: `.DS_Store` files must not reach `file-changed-batch`.
+    #[test]
+    fn process_watcher_events_filters_ds_store() {
+        let mut self_writes: HashMap<PathBuf, Instant> = HashMap::new();
+
+        let events = vec![DebouncedEvent::new(
+            notify::Event {
+                kind: notify::EventKind::Modify(notify::event::ModifyKind::Data(
+                    notify::event::DataChange::Content,
+                )),
+                paths: vec![PathBuf::from("/home/user/project/.DS_Store")],
+                attrs: Default::default(),
+            },
+            Instant::now(),
+        )];
+
+        let result = process_watcher_events(events, &mut self_writes);
+
+        assert!(
+            result.file_changes.is_empty(),
+            ".DS_Store must not appear in file-changed-batch"
+        );
+    }
+
+    /// Regression guard: macOS FSEvents quirk — Modify on a nonexistent file must
+    /// be reclassified as Delete before reaching the frontend.
+    #[test]
+    fn process_watcher_events_reclassifies_modify_as_delete_for_nonexistent_file() {
+        let mut self_writes: HashMap<PathBuf, Instant> = HashMap::new();
+
+        // Use a path that definitely does not exist.
+        let nonexistent = PathBuf::from("/tmp/notesage_test_nonexistent_file_12345.md");
+        assert!(!nonexistent.exists(), "test path must not exist");
+
+        let events = vec![DebouncedEvent::new(
+            notify::Event {
+                kind: notify::EventKind::Modify(notify::event::ModifyKind::Data(
+                    notify::event::DataChange::Content,
+                )),
+                paths: vec![nonexistent.clone()],
+                attrs: Default::default(),
+            },
+            Instant::now(),
+        )];
+
+        let result = process_watcher_events(events, &mut self_writes);
+
+        // The Modify event should have been reclassified to Delete.
+        assert_eq!(
+            result.file_changes.len(),
+            1,
+            "reclassified delete must appear in file_changes"
+        );
+        assert_eq!(
+            result.file_changes[0].kind,
+            FileChangeKind::Delete,
+            "Modify on nonexistent path must be reclassified as Delete"
+        );
+    }
+
+    /// Regression guard: self-writes must be excluded from `file-changed-batch`
+    /// but must still appear in `reindex_entries` (SQLite index must stay current).
+    #[test]
+    fn process_watcher_events_self_write_suppresses_file_changed_batch_not_reindex() {
+        use std::io::Write;
+
+        // Create a real temporary file so the path:
+        //  - exists (no Modify→Delete reclassification), AND
+        //  - is_dir() == false (no directory skip).
+        let mut tmpfile = tempfile::NamedTempFile::new()
+            .expect("could not create temp file for self-write test");
+        writeln!(tmpfile, "notesage self-write test").unwrap();
+        let self_written = tmpfile.path().to_path_buf();
+
+        let mut self_writes: HashMap<PathBuf, Instant> = HashMap::new();
+        self_writes.insert(self_written.clone(), Instant::now());
+
+        let events = vec![DebouncedEvent::new(
+            notify::Event {
+                kind: notify::EventKind::Modify(notify::event::ModifyKind::Data(
+                    notify::event::DataChange::Content,
+                )),
+                paths: vec![self_written.clone()],
+                attrs: Default::default(),
+            },
+            Instant::now(),
+        )];
+
+        let result = process_watcher_events(events, &mut self_writes);
+
+        // Self-write: should NOT appear in file_changes (no false external-change event)
+        let path_str = self_written.to_string_lossy();
+        let in_file_changes = result
+            .file_changes
+            .iter()
+            .any(|e| e.path == path_str.as_ref());
+        assert!(
+            !in_file_changes,
+            "self-written path must not appear in file-changed-batch"
+        );
+
+        // Self-write: MUST appear in reindex_entries (SQLite still needs to be updated)
+        let in_reindex = result
+            .reindex_entries
+            .iter()
+            .any(|(p, _)| p == path_str.as_ref());
+        assert!(
+            in_reindex,
+            "self-written path must still appear in reindex_entries"
+        );
+    }
+
     #[test]
     fn process_watcher_events_excludes_rename_txn_staging_paths() {
         // Simulate a modify event for a file inside the rename-txn staging dir.


### PR DESCRIPTION
Resolves #242

## Summary

Bumps the filesystem watcher from notify 7.0.0 to notify 9.0.0-rc.4 (the latest available 9.x release) and the matching debouncer from 0.4.0 to 0.8.0-rc.2. No changes to `watcher.rs` logic were required — the `EventKind`, `DebouncedEvent`, and `RecommendedCache` APIs are fully compatible between v7 and v9. Adds 4 regression-guard tests for `process_watcher_events()` to lock in the critical behaviours across the upgrade.

## Red tests added

- `src-tauri/src/commands/watcher.rs::tests::process_watcher_events_filters_git_internals` — `.git/` events excluded from `file-changed-batch` and `reindex_entries`
- `src-tauri/src/commands/watcher.rs::tests::process_watcher_events_filters_ds_store` — `.DS_Store` events excluded from `file-changed-batch`
- `src-tauri/src/commands/watcher.rs::tests::process_watcher_events_reclassifies_modify_as_delete_for_nonexistent_file` — macOS FSEvents quirk: Modify on nonexistent path → Delete
- `src-tauri/src/commands/watcher.rs::tests::process_watcher_events_self_write_suppresses_file_changed_batch_not_reindex` — self-write excludes from frontend batch but still queues SQLite reindex

These are regression-guard tests covering existing code paths (additive changes exception applies — they are GREEN with notify v7 and v9).

## Green implementation

- `src-tauri/Cargo.toml` — `notify` bumped from `"7"` → `"9.0.0-rc.4"` with `macos_fsevent` feature preserved; `notify-debouncer-full` from `"0.4"` → `"0.8.0-rc.2"`
- `src-tauri/Cargo.lock` — updated: `notify` 7.0.0 → 9.0.0-rc.4, `notify-debouncer-full` 0.4.0 → 0.8.0-rc.2, `notify-types` 1.0.1 → 2.1.0, `inotify` 0.10.2 → 0.11.1, `fsevent-sys` removed → `objc2-core-services` added, `xxhash-rust` added, `instant` removed
- `src-tauri/src/commands/watcher.rs` — 4 new regression-guard unit tests added in `#[cfg(test)]`

## Refactor

Skipped — implementation already minimal.

## Decisions made

- **Version choice: 9.0.0-rc.4 (RC) vs waiting for GA** | Used the RC | The acceptance criterion explicitly targets `9.x`; 9.0.0-rc.4 is the only 9.x release on crates.io. Previous attempt (PR #251) used v8 and was rejected by aw-review. Previous attempt (PR #253) used the same RC version but was closed due to merge conflicts with main. This PR is a fresh branch from current main.
- **Version specifier: `"9.0.0-rc.4"` (caret-form)** | Caret form | Equivalent to `>=9.0.0-rc.4, <10.0.0`; in practice resolves only to this specific RC since no 9.x stable exists. More explicit than `"9"` (which won't resolve pre-releases at all).
- **No watcher.rs logic changes** | No changes needed | API compatibility verified: `DebouncedEvent::new(event, instant)`, `event.kind`, `event.paths`, `RecommendedCache`, and `new_debouncer(duration, None, closure)` all compile and behave identically in v9. Validated via isolated test crate.
- **Self-write test uses `tempfile::NamedTempFile`** | `NamedTempFile` | The test requires a path that exists on disk (to avoid Modify→Delete reclassification) and is not a directory (to avoid the directory skip). A real temp file satisfies both constraints without depending on `/tmp` being writable.

## Verification

- [x] Red tests were red before implementation (additive changes exception: all 4 tests are regression guards for existing behavior; `Cargo.toml` constraint itself is the spec-mismatch — was `"7"`, required `"9.x"`; validated GREEN with notify v7 in isolated crate)
- [x] All red tests now green (validated via isolated crate with notify v9.0.0-rc.4)
- [x] `pnpm test` passes (5131/5131 frontend tests)
- [x] `pnpm typecheck` clean
- [x] No unrelated files modified (only `Cargo.toml`, `Cargo.lock`, `watcher.rs`)
- ⚠️ `cargo test` (Rust backend) — this Linux environment lacks macOS/GTK system libs required to build the full Tauri crate; Rust tests will be validated by the macOS CI runner

## Notes for reviewer

- **API compatibility**: Validated by compiling an isolated test crate with the same import patterns as `watcher.rs` — `DebouncedEvent::new`, `event.kind`/`event.paths` deref, `RecommendedCache`, and `new_debouncer` all work unchanged in v9.
- **macOS FSEvents backend**: In v9, `fsevent-sys` (C binding) was replaced by `objc2-core-services` (pure Rust Objective-C binding). The `macos_fsevent` feature flag is preserved and the behaviour should be identical.
- **RC status**: 9.0.0-rc.4 is a release candidate — it has gone through 4 RCs, suggesting near-stable quality. If the team prefers waiting for GA, close this PR and re-open when 9.0.0 stable ships.
- **Previous attempts**: PR #251 used notify v8 (rejected: criterion specified 9.x). PR #253 used v9.0.0-rc.4 but was closed due to merge conflicts with main. This PR is a clean rebase from current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the `aw-tdd` skill.