### PR TITLE
chore(ci): chore(deps) fast-path in aw-alpha-prep classifier

### DIFF
--- a/.github/workflows/aw-alpha-prep.yml
+++ b/.github/workflows/aw-alpha-prep.yml
@@ -25,6 +25,21 @@ name: AW — Alpha Prep (Tier Classifier)
 #     - New feature (acceptance criteria mention new behaviour)
 #
 #   Tier A otherwise.
+#
+# ──  Dependency-bump fast-path (2026-05-16)  ───────────────────────────────────
+# `chore(deps):` PRs with small prod diffs go straight to Tier A even when they
+# touch load-bearing paths. Rationale: dep bumps are mechanical shims against
+# upstream changelog. The upstream changelog is the spec; the test suite is the
+# validation; a human reading 18 lines of `row.get::<_, i64>` cast adds nothing
+# the CI doesn't already verify. The hitl/visual check still wins (issue authors
+# can force a manual review by tagging the issue).
+#
+# Fast-path triggers when ALL hold:
+#   - PR title starts with `chore(deps):`
+#   - No `hitl`/`visual` label on originating issue
+#   - prod_additions < 50  (a "small mechanical shim")
+#   - prod_count    ≤ 3
+# Result: Tier A, regardless of load-bearing path.
 
 on:
   pull_request:
@@ -64,11 +79,12 @@ jobs:
           set -euo pipefail
 
           # Load PR metadata.
-          pr_json=$(gh pr view "$PR_NUMBER" --json additions,deletions,changedFiles,files,closingIssuesReferences,headRefName,labels,isDraft,state)
+          pr_json=$(gh pr view "$PR_NUMBER" --json additions,deletions,changedFiles,files,closingIssuesReferences,headRefName,labels,isDraft,state,title)
 
           additions=$(echo "$pr_json" | jq -r '.additions')
           changed_files=$(echo "$pr_json" | jq -r '.changedFiles')
           file_paths=$(echo "$pr_json" | jq -r '.files[].path')
+          pr_title=$(echo "$pr_json" | jq -r '.title')
 
           # Identify test-only files. Patterns:
           #   - e2e-real/** (real-E2E tests + fixtures + helpers)
@@ -91,6 +107,24 @@ jobs:
           test_count=${test_count:-0}
 
           echo "  production files: $prod_count, test-only files: $test_count"
+
+          # Compute prod_additions early — the deps fast-path needs it before
+          # the load-bearing check. Bash pipeline (not jq) because passing
+          # TEST_FILE_REGEX through jq's JSON-string parser hits "Invalid
+          # escape" on the \. sequences.
+          prod_additions=0
+          if [[ -n "$prod_paths" ]]; then
+            prod_additions=$(echo "$pr_json" \
+              | jq -r '.files[] | "\(.additions) \(.path)"' \
+              | while read -r adds path; do
+                  if ! echo "$path" | grep -qE "$TEST_FILE_REGEX"; then
+                    echo "$adds"
+                  fi
+                done \
+              | awk '{ s += $1 } END { print s+0 }')
+          fi
+          echo "  production additions: $prod_additions / $additions total"
+
           issue_numbers=$(echo "$pr_json" | jq -r '.closingIssuesReferences[].number // empty')
           pr_labels=$(echo "$pr_json" | jq -r '.labels[].name // empty')
           is_draft=$(echo "$pr_json" | jq -r '.isDraft')
@@ -146,6 +180,30 @@ jobs:
             exit 0
           fi
 
+          # ----- Dependency-bump fast-path -----
+          # `chore(deps):` PRs with small prod diffs bypass the load-bearing
+          # check and go straight to Tier A. Rationale documented in the
+          # header comment. The hitl/visual check above still wins.
+          if [[ "$tier" != "C" \
+              && "$pr_title" =~ ^chore\(deps\): \
+              && $prod_additions -lt 50 \
+              && $prod_count -le 3 ]]; then
+            reason="Dep-bump fast-path: chore(deps): with $prod_additions prod lines across $prod_count file(s) (< 50/3 ceiling)"
+            echo "  fast-path: $reason"
+            label="tier:A"
+            echo "Classified: $label  ($reason)"
+            gh pr edit "$PR_NUMBER" --add-label "$label"
+            comment_body=$(cat <<EOF
+          🧮 **aw-alpha-prep:** \`$label\` — $reason
+
+          Auto-merge eligibility:
+          - **tier:A** → enabled by \`aw-merge\` workflow; merges automatically when CI is green.
+          EOF
+          )
+            gh pr comment "$PR_NUMBER" --body "$comment_body"
+            exit 0
+          fi
+
           # ----- Tier C: load-bearing files touched -----
           # Only check PRODUCTION files (test files in load-bearing-named directories
           # like `e2e-real/tests/watcher-integration.test.ts` are still test files
@@ -160,22 +218,7 @@ jobs:
           # ----- Tier C: oversized PRODUCTION diff -----
           # Size ceiling applies to production files only. A 600-line e2e spec
           # is not blast-radius — and shouldn't be size-throttled.
-          # Compute prod_additions in bash (not jq, because passing the regex
-          # through jq's JSON-string parser hits an "Invalid escape" error on
-          # the \. sequences).
-          prod_additions=0
-          if [[ -n "$prod_paths" ]]; then
-            prod_additions=$(echo "$pr_json" \
-              | jq -r '.files[] | "\(.additions) \(.path)"' \
-              | while read -r adds path; do
-                  if ! echo "$path" | grep -qE "$TEST_FILE_REGEX"; then
-                    echo "$adds"
-                  fi
-                done \
-              | awk '{ s += $1 } END { print s+0 }')
-          fi
-          echo "  production additions: $prod_additions / $additions total"
-
+          # prod_additions is already computed above (needed for deps fast-path).
           if [[ "$tier" != "C" ]] && { (( prod_additions > 250 )) || (( prod_count > 8 )); }; then
             tier="C"
             reason="Production diff exceeds Tier-B ceiling ($prod_additions lines, $prod_count files; ceiling 250/8)"

--- a/src/lib/__tests__/aw-deps-fast-path.test.ts
+++ b/src/lib/__tests__/aw-deps-fast-path.test.ts
@@ -1,0 +1,108 @@
+// Regression-lock for the `chore(deps):` fast-path in aw-alpha-prep.yml.
+//
+// Background: dep-bump PRs that touch load-bearing paths (`/index/`,
+// `/watcher.rs`, etc.) were classified Tier C even when the diff was a
+// mechanical 15-line shim against an upstream changelog. Tier C requires
+// human review, which for non-coding repo owners is the wrong reviewer.
+//
+// The fix: a `chore(deps):` fast-path that overrides the load-bearing
+// check when the prod diff is small. Rationale captured in
+// `feedback_aw_dep_upgrades.md`. The fast-path triggers when ALL hold:
+//   - PR title starts with `chore(deps):`
+//   - Originating issue has neither `hitl` nor `visual` label
+//   - prod_additions < 50
+//   - prod_count    ≤ 3
+//
+// These tests assert the rule is encoded correctly in the classifier
+// script. They catch drift if someone:
+//   - widens the prod-line ceiling without thinking (e.g. raises 50 → 200)
+//   - drops the hitl/visual check (would let any `chore(deps):` PR through)
+//   - reorders the steps so load-bearing C wins over deps A
+//   - removes the title check (would let unrelated small PRs slip through)
+//
+// We parse the YAML and read the bash body of the `Classify PR` step.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { parse as parseYaml } from 'yaml';
+
+const WORKFLOW_PATH = resolve(__dirname, '../../../.github/workflows/aw-alpha-prep.yml');
+const YAML_TEXT = readFileSync(WORKFLOW_PATH, 'utf-8');
+
+interface Step {
+  name?: string;
+  run?: string;
+}
+interface Job {
+  steps?: Step[];
+}
+interface Workflow {
+  jobs: Record<string, Job>;
+}
+
+function classifyStepBody(): string {
+  const wf = parseYaml(YAML_TEXT) as Workflow;
+  const job = wf.jobs?.classify;
+  expect(job, 'classify job must exist').toBeDefined();
+  const step = (job?.steps ?? []).find((s) => s.name === 'Classify PR into Tier A / B / C');
+  expect(step, '"Classify PR into Tier A / B / C" step must exist').toBeDefined();
+  return step?.run ?? '';
+}
+
+describe('aw-alpha-prep — chore(deps) fast-path', () => {
+  const body = classifyStepBody();
+
+  it('reads PR title into a pr_title variable', () => {
+    // The classifier must request `title` in the `gh pr view --json` call
+    // and assign it to `pr_title`. Without this, the title regex below
+    // can't fire.
+    expect(body).toMatch(/--json[^']*title[,)]?[^']*\)/);
+    expect(body).toMatch(/pr_title=\$\(echo "\$pr_json" \| jq -r '\.title'\)/);
+  });
+
+  it('matches chore(deps): prefix via bash regex on pr_title', () => {
+    // The regex is the trigger: PRs whose title starts with `chore(deps):`
+    // (and only those) enter the fast-path. Match must use bash `=~` so
+    // it survives across runner shells.
+    expect(body).toMatch(/"\$pr_title"\s*=~\s*\^chore\\\(deps\\\):/);
+  });
+
+  it('enforces prod_additions < 50 ceiling', () => {
+    // Above 50 lines, deps PRs go through the regular Tier B / C path.
+    // The number 50 is the documented "small mechanical shim" threshold.
+    expect(body).toMatch(/\$prod_additions\s+-lt\s+50\b/);
+  });
+
+  it('enforces prod_count ≤ 3 ceiling', () => {
+    // Cargo.lock + Cargo.toml + one source shim = 3 files. Anything more
+    // is a multi-file refactor disguised as a dep bump.
+    expect(body).toMatch(/\$prod_count\s+-le\s+3\b/);
+  });
+
+  it('runs the fast-path AFTER the hitl/visual check', () => {
+    // The fast-path body conditions on `$tier != "C"`, so a prior hitl/
+    // visual flag still wins. Confirm the literal guard exists in the
+    // deps block (the test-only fast-path uses the same guard).
+    const depsBlockMatch = body.match(/# ----- Dependency-bump fast-path -----[\s\S]*?fi/);
+    expect(depsBlockMatch, 'deps fast-path block must exist').not.toBeNull();
+    expect(depsBlockMatch?.[0] ?? '').toMatch(/\$tier"?\s*!=\s*"C"/);
+  });
+
+  it('runs the fast-path BEFORE the load-bearing check', () => {
+    // Ordering matters: if load-bearing C ran first, a chore(deps):
+    // touching /index/ would already be tagged C before we got here.
+    const depsIdx = body.indexOf('# ----- Dependency-bump fast-path -----');
+    const loadBearingIdx = body.indexOf('# ----- Tier C: load-bearing files touched -----');
+    expect(depsIdx, 'deps fast-path comment must exist').toBeGreaterThan(-1);
+    expect(loadBearingIdx, 'load-bearing comment must exist').toBeGreaterThan(-1);
+    expect(depsIdx).toBeLessThan(loadBearingIdx);
+  });
+
+  it('exits with tier:A label on a fast-path hit', () => {
+    const depsBlockMatch = body.match(/# ----- Dependency-bump fast-path -----[\s\S]*?exit 0/);
+    expect(depsBlockMatch, 'deps fast-path must end with exit 0').not.toBeNull();
+    expect(depsBlockMatch?.[0] ?? '').toMatch(/label="tier:A"/);
+    expect(depsBlockMatch?.[0] ?? '').toMatch(/gh pr edit "\$PR_NUMBER" --add-label "\$label"/);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a `chore(deps):` fast-path to the AW tier classifier so small mechanical dep bumps go straight to Tier A even when they touch load-bearing paths (`/index/`, `/watcher.rs`, `.github/workflows/`).
- Fast-path triggers when ALL hold: title starts with `chore(deps):`, no `hitl`/`visual` label on the originating issue, prod_additions < 50, prod_count ≤ 3.
- The hitl/visual check still wins — issue authors can force manual review by tagging the issue.

## Why
This weekend's dep backlog (#250 comrak, #298 rusqlite, #270 release.yml, #294 perf job, #257 watcher test, #267 mock ACP fixture) all got classified Tier C because they touch `/index/`, `/watcher.rs`, or `.github/workflows/`. Tier C requires human review — but the repo owner explicitly stated they're not the right reviewer for a 15-line `row.get::<_, i64>` cast. The right reviewer is the agent, against the upstream changelog.

Rationale captured in `feedback_aw_dep_upgrades.md`. The 30-minute rule: if a competent human can do it locally in <30 min, AW is overhead, not leverage.

## Test plan
- [x] All 7 new regression tests in `src/lib/__tests__/aw-deps-fast-path.test.ts` pass
- [x] All 6 existing `aw-*.test.ts` files still pass (134 tests total)
- [x] YAML parses with `node -e require('yaml').parse(...)`
- [x] Ordering: deps fast-path runs after hitl/visual, before load-bearing
- [ ] Self-test on this PR — its own title is `chore(ci):`, NOT `chore(deps):`, so it must NOT trigger the deps fast-path; expecting `tier:C` (touches `.github/workflows/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)