### PR TITLE
fix(ui): clarify Read Only mode tooltip — agent denied, not asking

### DIFF
--- a/src/lib/ai/acp-agent-state.ts
+++ b/src/lib/ai/acp-agent-state.ts
@@ -21,7 +21,7 @@ interface CommonMode {
 }
 
 const COMMON_MODES: Record<CommonModeKey, CommonMode> = {
-  read_only:   { key: 'read_only',    name: 'Read Only',   tooltip: 'Can read files — must ask for everything else' },
+  read_only:   { key: 'read_only',    name: 'Read Only',   tooltip: 'Read access only — agent is denied any write or execute tool calls' },
   agent:       { key: 'agent',        name: 'Agent',       tooltip: 'Can read and edit files — asks for risky operations' },
   full_access: { key: 'full_access',  name: 'Full Access', tooltip: 'No permission prompts — use with caution' },
   plan:        { key: 'plan',         name: 'Plan',        tooltip: 'Read-only — proposes changes without executing' },


### PR DESCRIPTION
## Summary
- The Read Only mode tooltip read "Can read files — must ask for everything else", implying a permission prompt would appear for writes/executes
- In practice the agent is instructed it has read-only access and silently doesn't attempt those tools — no permission card ever surfaces
- New wording: "Read access only — agent is denied any write or execute tool calls" (accurate, no misleading "must ask")

## Test plan
- [ ] Open chat with an ACP connection, open the mode picker, hover the Read Only option
- [ ] Tooltip reads "Read access only — agent is denied any write or execute tool calls"

🤖 Generated with [Claude Code](https://claude.com/claude-code)