### PR TITLE
fix(acp): backfill connection.acpCapabilities from eager session response

### DIFF
--- a/src/hooks/useAcpLifecycle.ts
+++ b/src/hooks/useAcpLifecycle.ts
@@ -17,7 +17,7 @@ import { useSettingsStore } from '@/stores/settings-store';
 import type { AcpSessionResult, AcpSessionUpdatePayload, AcpPermissionRequestPayload } from '@/lib/ai/acp-utils';
 import { restoreOrCreateAcpSession } from '@/lib/ai/acp-session-restore';
 import { buildAttachmentActivities, getChatSandboxScope, hasLoadSessionCapability } from '@/lib/ai/acp-utils';
-import { acpAgent, stopAcpAgent, ensureAcpAgent, updateAcpAgentInstanceId, setSessionModes, setSessionConfigOptions, updateCurrentMode, updateConfigOptionValue, setAvailableCommands } from '@/lib/ai/acp-agent-state';
+import { acpAgent, stopAcpAgent, ensureAcpAgent, updateAcpAgentInstanceId, setSessionModes, setSessionConfigOptions, updateCurrentMode, updateConfigOptionValue, setAvailableCommands, backfillAcpCapabilities } from '@/lib/ai/acp-agent-state';
 import { setupAcpChatListeners, buildAcpChatCleanup } from '@/hooks/useAcpSessionListeners';
 import { useAgentStatusStore } from '@/stores/agent-status-store';
 
@@ -412,6 +412,7 @@ export function useAcpLifecycle({ effectiveConnection, acpSystemMessage, buildAc
         log.info('ai', `ACP eager session modes: ${JSON.stringify(session.modes)}`);
         setSessionModes(session.modes ?? null);
         setSessionConfigOptions(session.config_options ?? null);
+        backfillAcpCapabilities(effectiveConnection?.id, session);
 
         // Apply user's configured defaults only for fresh sessions. A restoration hit
         // returns the agent's existing mode/config — don't overwrite it.
@@ -711,6 +712,7 @@ export function useAcpLifecycle({ effectiveConnection, acpSystemMessage, buildAc
           log.info('ai', `ACP session config_options: ${JSON.stringify(session.config_options)}`);
           setSessionModes(session.modes ?? null);
           setSessionConfigOptions(session.config_options ?? null);
+          backfillAcpCapabilities(effectiveConnection?.id, session);
 
           // Set model via ACP-native mechanism (replaces CLI arg injection)
           if (effectiveConnection?.config?.model && session.session_id) {
@@ -983,6 +985,7 @@ export function useAcpLifecycle({ effectiveConnection, acpSystemMessage, buildAc
         // Store session modes and config options for UI rendering
         setSessionModes(session.modes ?? null);
         setSessionConfigOptions(session.config_options ?? null);
+        backfillAcpCapabilities(effectiveConnection?.id, session);
 
         // Set model via ACP-native mechanism
         if (effectiveConnection?.config?.model && session.session_id) {

--- a/src/lib/ai/acp-agent-state.ts
+++ b/src/lib/ai/acp-agent-state.ts
@@ -4,6 +4,7 @@
 import { invoke } from '@tauri-apps/api/core';
 import { log } from '@/lib/logger';
 import { usePermissionStore } from '@/stores/permission-store';
+import { useConnectionsStore } from '@/stores/connections-store';
 import { PROVIDER_OPTIONS } from '@/lib/ai/connections';
 import type { Connection, AcpDiscoveredCapabilities } from '@/lib/ai/connections';
 import type { AcpSpawnResult, AcpSessionResult, AcpSessionModeState, AcpSessionConfigOption, AcpAgentCapabilities } from '@/lib/ai/acp-utils';
@@ -459,4 +460,49 @@ export async function probeAcpCapabilities(connection: Connection): Promise<AcpD
       invoke('acp_agent_stop', { instanceId }).catch(() => {});
     }
   }
+}
+
+/**
+ * Backfill `connection.acpCapabilities` from a session/new (or load/resume/fork) response.
+ *
+ * Lazy upgrade path for connections that existed before the capability probe was
+ * introduced (commit 29013ce8): the eager-session response from `useAcpLifecycle`
+ * carries the same `modes` + `config_options` data the probe extracts, so we
+ * populate caps for free whenever the user opens or switches a chat — no extra
+ * spawn, no startup cost.
+ *
+ * No-op when caps are already populated AND fresh (<24h) AND non-empty.
+ */
+export function backfillAcpCapabilities(
+  connectionId: string | undefined,
+  session: { modes?: AcpSessionModeState | null; config_options?: AcpSessionConfigOption[] | null },
+): void {
+  if (!connectionId) return;
+  const connection = useConnectionsStore.getState().getConnection(connectionId);
+  if (!connection || connection.authMethod !== 'agent_managed') return;
+
+  const existing = connection.acpCapabilities;
+  const fresh = !!existing?.lastProbed && Date.now() - existing.lastProbed < 24 * 60 * 60 * 1000;
+  const hasModes = (existing?.availableModes?.length ?? 0) > 0;
+  if (fresh && hasModes) return;
+
+  const next: AcpDiscoveredCapabilities = {
+    ...existing,
+    availableModes: session.modes?.availableModes ?? existing?.availableModes,
+    configOptions:
+      session.config_options?.map((opt) => ({
+        id: opt.id,
+        name: opt.name,
+        description: opt.description,
+        category: opt.category,
+        currentValue: opt.currentValue,
+        options: opt.options,
+      })) ?? existing?.configOptions,
+    supportsLoadSession: existing?.supportsLoadSession ?? false,
+    supportsImages: existing?.supportsImages ?? false,
+    agentVersion: existing?.agentVersion,
+    lastProbed: Date.now(),
+  };
+  useConnectionsStore.getState().updateConnection(connectionId, { acpCapabilities: next });
+  log.info('ai', `Backfilled acpCapabilities for ${connectionId} from eager session`);
 }


### PR DESCRIPTION
## Summary
- Mode picker has been hidden for users whose ACP connections were created before commit 29013ce8 (Apr 19) — `connection.acpCapabilities` was never populated, and the only re-probe path runs when the user opens the Connection Config dialog
- Backfill the field from the session/new response that the eager session already has (no extra spawn, no startup cost) — three call sites in \`useAcpLifecycle\` now invoke \`backfillAcpCapabilities\` after \`setSessionConfigOptions\`
- No-op when caps are already populated and fresh (<24h) to avoid pointless re-renders

## Effect
Users with pre-29013ce8 ACP connections see the picker reappear on next chat open instead of having to re-add the connection or visit the config dialog.

## Test plan
- [ ] Have an existing ACP connection without acpCapabilities (or wipe it via devtools)
- [ ] Open the chat — eager session fires
- [ ] Mode picker (Shield icon) now appears in the chat footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)