### PR TITLE
fix(ci): set up pnpm + Node in aw-alpha-cut cut job

### DIFF
--- a/.github/workflows/aw-alpha-cut.yml
+++ b/.github/workflows/aw-alpha-cut.yml
@@ -139,6 +139,15 @@ jobs:
           token: ${{ secrets.WORKFLOW_PAT }}
           fetch-depth: 0
 
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: "pnpm"
+
       - name: Configure git
         run: |
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
## Summary
- The `cut` job in `aw-alpha-cut.yml` calls `pnpm install --frozen-lockfile && pnpm generate-changelog` without first installing pnpm or Node, so the periodic Alpha Cut workflow fails with `pnpm: command not found` (exit 127).
- Add the same `pnpm/action-setup@v4` + `actions/setup-node@v5` block already used by every other workflow that touches the lockfile (aw-iterate, aw-tdd, aw-sweep, release, test).
- Last reproduced: run 26228274211 on 2026-05-21.

## Test plan
- [ ] CI green on this PR.
- [ ] After merge, next scheduled `AW — Alpha Cut (periodic)` run completes the "Regenerate changelog" step without `pnpm: command not found`.
- [ ] Or run `gh workflow run aw-alpha-cut.yml -f dry_run=true` to verify manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)