### PR TITLE
fix(e2e-real): turn the Cmd+S save flake into a diagnostic failure

### DIFF
--- a/e2e-real/tests/editor.test.ts
+++ b/e2e-real/tests/editor.test.ts
@@ -56,18 +56,52 @@ describe('Editor interactions', () => {
         await typeInEditor(uniqueText);
         console.log(`[editor] Typed unique text: ${uniqueText}`);
 
-        // Save with Cmd+S
+        // Guard against silent type failure: confirm the marker landed in the
+        // editor BEFORE pressing ⌘S. Without this guard the test surfaces as a
+        // "save didn't run" failure when the real cause is "type didn't land",
+        // because Notesage only flushes dirty docs and an empty edit leaves the
+        // tab clean. The previous version pressed ⌘S unconditionally and
+        // failed reading the unmodified file off disk (CI run 77228338009).
+        try {
+            await browser.waitUntil(
+                async () => {
+                    const text = await getEditorText();
+                    return text.includes(uniqueText);
+                },
+                {
+                    timeout: 5_000,
+                    interval: 100,
+                    timeoutMsg: `Editor never showed "${uniqueText}" after typeInEditor — focus likely didn't land on ProseMirror`,
+                },
+            );
+        } catch (err) {
+            // Restore the file before rethrowing — otherwise a failure here
+            // leaves a dirty in-memory tab that the next spec inherits.
+            await tauriInvoke('write_file', { path: filePath, content: originalContent });
+            throw err;
+        }
+
+        // Save with Cmd+S, then poll disk for the marker. Replaces a fixed
+        // 1s sleep that was sometimes too short on macos-latest under load.
         await pressShortcut(['Meta', 's']);
-        await browser.pause(1000);
 
-        // Verify file on disk contains unique text
-        const savedContent = await tauriInvoke<string>('read_file', { path: filePath });
-        console.log(`[editor] Saved content length: ${savedContent.length}`);
-        expect(savedContent).toContain(uniqueText);
-
-        // Restore original
-        await tauriInvoke('write_file', { path: filePath, content: originalContent });
-        console.log('[editor] File restored');
+        try {
+            await browser.waitUntil(
+                async () => {
+                    const onDisk = await tauriInvoke<string>('read_file', { path: filePath });
+                    return onDisk.includes(uniqueText);
+                },
+                {
+                    timeout: 5_000,
+                    interval: 200,
+                    timeoutMsg: `File on disk never contained "${uniqueText}" within 5s of ⌘S — save handler likely did not fire`,
+                },
+            );
+        } finally {
+            // Always restore — even if the assertion above failed.
+            await tauriInvoke('write_file', { path: filePath, content: originalContent });
+            console.log('[editor] File restored');
+        }
     });
 
     it('should not show external change toast after saving', async () => {


### PR DESCRIPTION
## Summary
- The Real-E2E test \`editor.test.ts › should save file to disk with Cmd+S\` failed on PR #314 (run 26241376775 / job 77228338009) with the original unmodified file content, not the typed marker. PR #314 only bumped a Rust crate (\`openssl\` 0.10.79 → 0.10.80) so the failure is a CI flake, not a regression.
- The old shape — \`typeInEditor → ⌘S → browser.pause(1000) → expect(file).toContain(marker)\` — has two distinct failure modes that report the same opaque symptom:
  1. Focus didn't land on ProseMirror, so the type was a no-op, so the tab stayed clean, so ⌘S did nothing.
  2. ⌘S fired but the save flush hadn't finished writing in 1s.
- Replaced with two staged \`waitUntil\` guards. Each fails with a precise diagnostic, and the fixed 1s sleep is gone (the happy path now finishes whenever the save actually completes, typically <500ms).
- Both guards restore the original file content via \`try/catch\` / \`finally\` so a failure can't leave a dirty in-memory tab that poisons the next spec.

## Test plan
- [ ] CI green on this PR (run \`editor.test.ts\` through the Real Tauri E2E job).
- [ ] If the test now fails, the failure message should say either \"Editor never showed … focus likely didn't land\" OR \"File on disk never contained … save handler likely did not fire\" — never both.
- [ ] No regression on the rest of the editor.test.ts suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)