### PR TITLE
fix(release): alpha-2 user-facing notes + workflow stub aligns

### DIFF
--- a/.github/workflows/aw-alpha-cut.yml
+++ b/.github/workflows/aw-alpha-cut.yml
@@ -192,23 +192,27 @@ jobs:
             echo "**Previous version:** ${PREVIOUS_TAG#v}"
             echo "**Channel:** Alpha"
             echo ""
-            echo "Auto-cut by \`aw-alpha-cut\` after Tier-A/B PRs landed. Review the merged PRs listed below to confirm the change set matches your expectations before promoting to stable."
+            echo "Auto-cut by \`aw-alpha-cut\` after Tier-A/B PRs landed. The auto-dump under \"Under the hood\" lists the merged PRs verbatim."
+            echo ""
+            echo "Before promoting this alpha to stable, edit this file:"
+            echo "  - Move anything user-visible from \"Under the hood\" into \"## Changes\" under \`### Features\`, \`### Improvements\`, or \`### Fixes\` — and rewrite each bullet in user-facing prose (drop PR titles, version triples, internal jargon)."
+            echo "  - Leave \"## Changes\" as \`_No user-visible changes._\` for infra-only releases."
+            echo "  - See \`feedback_user_facing_release_notes.md\` and \`scripts/generate-changelog.ts\` linter rules."
             echo ""
             echo "## Changes"
             echo ""
             echo "### Improvements"
             echo ""
+            echo "- **Infrastructure-only release.** Pending hand-edit before stable promotion. The auto-dump under \"Under the hood\" lists merged Tier-A/B PRs verbatim; move anything user-visible up here as \`### Features\` / \`### Improvements\` / \`### Fixes\` and rewrite in user-facing prose. <!-- Generator silently skips releases with no Features/Improvements/Fixes section; keep at least one bullet here. -->"
+            echo ""
+            echo "## Under the hood"
+            echo ""
+            echo "Auto-generated dump of merged Tier-A/B PRs. Rewrite as prose grouped by area before stable promotion."
+            echo ""
             IFS=',' read -ra PRS <<< "$PR_NUMBERS"
             for pr in "${PRS[@]}"; do
               title=$(gh pr view "$pr" --json title --jq .title)
               echo "- ${title} (#${pr})"
-            done
-            echo ""
-            echo "## Under the hood"
-            echo ""
-            echo "Auto-generated. For per-PR detail, see the individual PRs:"
-            for pr in "${PRS[@]}"; do
-              echo "- #${pr}"
             done
           } > "$FILE"
 

--- a/docs/history/120-release-v0.45.0-alpha.2.md
+++ b/docs/history/120-release-v0.45.0-alpha.2.md
@@ -4,25 +4,29 @@
 **Previous version:** 0.45.0-alpha.1
 **Channel:** Alpha
 
-Auto-cut by `aw-alpha-cut` after Tier-A/B PRs landed. Review the merged PRs listed below to confirm the change set matches your expectations before promoting to stable.
+Infrastructure-only release. No user-visible changes vs. alpha.1 — same features, same behaviour. Cut to land the CI plumbing that makes future auto-cuts actually work and to clear two routine dependency patches.
 
 ## Changes
 
 ### Improvements
 
-- fix(ci): aw-alpha-cut pushes to release branch + opens auto-merge PR (#317)
-- fix(e2e-real): turn the Cmd+S save flake into a diagnostic failure (#316)
-- fix(ci): set up pnpm + Node in aw-alpha-cut cut job (#315)
-- chore(deps): bump openssl from 0.10.79 to 0.10.80 in /src-tauri in the cargo group across 1 directory (#314)
-- chore(deps): bump ws from 8.19.0 to 8.20.1 (via audit fix) in /bundled-skills/download-webpage/scripts in the npm_and_yarn group across 1 directory (#313)
-- chore: release v0.45.0-alpha.1 (#312)
+- **Infrastructure-only release.** No user-visible changes vs. alpha.1 — same features, same behaviour. This alpha ships the CI plumbing that makes future auto-cuts actually work, plus two routine dependency patches.
 
 ## Under the hood
 
-Auto-generated. For per-PR detail, see the individual PRs:
-- #317
-- #316
-- #315
-- #314
-- #313
-- #312
+### Auto-cut machinery actually fires end-to-end
+
+`aw-alpha-cut.yml` had two latent bugs that surfaced the first time we tried to fire it. The `cut` job ran `pnpm install` without setting up Node or pnpm and exited 127 (#315). After that was fixed it tried to `git push origin main` directly and was rejected by branch protection because the runner's local commit couldn't satisfy the 4 required status checks (#317). Restructured into two jobs in the same file: `cut` pushes to a `release/v${NEXT_VERSION}` branch and opens an auto-merge PR (going through the same gate as every other PR); `tag-after-merge` fires on the merged PR's close event, tags the merge commit on main, and pushes the tag — which triggers `release.yml` to build the artifacts. The two-job split lets the cut job exit in seconds rather than holding a runner for the entire CI duration.
+
+This alpha is also the first one that rode the new pipeline.
+
+### Real-E2E save-test diagnostic
+
+`editor.test.ts › should save file to disk with Cmd+S` had two distinct failure modes (focus didn't land on ProseMirror; ⌘S didn't flush in 1 s) that both presented as `expected file to contain "SAVE_TEST_<ts>"`. Replaced the fixed 1 s sleep with two staged `waitUntil` guards that fail with precise diagnostics — focus race vs. save-handler-not-firing (#316). Happy path also got faster (no fixed sleep).
+
+### Dependency bumps
+
+- `openssl` 0.10.79 → 0.10.80 (Rust transitive, security patch) — #314.
+- `ws` 8.19.0 → 8.20.1 inside the `bundled-skills/download-webpage` Node script — `npm audit fix` (#313).
+
+Both are mechanical bumps, no behaviour change.

--- a/public/changelog-alpha.json
+++ b/public/changelog-alpha.json
@@ -6,12 +6,7 @@
       "previousVersion": "0.45.0",
       "sections": {
         "improvements": [
-          "fix(ci): aw-alpha-cut pushes to release branch + opens auto-merge PR (#317)",
-          "fix(e2e-real): turn the Cmd+S save flake into a diagnostic failure (#316)",
-          "fix(ci): set up pnpm + Node in aw-alpha-cut cut job (#315)",
-          "chore(deps): bump openssl from 0.10.79 to 0.10.80 in /src-tauri in the cargo group across 1 directory (#314)",
-          "chore(deps): bump ws from 8.19.0 to 8.20.1 (via audit fix) in /bundled-skills/download-webpage/scripts in the npm_and_yarn group across 1 directory (#313)",
-          "chore: release v0.45.0-alpha.1 (#312)"
+          "**Infrastructure-only release.** No user-visible changes vs. alpha.1 — same features, same behaviour. This alpha ships the CI plumbing that makes future auto-cuts actually work, plus two routine dependency patches."
         ]
       }
     },


### PR DESCRIPTION
## Summary
- Rewrote \`docs/history/120-release-v0.45.0-alpha.2.md\` so the user-facing \`### Improvements\` section is one honest bullet ("Infrastructure-only release...") and the six auto-dumped PR titles live under \`## Under the hood\` as prose.
- Already uploaded the regenerated \`public/changelog-alpha.json\` to the \`v0.45.0-alpha.2\` GitHub release via \`gh release upload --clobber\`. The in-app changelog refreshes on next launch — no rebuild needed (per \`project_live_changelog_swap.md\`).
- Aligned \`aw-alpha-cut.yml\`'s history-file generator: \`### Improvements\` gets a single placeholder bullet; the per-PR auto-dump goes under \`## Under the hood\`. Future auto-cuts produce the right shape by default.
- Note for future-self: \`scripts/generate-changelog.ts\` silently skips releases with no \`### Features\` / \`### Improvements\` / \`### Fixes\`. The placeholder bullet exists to prevent that silent disappearance.

## Test plan
- [ ] CI green.
- [ ] In-app changelog (Settings → About → View Changelog) shows v0.45.0-alpha.2 as "Infrastructure-only release" without dev jargon.
- [ ] Next auto-cut (alpha-3, when it fires) produces a history file with placeholder \`### Improvements\` and PR auto-dump under \`## Under the hood\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)