### PR TITLE
chore: release v0.45.0-alpha.5

### DIFF
--- a/docs/history/123-release-v0.45.0-alpha.5.md
+++ b/docs/history/123-release-v0.45.0-alpha.5.md
@@ -1,0 +1,25 @@
+# Release v0.45.0-alpha.5
+
+**Date:** 2026-05-24
+**Previous version:** 0.45.0-alpha.4
+**Channel:** Alpha
+
+Auto-cut by `aw-alpha-cut` after Tier-A/B PRs landed. The auto-dump under "Under the hood" lists the merged PRs verbatim.
+
+Before promoting this alpha to stable, edit this file:
+  - Move anything user-visible from "Under the hood" into "## Changes" under `### Features`, `### Improvements`, or `### Fixes` — and rewrite each bullet in user-facing prose (drop PR titles, version triples, internal jargon).
+  - Leave "## Changes" as `_No user-visible changes._` for infra-only releases.
+  - See `feedback_user_facing_release_notes.md` and `scripts/generate-changelog.ts` linter rules.
+
+## Changes
+
+_No user-visible changes._
+
+## Under the hood
+
+Auto-generated dump of merged Tier-A/B PRs. Rewrite as prose grouped by area before stable promotion.
+
+- fix(editor): restore warm-click perf in Quiet Composer (Tiptap 3.23.6 + EditorState cache re-key) (#346)
+- fix(epub): guard paginator expand() against null this.document on viewer swap (#344)
+- feat(.claude): AW feedback integration — Phases 1-6 complete (closes #336) (#337)
+- chore: remove Classic Layout — Quiet Composer is the only UI shell (#333)

--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -126,3 +126,4 @@ Chronological log of major implementation milestones and changes.
 | 120 | [Release v0.45.0-alpha.2](120-release-v0.45.0-alpha.2.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
 | 121 | [Release v0.45.0-alpha.3](121-release-v0.45.0-alpha.3.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
 | 122 | [Release v0.45.0-alpha.4](122-release-v0.45.0-alpha.4.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
+| 123 | [Release v0.45.0-alpha.5](123-release-v0.45.0-alpha.5.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "notesage",
   "private": true,
-  "version": "0.45.0-alpha.4",
+  "version": "0.45.0-alpha.5",
   "license": "MIT",
   "author": "Peter Blenessy",
   "type": "module",


### PR DESCRIPTION
Auto-cut by `aw-alpha-cut`. The history file at `docs/history/123-release-v0.45.0-alpha.5.md` lists the merged PRs.

## PRs included

- #346
- #344
- #337
- #333

Auto-merge enabled. Once the 4 required status checks pass, this merges to main, and the `tag-after-merge` job in `aw-alpha-cut.yml` tags + pushes `v0.45.0-alpha.5`. `release.yml` then builds and publishes.
