### PR TITLE
docs(release): rewrite v0.45.0-alpha.5 notes with user-facing prose

### DIFF
--- a/docs/history/123-release-v0.45.0-alpha.5.md
+++ b/docs/history/123-release-v0.45.0-alpha.5.md
@@ -4,22 +4,44 @@
 **Previous version:** 0.45.0-alpha.4
 **Channel:** Alpha
 
-Auto-cut by `aw-alpha-cut` after Tier-A/B PRs landed. The auto-dump under "Under the hood" lists the merged PRs verbatim.
-
-Before promoting this alpha to stable, edit this file:
-  - Move anything user-visible from "Under the hood" into "## Changes" under `### Features`, `### Improvements`, or `### Fixes` — and rewrite each bullet in user-facing prose (drop PR titles, version triples, internal jargon).
-  - Leave "## Changes" as `_No user-visible changes._` for infra-only releases.
-  - See `feedback_user_facing_release_notes.md` and `scripts/generate-changelog.ts` linter rules.
+The first alpha after Classic Layout was removed — Quiet Composer is now the only editor shell. Also restores warm-click load time for large documents, which had regressed during the layout transition.
 
 ## Changes
 
-_No user-visible changes._
+### Improvements
+
+- **Quiet Composer is now the only editor shell.** The earlier multi-column workspace with tab strips, the activity panel rail, the chat panel, and the command palette modal has been removed. Everything you used to do there now lives in one of the surfaces you already know: the floating command bar (⌘K) for prompts, palettes, and quick switches; the flat sidebar for Pinned / Projects / Recent / Tags / Mentions; and the document switcher (⌃Tab / ⌃⇧Tab) for cycling recent files. One coherent interface instead of two parallel ones.
+
+- **Large markdown documents reopen in under a second.** A regression introduced during the layout transition meant the editor's document state was being thrown away every time you switched to another file and back. Returning to a long note now feels instant — roughly six times faster on a 500 KB document — and your undo history is preserved across switches.
+
+### Fixes
+
+- **PDF, DOCX, and EPUB viewers no longer log a teardown error.** Switching from an open EPUB to a different file fired one final layout callback after the EPUB had unmounted, throwing a `paginator.js` error into the developer console. The error was non-fatal — the new viewer rendered normally — but it cluttered the console and broke the "clean console after viewer swap" expectation.
 
 ## Under the hood
 
-Auto-generated dump of merged Tier-A/B PRs. Rewrite as prose grouped by area before stable promotion.
+### Editor cache survives single-document eviction
 
-- fix(editor): restore warm-click perf in Quiet Composer (Tiptap 3.23.6 + EditorState cache re-key) (#346)
-- fix(epub): guard paginator expand() against null this.document on viewer swap (#344)
-- feat(.claude): AW feedback integration — Phases 1-6 complete (closes #336) (#337)
-- chore: remove Classic Layout — Quiet Composer is the only UI shell (#333)
+Quiet Composer is a single-document shell — opening any new file evicts the previous one. The per-document `EditorState` cache that powers instant click-back restores was keyed by tab id, which is freshly minted on each open in this shell. The lookup with the new id always missed, forcing every warm click through full worker-parse plus streaming hydrate. Re-keyed the cache by file path so it survives eviction and reopen.
+
+WebDriver-driven measurement on a 502 KB book fixture: warm-click pipeline cost dropped from ~2.3 s to ~320 ms across three back-to-back cycles. (PR #346)
+
+Also picked up an upstream Tiptap fix that removed a per-keystroke document-tree traversal in the Placeholder extension — a separate, additive perf restoration. (PR #346)
+
+### AW pipeline reads from an in-repo feedback corpus
+
+Every AW skill now loads `.claude/feedback/INDEX.md` at start and pulls in the curated rules that target it. Behavioural corrections from interactive sessions — accumulated previously only in local memory — now live in the repo as `feedback_*.md` files with structured frontmatter, indexed automatically, and visible to every future automated run. New corrections land through a `save-feedback` user skill that writes the rule file, regenerates the index, and stages the change for review.
+
+The full six-phase integration: rule promotion, per-skill loaders, structural skill additions, curated rule lists, the save-feedback skill, and a `VALIDATION.md` confirming the corpus catches known past failure modes. (PR #337, closes #336)
+
+### EPUB renderer teardown guard
+
+Added a one-line null guard on `paginator.js`'s `expand()` method that mirrors the existing guard on `render()` — the vendored foliate-js was missing the same defence on the sibling call path. (PR #344)
+
+### Classic Layout deletion
+
+Removed `Layout.tsx`, `TabBar`, `ChatPanel`, `ChatFooter`, `ActivityStrip`, `CommandPalette`, `NewNoteDialog`, `NewProjectDialog`, `KeyboardShortcutsDialog`, `PreviewInvitation`, `RevertInvitation`, and the legacy `SettingsDialog`. Quiet Composer's components stand on their own. CI selectors updated to match the surviving shell; a handful of Classic-only regression tests retired. (PR #333)
+
+### CI runner image pin
+
+Pinned the Real Tauri E2E job to `macos-26` so it stays on Safari 26.4 — the rolled-forward `macos-15-arm64` image bundled Safari 26.5, whose WKWebView regressed the openFile sentinel poll. Belt-and-braces regression-lock test added so future rotations don't silently re-break.

--- a/public/changelog-alpha.json
+++ b/public/changelog-alpha.json
@@ -1,6 +1,20 @@
 {
   "releases": [
     {
+      "version": "0.45.0-alpha.5",
+      "date": "2026-05-24",
+      "previousVersion": "0.45.0",
+      "sections": {
+        "improvements": [
+          "**Quiet Composer is now the only editor shell.** The earlier multi-column workspace with tab strips, the activity panel rail, the chat panel, and the command palette modal has been removed. Everything you used to do there now lives in one of the surfaces you already know: the floating command bar (⌘K) for prompts, palettes, and quick switches; the flat sidebar for Pinned / Projects / Recent / Tags / Mentions; and the document switcher (⌃Tab / ⌃⇧Tab) for cycling recent files. One coherent interface instead of two parallel ones.",
+          "**Large markdown documents reopen in under a second.** A regression introduced during the layout transition meant the editor's document state was being thrown away every time you switched to another file and back. Returning to a long note now feels instant — roughly six times faster on a 500 KB document — and your undo history is preserved across switches."
+        ],
+        "fixes": [
+          "**PDF, DOCX, and EPUB viewers no longer log a teardown error.** Switching from an open EPUB to a different file fired one final layout callback after the EPUB had unmounted, throwing a `paginator.js` error into the developer console. The error was non-fatal — the new viewer rendered normally — but it cluttered the console and broke the \"clean console after viewer swap\" expectation."
+        ]
+      }
+    },
+    {
       "version": "0.45.0-alpha.2",
       "date": "2026-05-21",
       "previousVersion": "0.45.0",


### PR DESCRIPTION
## Summary

The auto-cut placeholder for v0.45.0-alpha.5 had `_No user-visible changes._` under \`## Changes\`, which is wrong for this alpha — it ships three real user-facing items:

- **Quiet Composer is the only editor shell** (Classic Layout removed)
- **Large markdown documents reopen in under a second** (warm-click 6× faster)
- **PDF/DOCX/EPUB viewers no longer log a teardown error on swap**

The auto-cut is working as designed (placeholder + linter, intended to be edited by a human before stable promotion). Doing the edit now because the user-visible changes matter for alpha testers.

Used \`.claude/skills/release/SKILL.md\` user-facing-copy guidance:
- Wrote bullets for non-technical scrolling, not commit messages
- No version triples or "crate" jargon in published sections
- Implementation detail (PR numbers, code paths, file lists) lives under \`## Under the hood\`

Regenerated \`public/changelog-alpha.json\` via \`pnpm generate-changelog\`. The new alpha.5 entry passes the linter clean (the 18 pre-existing warnings in the output are for older releases, not this one).

## Live-swap follow-up

The GitHub Release asset for v0.45.0-alpha.5 was already uploaded by \`release.yml\` before this PR existed. After merge:

\`\`\`
gh release upload v0.45.0-alpha.5 public/changelog-alpha.json --clobber
\`\`\`

Mentioned in the commit message; will execute once this lands.

## Test plan

- [x] \`pnpm generate-changelog\` — alpha.5 entry generates clean, linter clears it
- [x] \`jq '.releases[] | select(.version=="0.45.0-alpha.5")' public/changelog-alpha.json\` — entry has the 2 improvements + 1 fix
- [ ] After merge: \`gh release upload --clobber\` to update the live release asset
- [ ] Verify in-app "What's new" picks up the new prose on next launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)