### PR TITLE
fix(aw): detect unclassified merged PRs in alpha-cut preflight

### DIFF
--- a/.github/workflows/aw-alpha-cut.yml
+++ b/.github/workflows/aw-alpha-cut.yml
@@ -73,8 +73,42 @@ jobs:
           echo "previous_tag=$previous_tag" >> "$GITHUB_OUTPUT"
           echo "Previous alpha: $previous_tag"
 
-          # 2. Tier-A or Tier-B PRs merged since previous_tag?
+          # 2. Check for merged PRs since previous_tag.
           since_iso=$(git log -1 --format=%cI "$previous_tag")
+
+          # 2a. Detect merged PRs with no tier label — refuse to cut until
+          # they are tiered. Human-merged PRs often land without tier labels
+          # (the classifier only fires on bot-authored PRs), which caused the
+          # preflight to evaluate zero qualifying PRs even when real work had
+          # landed. Checking first blocks the cut and surfaces the listing so
+          # the release manager can tier each PR before re-dispatching.
+          echo "Checking for merged PRs without tier labels since $since_iso"
+          unclassified_prs=$(gh pr list \
+            --state merged --base main \
+            --search "merged:>$since_iso -label:tier:A -label:tier:B -label:tier:C" \
+            --json number --jq '.[].number')
+
+          if [[ -n "$unclassified_prs" ]]; then
+            echo "Unclassified merged PRs found — refusing to cut until they are tiered."
+            {
+              echo "## ❌ Alpha cut blocked — unclassified merged PRs"
+              echo ""
+              echo "The following PRs were merged to \`main\` since \`$previous_tag\` without a tier label."
+              echo "Apply \`tier:A\`, \`tier:B\`, or \`tier:C\` to each, then re-dispatch this workflow."
+              echo ""
+              echo "| PR | Title |"
+              echo "|---|---|"
+              gh pr list \
+                --state merged --base main \
+                --search "merged:>$since_iso -label:tier:A -label:tier:B -label:tier:C" \
+                --json number,title \
+                --jq '.[] | "| #\(.number) | \(.title) |"'
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "should_cut=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # 2b. Tier-A or Tier-B PRs merged since previous_tag?
           echo "Looking for tier:A/B PRs merged since $since_iso"
           pr_numbers=$(gh pr list \
             --state merged --base main \

--- a/src/lib/__tests__/aw-alpha-cut-preflight.test.ts
+++ b/src/lib/__tests__/aw-alpha-cut-preflight.test.ts
@@ -1,0 +1,130 @@
+// Regression-lock for issue #351 — aw-alpha-cut preflight silently skips
+// human-merged PRs without tier labels.
+//
+// Background: when a human merges a PR to main without applying a tier label,
+// the preflight's step 2 searches for `label:tier:A,tier:B` PRs and finds
+// zero — reporting "nothing to ship" even though a real PR landed. The
+// workflow exits cleanly with `should_cut=false`, making it look like no
+// work was done.
+//
+// The fix: before (or alongside) the tier:A/B check, query for merged PRs
+// that carry NONE of the three tier labels. If any are found, refuse to cut
+// and write a listing of those PRs (number + title) to the Actions step
+// summary so the human knows exactly what to tier.
+//
+// These tests parse the actual workflow YAML to lock in the new logic.
+// They catch any future drift where someone re-silences the unclassified-PR
+// detection.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { parse as parseYaml } from 'yaml';
+
+interface StepYaml {
+  name?: string;
+  id?: string;
+  run?: string;
+  env?: Record<string, string>;
+  [key: string]: unknown;
+}
+
+interface JobYaml {
+  steps?: StepYaml[];
+  [key: string]: unknown;
+}
+
+interface WorkflowYaml {
+  name: string;
+  jobs: Record<string, JobYaml>;
+}
+
+const WORKFLOW_PATH = resolve(
+  __dirname,
+  '../../../.github/workflows/aw-alpha-cut.yml',
+);
+const YAML_TEXT = readFileSync(WORKFLOW_PATH, 'utf-8');
+
+function checkStepBody(): string {
+  const wf = parseYaml(YAML_TEXT) as WorkflowYaml;
+  const job = wf.jobs?.preflight;
+  expect(job, 'preflight job must exist').toBeDefined();
+  const step = (job?.steps ?? []).find(
+    (s) => s.id === 'check' || s.name === 'Determine whether to cut a new alpha',
+  );
+  expect(step, 'check step must exist in preflight job').toBeDefined();
+  return step?.run ?? '';
+}
+
+describe('aw-alpha-cut preflight — unclassified PR detection (#351)', () => {
+  const body = checkStepBody();
+
+  it('queries for merged PRs with no tier label', () => {
+    // The preflight must issue a gh pr list call that excludes tier:A, tier:B,
+    // and tier:C — so that PRs merged without any tier label are surfaced.
+    // The GitHub search syntax for exclusion is `-label:tier:A`.
+    expect(body).toMatch(/-label:tier:A/);
+    expect(body).toMatch(/-label:tier:B/);
+    expect(body).toMatch(/-label:tier:C/);
+  });
+
+  it('requests number and title for unclassified PRs', () => {
+    // The query for unclassified PRs must request both number and title fields
+    // so they can be listed in the summary.
+    const unclassifiedBlock = extractUnclassifiedBlock(body);
+    expect(unclassifiedBlock).toMatch(/number/);
+    expect(unclassifiedBlock).toMatch(/title/);
+  });
+
+  it('sets should_cut=false when unclassified PRs are found', () => {
+    // The guard must emit should_cut=false into $GITHUB_OUTPUT before exiting.
+    // Extract the block that runs when unclassified PRs are detected.
+    const unclassifiedBlock = extractUnclassifiedBlock(body);
+    expect(unclassifiedBlock).toMatch(/should_cut=false/);
+  });
+
+  it('writes the unclassified PR listing to GITHUB_STEP_SUMMARY', () => {
+    // The human must be able to see which PRs need tiering. Writing to
+    // $GITHUB_STEP_SUMMARY surfaces the listing in the workflow run UI.
+    const unclassifiedBlock = extractUnclassifiedBlock(body);
+    expect(unclassifiedBlock).toMatch(/GITHUB_STEP_SUMMARY/);
+  });
+
+  it('unclassified PR check runs before the no-Tier-A/B early exit', () => {
+    // If the unclassified check ran AFTER the "no tier:A/B PRs" check, a
+    // workflow with only unclassified PRs (no tier:A/B PRs at all) would
+    // exit with "nothing to ship" before ever reaching the unclassified
+    // guard — silently swallowing the unclassified work.
+    const unclassifiedIdx = body.indexOf('-label:tier:A');
+    const nothingToShipIdx = body.indexOf('nothing to ship');
+    expect(unclassifiedIdx, 'unclassified PR query must appear in check body').toBeGreaterThan(-1);
+    expect(nothingToShipIdx, '"nothing to ship" text must appear in check body').toBeGreaterThan(-1);
+    expect(unclassifiedIdx).toBeLessThan(nothingToShipIdx);
+  });
+
+  it('exits without cutting when unclassified PRs exist', () => {
+    // When unclassified PRs are found the step must not continue to set
+    // should_cut=true — it must exit before reaching step 5 (compute version).
+    // The exit 0 after the unclassified check is the gate.
+    const unclassifiedBlock = extractUnclassifiedBlock(body);
+    expect(unclassifiedBlock).toMatch(/exit 0/);
+  });
+});
+
+// ── helper ──────────────────────────────────────────────────────────────────
+
+/**
+ * Extract the bash block that handles the case where unclassified PRs are
+ * found. We look for the if-block that fires on a non-empty unclassified_prs
+ * variable, which must appear BEFORE the "nothing to ship" comment.
+ */
+function extractUnclassifiedBlock(body: string): string {
+  // Match the `if [[ -n "$unclassified..." ]]` block up to its closing `fi`.
+  // We use `\nfi\b` (newline + fi + word-boundary) so we don't stop at `fi`
+  // as a substring inside words like "Unclassified" or "refined".
+  const match = body.match(
+    /if\s*\[\[\s*-n\s*"\$unclassified[^"]*"\s*\]\][\s\S]*?\nfi\b/,
+  );
+  if (!match) return '';
+  return match[0];
+}


### PR DESCRIPTION
Fixes #351

## Summary

The `aw-alpha-cut` preflight was silently reporting "nothing to ship" when human-merged PRs landed without a tier label. The `aw-alpha-prep` classifier only fires on bot-authored PRs, so human merges always skip classification. This PR adds a new check (step 2a) that queries for merged PRs carrying none of `tier:A`, `tier:B`, or `tier:C`. When any are found, the preflight writes a markdown table of offending PRs (number + title) to `$GITHUB_STEP_SUMMARY` and exits with `should_cut=false` — giving the release manager clear visibility into what needs tiering before re-dispatching.

## Red tests added

- `src/lib/__tests__/aw-alpha-cut-preflight.test.ts::queries for merged PRs with no tier label` — preflight bash script uses `-label:tier:A/B/C` negation search syntax
- `src/lib/__tests__/aw-alpha-cut-preflight.test.ts::requests number and title for unclassified PRs` — inner gh call requests `--json number,title` for the listing
- `src/lib/__tests__/aw-alpha-cut-preflight.test.ts::sets should_cut=false when unclassified PRs are found` — if-block emits `should_cut=false` to `$GITHUB_OUTPUT`
- `src/lib/__tests__/aw-alpha-cut-preflight.test.ts::writes the unclassified PR listing to GITHUB_STEP_SUMMARY` — listing appended to `$GITHUB_STEP_SUMMARY`
- `src/lib/__tests__/aw-alpha-cut-preflight.test.ts::unclassified PR check runs before the no-Tier-A/B early exit` — `-label:tier:A` query position precedes `nothing to ship` text
- `src/lib/__tests__/aw-alpha-cut-preflight.test.ts::exits without cutting when unclassified PRs exist` — if-block contains `exit 0`

## Green implementation

- `.github/workflows/aw-alpha-cut.yml` — inserted step 2a between the `since_iso` computation and the existing tier:A/B check; queries for unclassified PRs, writes markdown table to step summary, sets `should_cut=false`, and exits without cutting
- `src/lib/__tests__/aw-alpha-cut-preflight.test.ts` — 6 regression-lock tests parse the workflow YAML and assert each part of the new check

## Refactor

Skipped — implementation is already minimal.

## Decisions made

- **Output mechanism: `$GITHUB_STEP_SUMMARY`** — For a cron/dispatch workflow with no associated issue, `$GITHUB_STEP_SUMMARY` is the most visible output surface (appears in the workflow run UI). A secondary `echo "Unclassified merged PRs found..."` to the step log is also included.
- **Query runs twice** — the first query (`--json number`) checks for the existence of unclassified PRs; the second query (`--json number,title`) builds the listing table. This avoids storing the full JSON in a shell variable only to re-parse it, which is fragile in bash.
- **Placement: before tier:A/B check** — the unclassified guard must fire even when there are also tier:A/B PRs (to prevent silent partial cuts), so it runs before the tier:A/B check. Ordering is regression-locked by the position test.

## Verification

- [x] Red tests were red before implementation
- [x] All red tests now green
- [x] `pnpm test` passes (full suite — 5064 tests, 286 files)
- [x] `pnpm typecheck` clean
- [x] No unrelated files modified

## Notes for reviewer

The "nothing to ship" flow still fires correctly when there truly are no merged PRs since the last tag (they would all appear in the unclassified list too, unless they have tier labels). The happy path (all merged PRs are already tiered) is unaffected — the unclassified query returns empty and the check falls through to the existing tier:A/B logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the `aw-tdd` skill.