### PR TITLE
chore: release v0.45.0

### DIFF
--- a/docs/history/124-release-v0.45.0.md
+++ b/docs/history/124-release-v0.45.0.md
@@ -1,0 +1,45 @@
+# Release v0.45.0
+
+**Date:** 2026-05-24
+**Previous version:** 0.44.0
+**Channel:** Stable
+
+The big change is the editor shell: Quiet Composer is now the only workspace. Plus the usual editor polish, AI-connection clarity, and security pickups.
+
+## Changes
+
+### Improvements
+
+- **Quiet Composer is now the only editor shell.** The floating command bar (⌘K), the flat sidebar (Pinned / Projects / Recent / Tags / Mentions), and the document switcher (⌃Tab / ⌃⇧Tab) are the whole interface. The previous multi-column layout has been retired.
+
+- **Read Only mode tooltip describes what actually happens.** Read Only means the agent has read-only access and silently doesn't try writes — no permission prompts. The tooltip used to suggest the agent would ask first; now it says *"Read access only — agent is denied any write or execute tool calls."*
+
+- **Image hover toolbar works in production builds and matches the other block toolbars.** Hovering an image shows the width and alignment popover with the same look as charts, drawings, and link previews.
+
+- **Microphone button stays in sync across the toolbar and status bar.** Starting on one and stopping on the other works as expected.
+
+- **Empty HTML files show a placeholder.** Opening a 0-byte or whitespace-only `.html` file displays "This HTML file is empty" instead of a blank pane.
+
+- **Multi-line table cells survive export.** Cells containing line breaks round-trip through PDF, DOCX, and HTML export without flattening to a single line.
+
+- **Editor scroll position restores more reliably** when reopening a document.
+
+### Fixes
+
+- **`⌘⇧E` (Export), `⌘⇧L` (Sidebar), `⌘⇧R` (Recording) work again.** An editor extension was silently capturing these chords for paragraph alignment.
+
+- **mermaid diagram security alerts closed.** The bundled mermaid renderer was advanced to close four alerts about Gantt-chart DoS, classDef HTML injection, configuration CSS injection, and classDef CSS injection.
+
+## Known issues
+
+- **Voice dictation can hang the app after extended use.** Start dictation, leave it running for a while, eventually the app becomes unresponsive and requires force-quit. Avoid extended dictation sessions on this release; fix is in progress.
+
+## Under the hood
+
+- **Document switching stays fast in the new shell.** Your undo history and scroll position are preserved when you switch away and come back.
+
+- **Dependencies refreshed across the frontend and backend, including security pickups** for mermaid and the Tauri framework.
+
+- **EPUB viewer cleanup.** Switching from an open EPUB to a different document no longer logs a non-fatal teardown error.
+
+- **Release-pipeline plumbing.** Internal CI work to enable auto-cut alphas and self-improving editor workflow automation. Invisible to users.

--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -127,3 +127,4 @@ Chronological log of major implementation milestones and changes.
 | 121 | [Release v0.45.0-alpha.3](121-release-v0.45.0-alpha.3.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
 | 122 | [Release v0.45.0-alpha.4](122-release-v0.45.0-alpha.4.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
 | 123 | [Release v0.45.0-alpha.5](123-release-v0.45.0-alpha.5.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
+| 124 | [Release v0.45.0](124-release-v0.45.0.md) | Promotes the v0.45.0 alpha series to stable — Quiet Composer is now the only editor shell. |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "notesage",
   "private": true,
-  "version": "0.45.0-alpha.5",
+  "version": "0.45.0",
   "license": "MIT",
   "author": "Peter Blenessy",
   "type": "module",

--- a/public/changelog-alpha.json
+++ b/public/changelog-alpha.json
@@ -1,6 +1,26 @@
 {
   "releases": [
     {
+      "version": "0.45.0",
+      "date": "2026-05-24",
+      "previousVersion": "0.44.0",
+      "sections": {
+        "improvements": [
+          "**Quiet Composer is now the only editor shell.** The floating command bar (⌘K), the flat sidebar (Pinned / Projects / Recent / Tags / Mentions), and the document switcher (⌃Tab / ⌃⇧Tab) are the whole interface. The previous multi-column layout has been retired.",
+          "**Read Only mode tooltip describes what actually happens.** Read Only means the agent has read-only access and silently doesn't try writes — no permission prompts. The tooltip used to suggest the agent would ask first; now it says *\"Read access only — agent is denied any write or execute tool calls.\"*",
+          "**Image hover toolbar works in production builds and matches the other block toolbars.** Hovering an image shows the width and alignment popover with the same look as charts, drawings, and link previews.",
+          "**Microphone button stays in sync across the toolbar and status bar.** Starting on one and stopping on the other works as expected.",
+          "**Empty HTML files show a placeholder.** Opening a 0-byte or whitespace-only `.html` file displays \"This HTML file is empty\" instead of a blank pane.",
+          "**Multi-line table cells survive export.** Cells containing line breaks round-trip through PDF, DOCX, and HTML export without flattening to a single line.",
+          "**Editor scroll position restores more reliably** when reopening a document."
+        ],
+        "fixes": [
+          "**`⌘⇧E` (Export), `⌘⇧L` (Sidebar), `⌘⇧R` (Recording) work again.** An editor extension was silently capturing these chords for paragraph alignment.",
+          "**mermaid diagram security alerts closed.** The bundled mermaid renderer was advanced to close four alerts about Gantt-chart DoS, classDef HTML injection, configuration CSS injection, and classDef CSS injection."
+        ]
+      }
+    },
+    {
       "version": "0.45.0-alpha.5",
       "date": "2026-05-24",
       "previousVersion": "0.45.0",

--- a/public/changelog.json
+++ b/public/changelog.json
@@ -1,6 +1,26 @@
 {
   "releases": [
     {
+      "version": "0.45.0",
+      "date": "2026-05-24",
+      "previousVersion": "0.44.0",
+      "sections": {
+        "improvements": [
+          "**Quiet Composer is now the only editor shell.** The floating command bar (⌘K), the flat sidebar (Pinned / Projects / Recent / Tags / Mentions), and the document switcher (⌃Tab / ⌃⇧Tab) are the whole interface. The previous multi-column layout has been retired.",
+          "**Read Only mode tooltip describes what actually happens.** Read Only means the agent has read-only access and silently doesn't try writes — no permission prompts. The tooltip used to suggest the agent would ask first; now it says *\"Read access only — agent is denied any write or execute tool calls.\"*",
+          "**Image hover toolbar works in production builds and matches the other block toolbars.** Hovering an image shows the width and alignment popover with the same look as charts, drawings, and link previews.",
+          "**Microphone button stays in sync across the toolbar and status bar.** Starting on one and stopping on the other works as expected.",
+          "**Empty HTML files show a placeholder.** Opening a 0-byte or whitespace-only `.html` file displays \"This HTML file is empty\" instead of a blank pane.",
+          "**Multi-line table cells survive export.** Cells containing line breaks round-trip through PDF, DOCX, and HTML export without flattening to a single line.",
+          "**Editor scroll position restores more reliably** when reopening a document."
+        ],
+        "fixes": [
+          "**`⌘⇧E` (Export), `⌘⇧L` (Sidebar), `⌘⇧R` (Recording) work again.** An editor extension was silently capturing these chords for paragraph alignment.",
+          "**mermaid diagram security alerts closed.** The bundled mermaid renderer was advanced to close four alerts about Gantt-chart DoS, classDef HTML injection, configuration CSS injection, and classDef CSS injection."
+        ]
+      }
+    },
+    {
       "version": "0.44.0",
       "date": "2026-05-14",
       "previousVersion": "0.43.1",


### PR DESCRIPTION
Promotes the v0.45.0 alpha series to stable.

Headline change: **Quiet Composer is now the only editor shell** — the multi-column legacy layout has been retired. Plus the cumulative editor polish, AI-connection clarity, security pickups, and infrastructure work from the alpha cycle.

## What's in this PR

- `docs/history/124-release-v0.45.0.md` — consolidated stable release notes (user-facing prose, alpha-internal noise filtered out)
- `package.json` — version bump `0.45.0-alpha.5` → `0.45.0`
- `public/changelog.json` + `public/changelog-alpha.json` — regenerated to include the v0.45.0 entry
- `docs/history/README.md` — index row added

## What happens after merge

1. I (the operator) tag the merge commit \`v0.45.0\` and push the tag
2. \`release.yml\` fires: builds the .dmg + .app.tar.gz + .sig, creates the GitHub Release with \`prerelease: false\`, uploads assets, patches \`latest.json\` URLs to tag-explicit form
3. GitHub auto-marks v0.45.0 as the "Latest" release (because \`prerelease: false\` and newest non-prerelease)
4. Stable users on v0.44.0 are auto-prompted to update on their next check

## Sanity gates run locally before push

- \`pnpm typecheck\` ✓
- \`pnpm test\` ✓ — 5064 tests pass across 286 files
- \`pnpm generate-changelog\` ✓ — v0.45.0 entry is linter-clean (the 18 existing warnings are all on older releases, grandfathered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)