### PR TITLE
fix(viewer): replace HtmlViewer static toolbar with floating pill

### DIFF
--- a/src/components/editor/EditorViewerContainer.tsx
+++ b/src/components/editor/EditorViewerContainer.tsx
@@ -1,7 +1,8 @@
-import { Suspense, lazy } from "react";
+import { Suspense, lazy, useState, useCallback } from "react";
 import { PlainTextViewer } from "./viewers/PlainTextViewer";
 import { StatusBar } from "./StatusBar";
 import { toast } from "sonner";
+import { isHtmlViewerFile } from "@/lib/codemirror-languages";
 
 // Lazy-load heavy viewers — their libraries (pdfjs-dist, docx-preview, foliate-js)
 // are only fetched when the user actually opens that file type.
@@ -40,6 +41,10 @@ interface EditorViewerContainerProps {
 }
 
 export function EditorViewerContainer({ activeTab, focusMode, onOpenFile, onShortcutsOpen, onOpenActions, updateTabContent, saveFile, statusBarVariant = "full" }: EditorViewerContainerProps) {
+  const isHtml = isHtmlViewerFile(activeTab.fileName);
+  const [htmlSourceMode, setHtmlSourceMode] = useState(false);
+  const toggleHtmlSourceMode = useCallback(() => setHtmlSourceMode((v) => !v), []);
+
   let viewer: React.ReactNode = null;
   switch (activeTab.fileType) {
     case "image":
@@ -98,6 +103,8 @@ export function EditorViewerContainer({ activeTab, focusMode, onOpenFile, onShor
               ? (content: string) => { saveFile(activeTab.filePath, content, activeTab.id); }
               : undefined
           }
+          sourceMode={isHtml ? htmlSourceMode : undefined}
+          onToggleSourceMode={isHtml ? toggleHtmlSourceMode : undefined}
         />
       );
       break;
@@ -116,6 +123,8 @@ export function EditorViewerContainer({ activeTab, focusMode, onOpenFile, onShor
           variant={statusBarVariant}
           onShortcutsOpen={onShortcutsOpen}
           onOpenActions={onOpenActions}
+          viewMode={isHtml ? (htmlSourceMode ? "source" : "wysiwyg") : undefined}
+          onToggleViewMode={isHtml ? toggleHtmlSourceMode : undefined}
         />
       )}
     </div>

--- a/src/components/editor/viewers/HtmlViewer.tsx
+++ b/src/components/editor/viewers/HtmlViewer.tsx
@@ -1,10 +1,11 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
-import { Code, Eye, ShieldAlert } from "lucide-react";
+import { Eye, ShieldAlert, Search, ChevronUp, ChevronDown, X } from "lucide-react";
+import { cn } from "@/lib/utils";
 import DOMPurify from "dompurify";
 import { invoke } from "@tauri-apps/api/core";
 import { highlightDomMatches, clearDomHighlights } from "@/lib/dom-search";
-import { FindBar } from "@/components/editor/FindBar";
 import { CodeEditor } from "./CodeEditor";
+import { ViewerToolbarPill } from "./ViewerToolbarPill";
 import { useSettingsStore } from "@/stores/settings-store";
 import { registerZoomController } from "@/hooks/useEditorZoom";
 import {
@@ -26,11 +27,25 @@ interface HtmlViewerProps {
   isDirty: boolean;
   updateTabContent: (content: string) => void;
   saveFileWithContent: (content: string) => void;
+  sourceMode?: boolean;
+  onToggleSourceMode?: () => void;
 }
 
 const ZOOM_STEP = 1.1;
 const ZOOM_MIN = 0.5;
 const ZOOM_MAX = 2.0;
+
+const PILL_BTN =
+  "inline-flex items-center gap-1 h-7 px-2 rounded-full text-xs hover:bg-muted/60 transition-colors disabled:opacity-50 disabled:pointer-events-none";
+
+function PillDivider() {
+  return (
+    <span
+      className="w-px h-3.5 bg-border/60 mx-0.5"
+      aria-hidden="true"
+    />
+  );
+}
 
 // Form tags + attributes that round-trip submission. Forbidden by default so a
 // sanitised .html file can't ship a covert "click here to submit" form. The
@@ -64,13 +79,18 @@ export function HtmlViewer({
   isDirty,
   updateTabContent,
   saveFileWithContent,
+  sourceMode: sourceModeControlled,
+  onToggleSourceMode,
 }: HtmlViewerProps) {
   const allowForms = useSettingsStore((s) => s.htmlViewerAllowForms);
   const allowScripts = useSettingsStore((s) => s.htmlViewerAllowScripts);
   const blockExternal = useSettingsStore((s) => s.htmlViewerBlockExternalResources);
-  const [sourceMode, setSourceMode] = useState(false);
+  const [sourceModeInternal, setSourceModeInternal] = useState(false);
+  const sourceMode = sourceModeControlled ?? sourceModeInternal;
+  const setSourceMode = onToggleSourceMode ?? (() => setSourceModeInternal((v) => !v));
   const [unsafeHtml, setUnsafeHtml] = useState<string | null>(null);
   const [findBarOpen, setFindBarOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
   const [searchMatches, setSearchMatches] = useState<HTMLElement[]>([]);
   const [searchCurrentIndex, setSearchCurrentIndex] = useState(-1);
   const [zoom, setZoom] = useState(1.0);
@@ -80,6 +100,7 @@ export function HtmlViewer({
   const renderRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const searchMatchesRef = useRef<HTMLElement[]>([]);
+  const searchInputRef = useRef<HTMLInputElement>(null);
 
   // Whether the content is empty or whitespace-only (triggers placeholder)
   const isEmpty = content.trim() === "";
@@ -167,7 +188,10 @@ export function HtmlViewer({
   // Listen for Cmd+F / notesage:find-open — only active in rendered mode
   useEffect(() => {
     if (sourceMode) return;
-    const handleFindOpen = () => setFindBarOpen(true);
+    const handleFindOpen = () => {
+      setFindBarOpen(true);
+      requestAnimationFrame(() => searchInputRef.current?.focus());
+    };
     window.addEventListener("notesage:find-open", handleFindOpen);
     return () => window.removeEventListener("notesage:find-open", handleFindOpen);
   }, [sourceMode]);
@@ -244,6 +268,7 @@ export function HtmlViewer({
 
   const handleClose = useCallback(() => {
     setFindBarOpen(false);
+    setSearchQuery("");
     const container = getSearchContainer();
     if (container) clearDomHighlights(container);
     setSearchMatches([]);
@@ -251,30 +276,20 @@ export function HtmlViewer({
     setSearchCurrentIndex(-1);
   }, [getSearchContainer]);
 
-  const toolbarClass =
-    "h-9 border-b border-border px-3 flex items-center gap-2 shrink-0 bg-background";
-
   if (sourceMode) {
     return (
-      <div className="h-full flex flex-col">
-        <div className={toolbarClass} data-testid="html-viewer-toolbar">
-          <span className="text-xs text-muted-foreground truncate max-w-[200px]">
-            {fileName}
-          </span>
-          {isDirty && <span className="text-xs text-muted-foreground">●</span>}
-          <span className="text-xs text-muted-foreground ml-2">Source</span>
-          <div className="ml-auto">
-            <button
-              type="button"
-              aria-label="Switch to rendered view"
-              onClick={() => setSourceMode(false)}
-              className="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-colors border border-border"
-            >
-              <Eye className="h-3.5 w-3.5" aria-hidden="true" />
-              Rendered
-            </button>
-          </div>
-        </div>
+      <div className="h-full flex flex-col relative">
+        <ViewerToolbarPill viewerId="html" scrollRef={scrollContainerRef} className="absolute top-4 left-1/2 -translate-x-1/2">
+          <button
+            type="button"
+            aria-label="Switch to rendered view"
+            onClick={setSourceMode}
+            className={cn(PILL_BTN, "text-muted-foreground")}
+          >
+            <Eye className="h-3.5 w-3.5" strokeWidth={1.5} />
+            <span>Rendered</span>
+          </button>
+        </ViewerToolbarPill>
         <div className="flex-1 min-h-0 overflow-hidden">
           <CodeEditor
             content={content}
@@ -316,58 +331,101 @@ export function HtmlViewer({
         </AlertDialogContent>
       </AlertDialog>
 
-      <div className="h-full flex flex-col">
-        <div className={toolbarClass} data-testid="html-viewer-toolbar">
-          <span className="text-xs text-muted-foreground truncate max-w-[200px]">
-            {fileName}
-          </span>
-          <span className="text-xs text-muted-foreground ml-2">
-            {unsafeMode ? "Unsafe preview" : "Rendered"}
-          </span>
-          {!unsafeMode && zoom !== 1.0 && (
-            <span
-              className="text-xs text-muted-foreground ml-2 tabular-nums"
-              aria-label="Zoom level"
-            >
-              {Math.round(zoom * 100)}%
-            </span>
-          )}
-          <div className="ml-auto flex items-center gap-1.5">
-            <button
-              type="button"
-              aria-label="Unsafe preview mode"
-              title={
-                unsafeMode
-                  ? "Unsafe preview active — scripts are executing"
-                  : "Enable unsafe preview mode (renders scripts)"
-              }
-              onClick={() => {
-                if (!unsafeMode) {
-                  setShowConfirmDialog(true);
-                } else {
-                  setUnsafeMode(false);
+      <div className="h-full flex flex-col relative">
+        <ViewerToolbarPill viewerId="html" scrollRef={scrollContainerRef} className="absolute top-4 left-1/2 -translate-x-1/2">
+          {findBarOpen ? (
+            <>
+              <Search className="h-3.5 w-3.5 text-muted-foreground ml-1.5 shrink-0" strokeWidth={1.5} />
+              <input
+                ref={searchInputRef}
+                type="text"
+                value={searchQuery}
+                onChange={(e) => {
+                  setSearchQuery(e.target.value);
+                  handleSearch(e.target.value);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    if (e.shiftKey) handlePrevious(); else handleNext();
+                  }
+                  if (e.key === "Escape") {
+                    e.preventDefault();
+                    handleClose();
+                  }
+                }}
+                placeholder="Find…"
+                className="bg-transparent border-none outline-none text-xs text-foreground placeholder:text-muted-foreground w-28 px-1"
+                aria-label="Find in document"
+                // eslint-disable-next-line jsx-a11y/no-autofocus
+                autoFocus
+              />
+              {searchMatches.length > 0 && (
+                <span className="text-[10px] text-muted-foreground tabular-nums shrink-0">
+                  {searchCurrentIndex + 1}/{searchMatches.length}
+                </span>
+              )}
+              <button type="button" onClick={handlePrevious} className={cn(PILL_BTN, "text-muted-foreground px-1")} aria-label="Previous match">
+                <ChevronUp className="h-3.5 w-3.5" strokeWidth={1.5} />
+              </button>
+              <button type="button" onClick={handleNext} className={cn(PILL_BTN, "text-muted-foreground px-1")} aria-label="Next match">
+                <ChevronDown className="h-3.5 w-3.5" strokeWidth={1.5} />
+              </button>
+              <button type="button" onClick={handleClose} className={cn(PILL_BTN, "text-muted-foreground px-1")} aria-label="Close find">
+                <X className="h-3.5 w-3.5" strokeWidth={1.5} />
+              </button>
+            </>
+          ) : (
+            <>
+              <button
+                type="button"
+                aria-label="Unsafe preview mode"
+                title={
+                  unsafeMode
+                    ? "Unsafe preview active — scripts are executing"
+                    : "Enable unsafe preview mode (renders scripts)"
                 }
-              }}
-              className={`inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium transition-colors border ${
-                unsafeMode
-                  ? "bg-destructive/10 text-destructive border-destructive/30 hover:bg-destructive/20"
-                  : "text-muted-foreground hover:bg-muted hover:text-foreground border-border"
-              }`}
-            >
-              <ShieldAlert className="h-3.5 w-3.5" aria-hidden="true" />
-              Unsafe preview
-            </button>
-            <button
-              type="button"
-              aria-label="Switch to source view"
-              onClick={() => setSourceMode(true)}
-              className="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-colors border border-border"
-            >
-              <Code className="h-3.5 w-3.5" aria-hidden="true" />
-              Source
-            </button>
-          </div>
-        </div>
+                onClick={() => {
+                  if (!unsafeMode) {
+                    setShowConfirmDialog(true);
+                  } else {
+                    setUnsafeMode(false);
+                  }
+                }}
+                className={cn(
+                  PILL_BTN,
+                  unsafeMode
+                    ? "bg-destructive/10 text-destructive"
+                    : "text-muted-foreground",
+                )}
+              >
+                <ShieldAlert className="h-3.5 w-3.5" strokeWidth={1.5} />
+                {unsafeMode && <span>Unsafe</span>}
+              </button>
+              <PillDivider />
+              <button
+                type="button"
+                onClick={() => {
+                  setFindBarOpen(true);
+                  requestAnimationFrame(() => searchInputRef.current?.focus());
+                }}
+                className={cn(PILL_BTN, "text-muted-foreground")}
+                title="Find (Cmd+F)"
+                aria-label="Find"
+              >
+                <Search className="h-3.5 w-3.5" strokeWidth={1.5} />
+              </button>
+              {!unsafeMode && zoom !== 1.0 && (
+                <>
+                  <PillDivider />
+                  <span className="text-xs text-muted-foreground tabular-nums px-1">
+                    {Math.round(zoom * 100)}%
+                  </span>
+                </>
+              )}
+            </>
+          )}
+        </ViewerToolbarPill>
 
         {/* Content area. Three render paths, in priority order:
             1. Unsafe preview mode (user clicked toolbar toggle + accepted dialog) —
@@ -380,56 +438,42 @@ export function HtmlViewer({
             3. Default — DOMPurify sanitised inline div. */}
         <div
           ref={scrollContainerRef}
-          className="flex-1 overflow-auto relative p-3"
+          className="flex-1 overflow-auto relative"
         >
           {unsafeMode ? (
             <iframe
               srcDoc={content}
               sandbox="allow-scripts"
-              className="w-full h-full border-0 rounded-lg"
+              className="w-full h-full border-0"
               title={`Unsafe preview: ${fileName}`}
             />
+          ) : isEmpty ? (
+            <div
+              className="flex flex-col items-center justify-center gap-2 py-16 text-muted-foreground"
+              aria-label={`Rendered HTML: ${fileName}`}
+            >
+              <span className="text-sm font-medium">This HTML file is empty</span>
+              <span className="text-xs">0 bytes</span>
+            </div>
+          ) : allowScripts && unsafeHtml !== null ? (
+            <iframe
+              sandbox="allow-scripts"
+              srcDoc={unsafeHtml}
+              title={`Rendered HTML (scripts enabled): ${fileName}`}
+              aria-label={`Rendered HTML: ${fileName}`}
+              className="w-full h-full border-0"
+              style={{ minHeight: "60vh", zoom }}
+            />
           ) : (
-            <>
-              <FindBar
-                open={findBarOpen}
-                onClose={handleClose}
-                matchCount={searchMatches.length}
-                currentMatch={searchCurrentIndex}
-                onSearch={handleSearch}
-                onNext={handleNext}
-                onPrevious={handlePrevious}
-                replaceEnabled={false}
-                replaceExpanded={false}
-                onReplaceExpandedChange={() => {}}
+            <div className="p-6">
+              <div
+                ref={renderRef}
+                className="bg-white text-black rounded-lg border border-border shadow-sm p-6 max-w-3xl mx-auto"
+                style={{ zoom }}
+                aria-label={`Rendered HTML: ${fileName}`}
+                dangerouslySetInnerHTML={{ __html: sanitisedBody }}
               />
-              {isEmpty ? (
-                <div
-                  className="flex flex-col items-center justify-center gap-2 py-16 text-muted-foreground"
-                  aria-label={`Rendered HTML: ${fileName}`}
-                >
-                  <span className="text-sm font-medium">This HTML file is empty</span>
-                  <span className="text-xs">0 bytes</span>
-                </div>
-              ) : allowScripts && unsafeHtml !== null ? (
-                <iframe
-                  sandbox="allow-scripts"
-                  srcDoc={unsafeHtml}
-                  title={`Rendered HTML (scripts enabled): ${fileName}`}
-                  aria-label={`Rendered HTML: ${fileName}`}
-                  className="w-full h-full rounded-lg border border-border shadow-sm bg-white"
-                  style={{ minHeight: "60vh", zoom }}
-                />
-              ) : (
-                <div
-                  ref={renderRef}
-                  className="bg-white text-black rounded-lg border border-border shadow-sm p-6 max-w-3xl mx-auto"
-                  style={{ zoom }}
-                  aria-label={`Rendered HTML: ${fileName}`}
-                  dangerouslySetInnerHTML={{ __html: sanitisedBody }}
-                />
-              )}
-            </>
+            </div>
           )}
         </div>
       </div>

--- a/src/components/editor/viewers/PlainTextViewer.tsx
+++ b/src/components/editor/viewers/PlainTextViewer.tsx
@@ -14,6 +14,8 @@ interface PlainTextViewerProps {
   isDirty?: boolean;
   updateTabContent?: (content: string) => void;
   saveFileWithContent?: (content: string) => void;
+  sourceMode?: boolean;
+  onToggleSourceMode?: () => void;
 }
 
 export function PlainTextViewer({
@@ -24,6 +26,8 @@ export function PlainTextViewer({
   isDirty,
   updateTabContent,
   saveFileWithContent,
+  sourceMode,
+  onToggleSourceMode,
 }: PlainTextViewerProps) {
   // Route .html/.htm files to the HTML rendered viewer
   if (isHtmlViewerFile(fileName) && filePath && tabId && updateTabContent && saveFileWithContent) {
@@ -36,6 +40,8 @@ export function PlainTextViewer({
         isDirty={isDirty ?? false}
         updateTabContent={updateTabContent}
         saveFileWithContent={saveFileWithContent}
+        sourceMode={sourceMode}
+        onToggleSourceMode={onToggleSourceMode}
       />
     );
   }
@@ -56,11 +62,11 @@ export function PlainTextViewer({
   }
 
   // Plain text fallback — existing <pre> rendering
-  return <PlainTextFallback content={content} fileName={fileName} />;
+  return <PlainTextFallback content={content} />;
 }
 
-/** Plain text viewer with DOM-based find bar — unchanged from the original. */
-function PlainTextFallback({ content, fileName }: { content: string; fileName: string }) {
+/** Plain text viewer with DOM-based find bar. */
+function PlainTextFallback({ content }: { content: string }) {
   // Search state
   const [findBarOpen, setFindBarOpen] = useState(false);
   const [searchMatches, setSearchMatches] = useState<HTMLElement[]>([]);
@@ -170,13 +176,6 @@ function PlainTextFallback({ content, fileName }: { content: string; fileName: s
 
   return (
     <div ref={viewerRef} className="h-full flex flex-col" tabIndex={-1}>
-      {/* Toolbar */}
-      <div className="h-9 border-b border-border px-3 flex items-center shrink-0 bg-background">
-        <span className="text-xs text-muted-foreground truncate max-w-[200px]">
-          {fileName}
-        </span>
-      </div>
-
       {/* Content area with FindBar overlay */}
       <div className="flex-1 overflow-hidden relative">
         <FindBar

--- a/src/components/editor/viewers/__tests__/HtmlViewer.test.tsx
+++ b/src/components/editor/viewers/__tests__/HtmlViewer.test.tsx
@@ -56,7 +56,7 @@ describe("HtmlViewer", () => {
     expect(document.querySelector("script")).toBeNull();
   });
 
-  it("shows a toggle button to switch between rendered and source modes", () => {
+  it("renders CodeEditor when sourceMode prop is true", () => {
     render(
       <HtmlViewer
         content={htmlContent}
@@ -66,14 +66,14 @@ describe("HtmlViewer", () => {
         isDirty={false}
         updateTabContent={vi.fn()}
         saveFileWithContent={vi.fn()}
+        sourceMode={true}
+        onToggleSourceMode={vi.fn()}
       />
     );
-    // There should be a source-view toggle button in rendered mode
-    const toggleButton = screen.getByRole("button", { name: /switch to source view/i });
-    expect(toggleButton).toBeTruthy();
+    expect(screen.getByTestId("code-editor")).toBeTruthy();
   });
 
-  it("clicking toggle switches to source (CodeEditor) mode", () => {
+  it("renders HTML content when sourceMode prop is false", () => {
     render(
       <HtmlViewer
         content={htmlContent}
@@ -83,20 +83,16 @@ describe("HtmlViewer", () => {
         isDirty={false}
         updateTabContent={vi.fn()}
         saveFileWithContent={vi.fn()}
+        sourceMode={false}
+        onToggleSourceMode={vi.fn()}
       />
     );
-    // Initially in rendered mode — no code editor
     expect(screen.queryByTestId("code-editor")).toBeNull();
-
-    // Click source toggle
-    const toggleButton = screen.getByRole("button", { name: /switch to source view/i });
-    fireEvent.click(toggleButton);
-
-    // Should now show CodeEditor
-    expect(screen.getByTestId("code-editor")).toBeTruthy();
+    expect(screen.getByText("Hello")).toBeTruthy();
   });
 
-  it("clicking toggle again returns to rendered mode", () => {
+  it("calls onToggleSourceMode when Rendered button is clicked in source mode", () => {
+    const toggleFn = vi.fn();
     render(
       <HtmlViewer
         content={htmlContent}
@@ -106,16 +102,12 @@ describe("HtmlViewer", () => {
         isDirty={false}
         updateTabContent={vi.fn()}
         saveFileWithContent={vi.fn()}
+        sourceMode={true}
+        onToggleSourceMode={toggleFn}
       />
     );
-    // Click to enter source mode
-    fireEvent.click(screen.getByRole("button", { name: /switch to source view/i }));
-    expect(screen.getByTestId("code-editor")).toBeTruthy();
-    // Click the rendered-view button to return
     fireEvent.click(screen.getByRole("button", { name: /switch to rendered view/i }));
-    expect(screen.queryByTestId("code-editor")).toBeNull();
-    // Inline-rendered body is back, and the rendered text is visible.
-    expect(screen.getByText("Hello")).toBeTruthy();
+    expect(toggleFn).toHaveBeenCalledOnce();
   });
 });
 

--- a/src/components/editor/viewers/__tests__/PlainTextViewer.test.tsx
+++ b/src/components/editor/viewers/__tests__/PlainTextViewer.test.tsx
@@ -18,7 +18,6 @@ describe("PlainTextViewer", () => {
       <PlainTextViewer content="Hello, world!" fileName="readme.txt" />
     );
     expect(screen.getByText("Hello, world!")).toBeTruthy();
-    expect(screen.getByText("readme.txt")).toBeTruthy();
   });
 
   it("renders plain text in <pre> for .log files", () => {


### PR DESCRIPTION
## Summary
- Replace the static `h-9 border-b` toolbar in HtmlViewer and PlainTextViewer with the shared `ViewerToolbarPill`, matching the Quiet Composer aesthetic used by PDF, DOCX, PPTX, and CodeEditor viewers
- Pill absolutely positioned within the editor view (centred to content area, not viewport)
- Source toggle moved from pill to StatusTray (matches how markdown source mode works)
- Find morphs inline into the pill — search icon transforms into input + match counter + prev/next/close
- PlainTextViewer static toolbar removed (was filename-only, TitleBar handles it)

## Test plan
- [x] All 5064 unit tests pass
- [x] TypeScript type check passes
- [ ] Open an HTML file — pill floats centred at top of content area
- [ ] Cmd+F morphs the pill into search input, Esc collapses back
- [ ] Source toggle appears in StatusTray popover for HTML files
- [ ] Open a plain text file — no static toolbar, just clean content
- [ ] Pill fades on scroll, reappears on mouse move (reduced motion respected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)