### PR TITLE
fix(ci): bump minor (not patch) when starting new alpha series

### DIFF
--- a/.github/workflows/aw-alpha-cut.yml
+++ b/.github/workflows/aw-alpha-cut.yml
@@ -158,11 +158,12 @@ jobs:
           counter=${version#*-alpha.}
 
           # If the stable tag for this base already exists (e.g. v0.45.0 is
-          # released but the last alpha was v0.45.0-alpha.5), bump the patch
-          # and start a new alpha series.
+          # released but the last alpha was v0.45.0-alpha.5), bump the minor
+          # version and start a new alpha series. Alphas are always for the
+          # next feature release, never for patch releases.
           if git tag --list "v${base}" | grep -q .; then
             IFS='.' read -r major minor patch <<< "$base"
-            base="${major}.${minor}.$(( patch + 1 ))"
+            base="${major}.$(( minor + 1 )).0"
             next_version="${base}-alpha.1"
             echo "Stable v${version%-alpha.*} exists — starting new series: v$next_version"
           else


### PR DESCRIPTION
## Summary
- Alpha cut should produce `v0.46.0-alpha.1` after `v0.45.0` stable, not `v0.45.1-alpha.1`
- Alphas are for the next feature release; patches are for hotfixes on stable
- This commit was pushed after PR #365 auto-merged, so the previous alpha cut used the old patch-bump logic

## Test plan
- [ ] Next alpha cut after merge produces `v0.46.0-alpha.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)