### PR TITLE
feat(sidebar): add tooltips to truncated filenames and tag/mention names

### DIFF
--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -2,6 +2,12 @@ import { X } from "lucide-react";
 import { useEditorStore } from "@/stores/editor-store";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 /**
  * TitleBar — top chrome for QuietLayout.
@@ -105,15 +111,24 @@ export function TitleBar(props: TitleBarProps) {
         className="flex-1 flex items-center justify-center min-w-0 px-4"
         data-tauri-drag-region
       >
-        <span
-          className={cn(
-            "text-xs truncate",
-            activeTab ? "text-foreground font-medium" : "text-muted-foreground"
-          )}
-          data-tauri-drag-region
-        >
-          {title}
-        </span>
+        <TooltipProvider delayDuration={300}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span
+                className={cn(
+                  "text-xs truncate",
+                  activeTab ? "text-foreground font-medium" : "text-muted-foreground"
+                )}
+                data-tauri-drag-region
+              >
+                {title}
+              </span>
+            </TooltipTrigger>
+            {activeTab && (
+              <TooltipContent side="bottom">{activeTab.filePath}</TooltipContent>
+            )}
+          </Tooltip>
+        </TooltipProvider>
       </div>
 
       {/* Right: dirty dot + close button. */}

--- a/src/components/__tests__/truncated-filename-tooltips.test.tsx
+++ b/src/components/__tests__/truncated-filename-tooltips.test.tsx
@@ -1,0 +1,221 @@
+// @vitest-environment jsdom
+
+/**
+ * Red tests for issue #361 — truncated filename tooltips.
+ *
+ * Each test verifies that the relevant truncated element is wrapped
+ * in a Radix Tooltip trigger (`data-slot="tooltip-trigger"`) so hovering
+ * reveals the full filename / path / name.
+ */
+
+import '@/test/tauri-mock';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { waitFor } from '@testing-library/react';
+import {
+  renderWithProviders,
+  screen,
+  registerDefaultHandlers,
+} from '@/test/component-harness';
+import { TagsSection } from '@/components/sidebar/quiet/TagsSection';
+import { MentionsSection } from '@/components/sidebar/quiet/MentionsSection';
+import { TitleBar } from '@/components/TitleBar';
+import { PinnedSection } from '@/components/sidebar/quiet/PinnedSection';
+import { RecentSection } from '@/components/sidebar/quiet/RecentSection';
+import { useEditorStore } from '@/stores/editor-store';
+import { useSettingsStore } from '@/stores/settings-store';
+
+// ---------------------------------------------------------------------------
+// Mocks shared across multiple tests
+// ---------------------------------------------------------------------------
+
+const indexTagsMock = vi.fn();
+const indexMentionsMock = vi.fn();
+
+vi.mock('@/lib/tauri', () => ({
+  tauriApi: {
+    indexTags: (...args: unknown[]) => indexTagsMock(...args),
+    indexMentions: (...args: unknown[]) => indexMentionsMock(...args),
+  },
+}));
+
+vi.mock('@/lib/cmd-bar-events', () => ({
+  emitCmdBarEvent: vi.fn(),
+}));
+
+// Workspace store — provide minimal shape for every component that reads it
+const mockWorkspaceState = { projects: [], pinnedFiles: [] as string[], explorerFolders: [], notesTree: [], recentProjects: [] };
+vi.mock('@/stores/workspace-store', () => ({
+  useWorkspaceStore: <T,>(sel: (s: typeof mockWorkspaceState) => T) => sel(mockWorkspaceState),
+}));
+
+// Editor store — module-level mock so all describe blocks can configure it
+vi.mock('@/stores/editor-store', () => ({
+  useEditorStore: vi.fn(),
+}));
+
+// File operations
+const mockOpenFile = vi.fn();
+const mockRenamePath = vi.fn();
+vi.mock('@/hooks/useFileOperations', () => ({
+  useFileOperations: vi.fn(() => ({
+    openFile: mockOpenFile,
+    openFileAtTag: vi.fn(),
+    openFileAtText: vi.fn(),
+    saveFile: vi.fn(),
+    createFile: vi.fn(),
+    createFolder: vi.fn(),
+    renamePath: mockRenamePath,
+    deletePath: vi.fn(),
+    refreshFileTree: vi.fn(),
+  })),
+}));
+
+vi.mock('@/components/sidebar/quiet/FilePreview', () => ({
+  FilePreview: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  isPreviewable: () => false,
+}));
+
+vi.mock('@/components/sidebar/quiet/SidebarContextMenu', () => ({
+  SidebarContextMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SIDEBAR_ENTER_RENAME_MODE_EVENT: 'notesage:sidebar-enter-rename-mode',
+}));
+
+vi.mock('@/components/sidebar/quiet/SidebarRowIndicators', () => ({
+  SidebarRowIndicators: () => null,
+}));
+
+// ---------------------------------------------------------------------------
+// 1. TagsSection — tag name is wrapped in a tooltip trigger
+// ---------------------------------------------------------------------------
+
+describe('TagsSection — truncated tag name tooltip', () => {
+  beforeEach(() => {
+    indexTagsMock.mockReset();
+    useSettingsStore.setState({ sidebarTagsCap: 5 });
+    mockWorkspaceState.projects = [];
+  });
+
+  it('wraps the tag name span in a Tooltip trigger', async () => {
+    indexTagsMock.mockResolvedValue([{ tag: 'averyverylongtagname', file_count: 4 }]);
+    renderWithProviders(<TagsSection />);
+
+    // Wait for the async fetch to settle and the tag row to appear
+    await waitFor(() => expect(screen.getByText('averyverylongtagname')).toBeTruthy());
+
+    // The tag name text node should be inside a tooltip trigger
+    const textEl = screen.getByText('averyverylongtagname');
+    const trigger = textEl.closest('[data-slot="tooltip-trigger"]');
+    expect(trigger).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. MentionsSection — mention name is wrapped in a tooltip trigger
+// ---------------------------------------------------------------------------
+
+describe('MentionsSection — truncated mention name tooltip', () => {
+  beforeEach(() => {
+    indexMentionsMock.mockReset();
+    useSettingsStore.setState({ sidebarMentionsCap: 5 });
+    mockWorkspaceState.projects = [];
+  });
+
+  it('wraps the mention name span in a Tooltip trigger', async () => {
+    indexMentionsMock.mockResolvedValue([{ mention: 'averylongpersonname', file_count: 2 }]);
+    renderWithProviders(<MentionsSection />);
+
+    await waitFor(() => expect(screen.getByText('averylongpersonname')).toBeTruthy());
+
+    const textEl = screen.getByText('averylongpersonname');
+    const trigger = textEl.closest('[data-slot="tooltip-trigger"]');
+    expect(trigger).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. TitleBar — document title is wrapped in a tooltip trigger
+// ---------------------------------------------------------------------------
+
+describe('TitleBar — document title tooltip', () => {
+  const editorState = {
+    openDocuments: [] as Array<{ id: string; fileName: string; isDirty: boolean; filePath: string }>,
+    activeTabId: null as string | null,
+    closeTab: vi.fn(),
+    setPendingCloseTabId: vi.fn(),
+  };
+
+  beforeEach(() => {
+    registerDefaultHandlers();
+    editorState.openDocuments = [];
+    editorState.activeTabId = null;
+    (useEditorStore as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      (sel: (s: typeof editorState) => unknown) => sel(editorState),
+    );
+    (useEditorStore as unknown as { getState: () => typeof editorState }).getState = () => editorState;
+  });
+
+  it('wraps the document filename span in a Tooltip trigger when a file is open', () => {
+    editorState.openDocuments = [
+      { id: 'tab1', fileName: 'a-very-long-document-filename.md', isDirty: false, filePath: '/projects/notes/a-very-long-document-filename.md' },
+    ];
+    editorState.activeTabId = 'tab1';
+
+    renderWithProviders(<TitleBar />);
+
+    const titleEl = screen.getByText('a-very-long-document-filename.md');
+    const trigger = titleEl.closest('[data-slot="tooltip-trigger"]');
+    expect(trigger).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. PinnedSection — pinned filename is wrapped in a tooltip trigger
+// ---------------------------------------------------------------------------
+
+describe('PinnedSection — pinned filename tooltip', () => {
+  beforeEach(() => {
+    (useEditorStore as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      (sel: (s: { recentFiles: unknown[]; openDocuments: unknown[]; activeTabId: null }) => unknown) =>
+        sel({ recentFiles: [], openDocuments: [], activeTabId: null }),
+    );
+    mockWorkspaceState.pinnedFiles = ['/projects/notes/a-very-long-pinned-filename.md'];
+  });
+
+  it('wraps the pinned filename span in a Tooltip trigger', () => {
+    renderWithProviders(<PinnedSection />);
+
+    const nameEl = screen.getByText('a-very-long-pinned-filename.md');
+    const trigger = nameEl.closest('[data-slot="tooltip-trigger"]');
+    expect(trigger).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. RecentSection — recent filename is wrapped in a tooltip trigger
+// ---------------------------------------------------------------------------
+
+describe('RecentSection — recent filename tooltip', () => {
+  beforeEach(() => {
+    useSettingsStore.setState({ sidebarRecentCap: 5 });
+    (useEditorStore as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      (sel: (s: {
+        recentFiles: Array<{ path: string; name: string; lastAccessedAt?: number }>;
+        openDocuments: unknown[];
+        activeTabId: null;
+      }) => unknown) =>
+        sel({
+          recentFiles: [{ path: '/projects/notes/a-very-long-recent-name.md', name: 'a-very-long-recent-name.md' }],
+          openDocuments: [],
+          activeTabId: null,
+        }),
+    );
+  });
+
+  it('wraps the recent filename span in a Tooltip trigger', () => {
+    renderWithProviders(<RecentSection />);
+
+    const nameEl = screen.getByText('a-very-long-recent-name.md');
+    const trigger = nameEl.closest('[data-slot="tooltip-trigger"]');
+    expect(trigger).not.toBeNull();
+  });
+});

--- a/src/components/sidebar/quiet/MentionsSection.tsx
+++ b/src/components/sidebar/quiet/MentionsSection.tsx
@@ -24,6 +24,12 @@ import { useWorkspaceStore } from "@/stores/workspace-store";
 import { useSettingsStore } from "@/stores/settings-store";
 import { emitCmdBarEvent } from "@/lib/cmd-bar-events";
 import { useRovingTabindex } from "@/components/sidebar/quiet/useRovingTabindex";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 /**
  * Default maximum number of mention rows shown before "Show more" expands
@@ -198,10 +204,17 @@ export function MentionsSection({
                   "focus-visible:ring-1 focus-visible:ring-[var(--accent,var(--primary))] focus-visible:z-10",
                 )}
               >
-                <span className="truncate min-w-0">
-                  <span className="text-muted-foreground">@</span>
-                  {mention.name}
-                </span>
+                <TooltipProvider delayDuration={300}>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className="truncate min-w-0">
+                        <span className="text-muted-foreground">@</span>
+                        {mention.name}
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent side="right">@{mention.name}</TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
                 <span className="text-xs text-muted-foreground ml-auto shrink-0">
                   {mention.usageCount}
                 </span>

--- a/src/components/sidebar/quiet/PinnedSection.tsx
+++ b/src/components/sidebar/quiet/PinnedSection.tsx
@@ -43,6 +43,12 @@ import {
   hasFileDrag,
   isBelowMidpoint,
 } from "./file-drag";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 /**
  * PinnedSection — the pinned-files list for the quiet-composer sidebar.
@@ -301,7 +307,14 @@ function PinnedRowImpl({
             />
           ) : (
             <>
-              <span className="truncate min-w-0 flex-1">{name}</span>
+              <TooltipProvider delayDuration={300}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="truncate min-w-0 flex-1">{name}</span>
+                  </TooltipTrigger>
+                  <TooltipContent side="right">{path}</TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
               {/* #129 — git status + external-change dot. Pinned rows are
                  *  always files, so `kind="file"` is hard-coded. */}
               <SidebarRowIndicators path={path} kind="file" />

--- a/src/components/sidebar/quiet/RecentSection.tsx
+++ b/src/components/sidebar/quiet/RecentSection.tsx
@@ -35,6 +35,12 @@ import { FilePreview } from "./FilePreview";
 import { SidebarRowIndicators } from "./SidebarRowIndicators";
 import { formatSavedShort } from "@/lib/saved-ago";
 import { beginFileDrag } from "./file-drag";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 /**
  * RecentSection — quiet-composer sidebar recent-documents list (task #33).
@@ -238,7 +244,14 @@ function RecentRow({
             />
           ) : (
             <>
-              <span className="truncate min-w-0 flex-1">{entry.name}</span>
+              <TooltipProvider delayDuration={300}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="truncate min-w-0 flex-1">{entry.name}</span>
+                  </TooltipTrigger>
+                  <TooltipContent side="right">{entry.path}</TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
               {/* #129 — git status + external-change dot. Recent rows are
                  *  always files, so `kind="file"` is hard-coded. */}
               <SidebarRowIndicators path={entry.path} kind="file" />

--- a/src/components/sidebar/quiet/TagsSection.tsx
+++ b/src/components/sidebar/quiet/TagsSection.tsx
@@ -20,6 +20,12 @@ import { useWorkspaceStore } from "@/stores/workspace-store";
 import { useSettingsStore } from "@/stores/settings-store";
 import { emitCmdBarEvent } from "@/lib/cmd-bar-events";
 import { useRovingTabindex } from "@/components/sidebar/quiet/useRovingTabindex";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 /**
  * Default maximum number of tag rows shown before "Show more" expands the
@@ -196,10 +202,17 @@ export function TagsSection({
                   "focus-visible:ring-1 focus-visible:ring-[var(--accent,var(--primary))] focus-visible:z-10",
                 )}
               >
-                <span className="truncate min-w-0">
-                  <span className="text-muted-foreground">#</span>
-                  {tag.name}
-                </span>
+                <TooltipProvider delayDuration={300}>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className="truncate min-w-0">
+                        <span className="text-muted-foreground">#</span>
+                        {tag.name}
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent side="right">#{tag.name}</TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
                 <span className="text-xs text-muted-foreground ml-auto shrink-0">
                   {tag.usageCount}
                 </span>


### PR DESCRIPTION
Closes #361

## Summary

- Wraps the truncated filename span in `PinnedSection` and `RecentSection` in a Radix `<Tooltip>` — tooltip shows the full absolute path
- Wraps the truncated tag name in `TagsSection` — tooltip shows `#tagname`
- Wraps the truncated mention name in `MentionsSection` — tooltip shows `@mention`
- Wraps the document title span in `TitleBar` — tooltip shows the full file path when a document is open

## Implementation

All five surfaces use the same pattern:
```tsx
<TooltipProvider delayDuration={300}>
  <Tooltip>
    <TooltipTrigger asChild>
      <span className="truncate …">{name}</span>
    </TooltipTrigger>
    <TooltipContent side="right">{fullPath}</TooltipContent>
  </Tooltip>
</TooltipProvider>
```

`asChild` merges `data-slot="tooltip-trigger"` onto the existing `<span>`, so the truncation layout is unchanged. Each component wraps its own `<TooltipProvider>` per the project convention (see `docs/design-system.md` §"Radix Tooltip — `<TooltipProvider>` is mandatory").

## Test plan

- [x] 5 new tests in `src/components/__tests__/truncated-filename-tooltips.test.tsx` — each verifies `textEl.closest('[data-slot="tooltip-trigger"]')` is non-null
- [x] All 5 tests were RED before implementation, GREEN after
- [x] `pnpm test` passes (2 pre-existing failures in `aw-alpha-cut-preflight.test.ts` unrelated to this change, confirmed on `main`)
- [x] `pnpm typecheck` passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)