### PR TITLE
chore: release v0.46.0-alpha.1

### DIFF
--- a/docs/history/126-release-v0.46.0-alpha.1.md
+++ b/docs/history/126-release-v0.46.0-alpha.1.md
@@ -1,0 +1,25 @@
+# Release v0.46.0-alpha.1
+
+**Date:** 2026-05-26
+**Previous version:** 0.45.0-alpha.5
+**Channel:** Alpha
+
+Auto-cut by `aw-alpha-cut` after Tier-A/B PRs landed. The auto-dump under "Under the hood" lists the merged PRs verbatim.
+
+Before promoting this alpha to stable, edit this file:
+  - Move anything user-visible from "Under the hood" into "## Changes" under `### Features`, `### Improvements`, or `### Fixes` — and rewrite each bullet in user-facing prose (drop PR titles, version triples, internal jargon).
+  - Leave "## Changes" as `_No user-visible changes._` for infra-only releases.
+  - See `feedback_user_facing_release_notes.md` and `scripts/generate-changelog.ts` linter rules.
+
+## Changes
+
+_No user-visible changes._
+
+## Under the hood
+
+Auto-generated dump of merged Tier-A/B PRs. Rewrite as prose grouped by area before stable promotion.
+
+- fix(ci): auto-label untiered merged PRs as tier:B in alpha cut (#365)
+- chore: release v0.45.0-alpha.6 (#364)
+- fix(viewer): replace HtmlViewer static toolbar with floating pill (#363)
+- fix(html-viewer): enforce blockExternal on all three render paths (#360) (#362)

--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -129,3 +129,4 @@ Chronological log of major implementation milestones and changes.
 | 123 | [Release v0.45.0-alpha.5](123-release-v0.45.0-alpha.5.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
 | 124 | [Release v0.45.0](124-release-v0.45.0.md) | Promotes the v0.45.0 alpha series to stable — Quiet Composer is now the only editor shell. |
 | 125 | [Release v0.45.0-alpha.6](125-release-v0.45.0-alpha.6.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
+| 126 | [Release v0.46.0-alpha.1](126-release-v0.46.0-alpha.1.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "notesage",
   "private": true,
-  "version": "0.45.0-alpha.6",
+  "version": "0.46.0-alpha.1",
   "license": "MIT",
   "author": "Peter Blenessy",
   "type": "module",


### PR DESCRIPTION
Auto-cut by `aw-alpha-cut`. The history file at `docs/history/126-release-v0.46.0-alpha.1.md` lists the merged PRs.

## PRs included

- #365
- #364
- #363
- #362

Auto-merge enabled. Once the 4 required status checks pass, this merges to main, and the `tag-after-merge` job in `aw-alpha-cut.yml` tags + pushes `v0.46.0-alpha.1`. `release.yml` then builds and publishes.
