### PR TITLE
fix(ci): exclude release PRs from alpha cut to prevent infinite loop

### DIFF
--- a/.github/workflows/aw-alpha-cut.yml
+++ b/.github/workflows/aw-alpha-cut.yml
@@ -82,11 +82,17 @@ jobs:
           # preflight to evaluate zero qualifying PRs even when real work had
           # landed. Checking first blocks the cut and surfaces the listing so
           # the release manager can tier each PR before re-dispatching.
+          # Release PRs ("chore: release v*") are excluded from all queries
+          # below — they are infra artifacts of a previous alpha cut, not
+          # shippable work. Including them would cause an infinite loop:
+          # alpha cut merges a release PR → next cut finds it → cuts again → ∞.
+          release_filter='select(.title | startswith("chore: release") | not)'
+
           echo "Checking for merged PRs without tier labels since $since_iso"
           unclassified_prs=$(gh pr list \
             --state merged --base main \
             --search "merged:>$since_iso -label:tier:A -label:tier:B -label:tier:C" \
-            --json number --jq '.[].number')
+            --json number,title --jq ".[] | $release_filter | .number")
 
           if [[ -n "$unclassified_prs" ]]; then
             echo "Unclassified merged PRs found — auto-labelling as tier:B."
@@ -113,7 +119,7 @@ jobs:
           pr_numbers=$(gh pr list \
             --state merged --base main \
             --search "merged:>$since_iso label:tier:A,tier:B" \
-            --json number --jq '.[].number' | tr '\n' ',' | sed 's/,$//')
+            --json number,title --jq "[.[] | $release_filter | .number] | join(\",\")")
 
           if [[ -z "$pr_numbers" ]]; then
             echo "No Tier-A/B PRs merged since $previous_tag — nothing to ship."


### PR DESCRIPTION
## Summary
- Release PRs (`chore: release v*`) were being counted as "new work" by the alpha cut preflight, causing each alpha to trigger another alpha in an infinite loop
- Root cause: alpha.1's release PR #372 was auto-labelled `tier:A`, then the 6-hour cron found it and cut alpha.2 with zero actual changes
- Fix: filter release PRs from both the unclassified-PR auto-labelling query and the tier:A/B "PRs to ship" query via a jq title filter

## Test plan
- [ ] Next cron-triggered alpha cut does not produce an empty release from its own release PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)