### PR TITLE
fix(html-viewer): fix 10 correctness bugs in HtmlViewer and EditorViewerContainer

### DIFF
--- a/src/components/editor/EditorViewerContainer.tsx
+++ b/src/components/editor/EditorViewerContainer.tsx
@@ -1,4 +1,4 @@
-import { Suspense, lazy, useState, useCallback } from "react";
+import { Suspense, lazy, useState, useCallback, useEffect } from "react";
 import { PlainTextViewer } from "./viewers/PlainTextViewer";
 import { StatusBar } from "./StatusBar";
 import { toast } from "sonner";
@@ -44,6 +44,11 @@ export function EditorViewerContainer({ activeTab, focusMode, onOpenFile, onShor
   const isHtml = isHtmlViewerFile(activeTab.fileName);
   const [htmlSourceMode, setHtmlSourceMode] = useState(false);
   const toggleHtmlSourceMode = useCallback(() => setHtmlSourceMode((v) => !v), []);
+
+  // Bug 5: Reset source mode when the active tab changes
+  useEffect(() => {
+    setHtmlSourceMode(false);
+  }, [activeTab.id]);
 
   let viewer: React.ReactNode = null;
   switch (activeTab.fileType) {

--- a/src/components/editor/viewers/HtmlViewer.tsx
+++ b/src/components/editor/viewers/HtmlViewer.tsx
@@ -24,6 +24,11 @@ import {
 // so the guarantee holds for the sanitised-div, allowScripts iframe, and
 // unsafe-preview iframe paths equally.
 function stripExternalResources(html: string): string {
+  // Bug 9: DOMParser/outerHTML drops the DOCTYPE declaration. Preserve it so
+  // the unsafe-preview iframe srcdoc renders in standards mode.
+  const doctypeMatch = html.match(/^\s*(<!DOCTYPE[^>]*>)\s*/i);
+  const doctype = doctypeMatch ? doctypeMatch[1] : "";
+
   const parser = new DOMParser();
   const doc = parser.parseFromString(html, "text/html");
   const externalPattern = /^https?:/i;
@@ -50,7 +55,29 @@ function stripExternalResources(html: string): string {
       }
     }
   }
-  return doc.documentElement.outerHTML;
+
+  // Bug 2 & 3: Strip additional attributes that can trigger external network
+  // requests: video poster thumbnails, form submission targets, ping beacons,
+  // object data sources, and formaction overrides.
+  for (const attr of ["poster", "formaction", "action", "ping", "data"]) {
+    for (const el of Array.from(doc.querySelectorAll(`[${attr}]`))) {
+      const val = el.getAttribute(attr);
+      if (val && externalPattern.test(val)) el.removeAttribute(attr);
+    }
+  }
+
+  // Bug 1: Strip CSS url() values containing external URLs from inline style
+  // attributes. Replaces e.g. url(https://evil.com/img.gif) with url().
+  const cssUrlExternal = /url\s*\(\s*['"]?\s*https?:[^)'"]*['"]?\s*\)/gi;
+  for (const el of Array.from(doc.querySelectorAll("[style]"))) {
+    const val = el.getAttribute("style");
+    if (val && cssUrlExternal.test(val)) {
+      el.setAttribute("style", val.replace(cssUrlExternal, "url()"));
+    }
+  }
+
+  // Bug 9: Restore the original DOCTYPE before returning.
+  return doctype + doc.documentElement.outerHTML;
 }
 
 interface HtmlViewerProps {
@@ -140,10 +167,17 @@ export function HtmlViewer({
   // file's stylesheet would bleed into the surrounding app chrome.
   // `<body>` content is rendered as a sanitised inline tree.
   const sanitisedBody = useMemo(() => {
-    // Pull out body if a full document was supplied; otherwise treat the
-    // whole content as fragment.
-    const bodyMatch = content.match(/<body[^>]*>([\s\S]*?)<\/body>/i);
-    const fragment = bodyMatch ? bodyMatch[1] : content;
+    // Bug 10: Use DOMParser instead of a non-greedy regex so that occurrences
+    // of </body> inside HTML comments (e.g. <!-- </body> -->) do not truncate
+    // the extracted fragment prematurely.
+    let fragment: string;
+    if (/<body\b/i.test(content)) {
+      const domParser = new DOMParser();
+      const parsedDoc = domParser.parseFromString(content, "text/html");
+      fragment = parsedDoc.body ? parsedDoc.body.innerHTML : content;
+    } else {
+      fragment = content;
+    }
 
     // Apply external-resource stripping before DOMPurify so the guarantee
     // is consistent with the iframe render paths (which use the same utility).
@@ -201,30 +235,41 @@ export function HtmlViewer({
     [content, blockExternal],
   );
 
-  // Reset search state when switching modes or content changes
+  // Reset search state when switching modes, content, or unsafe mode changes.
+  // Bug 7: include setSearchQuery("") so stale query text is cleared.
+  // Bug 6 (defensive): unsafeMode in deps ensures find bar is closed when
+  // switching to iframe mode, even if the bar was programmatically opened.
   useEffect(() => {
     setFindBarOpen(false);
+    setSearchQuery("");
     setSearchMatches([]);
     searchMatchesRef.current = [];
     setSearchCurrentIndex(-1);
-  }, [sourceMode, content]);
+  }, [sourceMode, content, unsafeMode]);
 
-  // Unsafe mode is session-only — reset when the user switches to a different tab
+  // Unsafe mode and zoom are session-only — reset when switching to a different tab.
+  // Bug 8: also reset zoom so the new tab always starts at 1.0, not the
+  // previous tab's zoom level.
   useEffect(() => {
     setUnsafeMode(false);
     setShowConfirmDialog(false);
+    setZoom(1.0);
   }, [tabId]);
 
-  // Listen for Cmd+F / notesage:find-open — only active in rendered mode
+  // Listen for Cmd+F / notesage:find-open — only active in the sanitised-div
+  // render path. Bugs 4 & 6: suppress the event when rendering an iframe
+  // (allowScripts or unsafeMode) because renderRef.current is null in those
+  // paths and DOM-based search would silently fail.
   useEffect(() => {
     if (sourceMode) return;
     const handleFindOpen = () => {
+      if (allowScripts || unsafeMode) return;
       setFindBarOpen(true);
       requestAnimationFrame(() => searchInputRef.current?.focus());
     };
     window.addEventListener("notesage:find-open", handleFindOpen);
     return () => window.removeEventListener("notesage:find-open", handleFindOpen);
-  }, [sourceMode]);
+  }, [sourceMode, allowScripts, unsafeMode]);
 
   // Register as the active zoom controller while rendered. ⌘+ / ⌘- / ⌘0
   // scale the rendered tree via CSS `zoom` (#188).

--- a/src/components/editor/viewers/__tests__/HtmlViewer.test.tsx
+++ b/src/components/editor/viewers/__tests__/HtmlViewer.test.tsx
@@ -1,11 +1,18 @@
 // @vitest-environment jsdom
 import "@/test/tauri-mock";
-import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach, beforeEach, beforeAll } from "vitest";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 import { HtmlViewer } from "../HtmlViewer";
 import { PlainTextViewer } from "../PlainTextViewer";
+import { EditorViewerContainer } from "../../EditorViewerContainer";
 import { useSettingsStore } from "@/stores/settings-store";
 import { setMockInvokeHandler } from "@/test/tauri-mock";
+import { fireZoom } from "@/hooks/useEditorZoom";
+
+// jsdom doesn't implement scrollIntoView — mock it globally
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn();
+});
 
 // Mock CodeEditor to avoid full CodeMirror setup in jsdom
 vi.mock("../CodeEditor", () => ({
@@ -13,6 +20,15 @@ vi.mock("../CodeEditor", () => ({
     <div data-testid="code-editor" data-filename={fileName}>
       {content}
     </div>
+  ),
+}));
+
+// Mock StatusBar to avoid complex store dependencies when testing EditorViewerContainer
+vi.mock("@/components/editor/StatusBar", () => ({
+  StatusBar: ({ onToggleViewMode }: { onToggleViewMode?: () => void }) => (
+    <button data-testid="status-toggle-view" onClick={onToggleViewMode}>
+      Toggle View
+    </button>
   ),
 }));
 
@@ -754,5 +770,308 @@ describe("HtmlViewer — Unsafe preview mode", () => {
     expect(iframe).not.toBeNull();
     // Raw inline script is preserved in srcdoc
     expect(iframe!.getAttribute("srcdoc")).toContain("window._test = 42");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RED tests — 10 correctness bugs identified in issue #375
+// These tests must be RED (failing) before implementation and GREEN after.
+// ---------------------------------------------------------------------------
+
+// Bug 1: CSS url() in inline style attributes not stripped by stripExternalResources
+describe("HtmlViewer — Bug 1: CSS url() in inline style not stripped when blockExternal ON", () => {
+  beforeEach(() => {
+    useSettingsStore.setState({ htmlViewerAllowScripts: false, htmlViewerBlockExternalResources: false } as Parameters<typeof useSettingsStore.setState>[0]);
+  });
+  afterEach(() => {
+    useSettingsStore.setState({ htmlViewerAllowScripts: false, htmlViewerBlockExternalResources: false } as Parameters<typeof useSettingsStore.setState>[0]);
+  });
+
+  it("blockExternal ON + unsafe preview: CSS url() in inline style is stripped from srcdoc", () => {
+    useSettingsStore.setState({ htmlViewerBlockExternalResources: true } as Parameters<typeof useSettingsStore.setState>[0]);
+    render(
+      <HtmlViewer
+        content='<html><body><div style="background-image: url(https://evil.com/img.gif)">Content</div></body></html>'
+        fileName="page.html"
+        filePath="/path/page.html"
+        tabId="tab-bug1"
+        isDirty={false}
+        updateTabContent={vi.fn()}
+        saveFileWithContent={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /unsafe preview/i }));
+    fireEvent.click(screen.getByRole("button", { name: /accept|enable|confirm/i }));
+    const iframe = document.querySelector("iframe");
+    expect(iframe).not.toBeNull();
+    const srcdoc = iframe!.getAttribute("srcdoc") ?? "";
+    expect(srcdoc).not.toMatch(/url\s*\(\s*https?:/i);
+  });
+});
+
+// Bug 2 & 3: Additional HTML attributes (poster, action) not stripped
+describe("HtmlViewer — Bug 2 & 3: poster and form action not stripped when blockExternal ON", () => {
+  beforeEach(() => {
+    useSettingsStore.setState({ htmlViewerAllowScripts: false, htmlViewerBlockExternalResources: false } as Parameters<typeof useSettingsStore.setState>[0]);
+  });
+  afterEach(() => {
+    useSettingsStore.setState({ htmlViewerAllowScripts: false, htmlViewerBlockExternalResources: false } as Parameters<typeof useSettingsStore.setState>[0]);
+  });
+
+  it("blockExternal ON + unsafe preview: video poster attribute is stripped from srcdoc", () => {
+    useSettingsStore.setState({ htmlViewerBlockExternalResources: true } as Parameters<typeof useSettingsStore.setState>[0]);
+    render(
+      <HtmlViewer
+        content='<html><body><video poster="https://evil.com/thumb.jpg"></video></body></html>'
+        fileName="page.html"
+        filePath="/path/page.html"
+        tabId="tab-bug2-poster"
+        isDirty={false}
+        updateTabContent={vi.fn()}
+        saveFileWithContent={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /unsafe preview/i }));
+    fireEvent.click(screen.getByRole("button", { name: /accept|enable|confirm/i }));
+    const iframe = document.querySelector("iframe");
+    expect(iframe).not.toBeNull();
+    const srcdoc = iframe!.getAttribute("srcdoc") ?? "";
+    expect(srcdoc).not.toContain("https://evil.com/thumb.jpg");
+  });
+
+  it("blockExternal ON + unsafe preview: form action attribute is stripped from srcdoc", () => {
+    useSettingsStore.setState({ htmlViewerBlockExternalResources: true } as Parameters<typeof useSettingsStore.setState>[0]);
+    render(
+      <HtmlViewer
+        content='<html><body><form action="https://evil.com/submit"><input type="submit" value="Go"></form></body></html>'
+        fileName="page.html"
+        filePath="/path/page.html"
+        tabId="tab-bug3-action"
+        isDirty={false}
+        updateTabContent={vi.fn()}
+        saveFileWithContent={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /unsafe preview/i }));
+    fireEvent.click(screen.getByRole("button", { name: /accept|enable|confirm/i }));
+    const iframe = document.querySelector("iframe");
+    expect(iframe).not.toBeNull();
+    const srcdoc = iframe!.getAttribute("srcdoc") ?? "";
+    expect(srcdoc).not.toContain("https://evil.com/submit");
+  });
+});
+
+// Bug 4: Find bar opens even when in iframe render mode (allowScripts or unsafeMode)
+describe("HtmlViewer — Bug 4: Find bar opens in iframe modes when it should not", () => {
+  afterEach(() => {
+    useSettingsStore.setState({ htmlViewerAllowScripts: false } as Parameters<typeof useSettingsStore.setState>[0]);
+  });
+
+  it("notesage:find-open event does not open find bar when allowScripts iframe is active", async () => {
+    useSettingsStore.setState({ htmlViewerAllowScripts: true } as Parameters<typeof useSettingsStore.setState>[0]);
+    render(
+      <HtmlViewer
+        content="<html><body><p>Hello</p></body></html>"
+        fileName="page.html"
+        filePath="/path/page.html"
+        tabId="tab-bug4"
+        isDirty={false}
+        updateTabContent={vi.fn()}
+        saveFileWithContent={vi.fn()}
+      />
+    );
+    await waitFor(() => expect(document.querySelector("iframe")).not.toBeNull());
+    fireEvent(window, new Event("notesage:find-open"));
+    expect(document.querySelector('input[aria-label="Find in document"]')).toBeNull();
+  });
+});
+
+// Bug 5: htmlSourceMode not reset when switching between HTML tabs in EditorViewerContainer
+describe("EditorViewerContainer — Bug 5: htmlSourceMode leaks across HTML tab switches", () => {
+  const makeHtmlTab = (id: string) => ({
+    id,
+    filePath: `/path/${id}.html`,
+    fileName: `${id}.html`,
+    fileType: "other" as const,
+    content: "<html><body><p>Hello</p></body></html>",
+    isDirty: false,
+  });
+
+  it("htmlSourceMode resets to false when switching to a different HTML tab", () => {
+    const tab1 = makeHtmlTab("evc-bug5-a");
+    const tab2 = makeHtmlTab("evc-bug5-b");
+    // updateTabContent and saveFile are required for PlainTextViewer to route to HtmlViewer
+    const updateTabContent = vi.fn();
+    const saveFile = vi.fn().mockResolvedValue(true);
+    const { rerender } = render(
+      <EditorViewerContainer
+        activeTab={tab1}
+        focusMode={false}
+        updateTabContent={updateTabContent}
+        saveFile={saveFile}
+      />
+    );
+    // Activate source mode via the mocked StatusBar toggle
+    fireEvent.click(screen.getByTestId("status-toggle-view"));
+    // Source mode ON — CodeEditor must be visible
+    expect(screen.getByTestId("code-editor")).toBeTruthy();
+    // Switch to a different tab
+    rerender(
+      <EditorViewerContainer
+        activeTab={tab2}
+        focusMode={false}
+        updateTabContent={updateTabContent}
+        saveFile={saveFile}
+      />
+    );
+    // Source mode must have reset — no CodeEditor
+    expect(screen.queryByTestId("code-editor")).toBeNull();
+  });
+});
+
+// Bug 6: notesage:find-open event opens find bar even when unsafeMode (iframe) is active
+describe("HtmlViewer — Bug 6: notesage:find-open opens find bar in unsafeMode", () => {
+  beforeEach(() => {
+    useSettingsStore.setState({ htmlViewerAllowScripts: false } as Parameters<typeof useSettingsStore.setState>[0]);
+  });
+  afterEach(() => {
+    useSettingsStore.setState({ htmlViewerAllowScripts: false } as Parameters<typeof useSettingsStore.setState>[0]);
+  });
+
+  it("notesage:find-open event does not open find bar when unsafeMode iframe is active", () => {
+    render(
+      <HtmlViewer
+        content="<html><body><p>Hello</p></body></html>"
+        fileName="page.html"
+        filePath="/path/page.html"
+        tabId="tab-bug6"
+        isDirty={false}
+        updateTabContent={vi.fn()}
+        saveFileWithContent={vi.fn()}
+      />
+    );
+    // Activate unsafe preview mode
+    fireEvent.click(screen.getByRole("button", { name: /unsafe preview/i }));
+    fireEvent.click(screen.getByRole("button", { name: /accept|enable|confirm/i }));
+    // Now in unsafe iframe mode — fire find-open event
+    fireEvent(window, new Event("notesage:find-open"));
+    // Find bar must NOT open (useless/broken in iframe mode — renderRef is null)
+    expect(document.querySelector('input[aria-label="Find in document"]')).toBeNull();
+  });
+});
+
+// Bug 7: searchQuery state not cleared when content changes (reset effect is incomplete)
+describe("HtmlViewer — Bug 7: searchQuery not cleared when content changes", () => {
+  it("search query input is empty when find bar is reopened after content change", () => {
+    const { rerender } = render(
+      <HtmlViewer
+        content="<html><body><p>Hello world</p></body></html>"
+        fileName="page.html"
+        filePath="/path/page.html"
+        tabId="tab-bug7"
+        isDirty={false}
+        updateTabContent={vi.fn()}
+        saveFileWithContent={vi.fn()}
+      />
+    );
+    // Open find bar and type a query
+    fireEvent.click(screen.getByRole("button", { name: "Find" }));
+    const input = document.querySelector('input[aria-label="Find in document"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "Hello" } });
+    expect(input.value).toBe("Hello");
+    // Change content — triggers the reset effect
+    rerender(
+      <HtmlViewer
+        content="<html><body><p>Different content entirely</p></body></html>"
+        fileName="page.html"
+        filePath="/path/page.html"
+        tabId="tab-bug7"
+        isDirty={false}
+        updateTabContent={vi.fn()}
+        saveFileWithContent={vi.fn()}
+      />
+    );
+    // Reopen find bar
+    fireEvent.click(screen.getByRole("button", { name: "Find" }));
+    const inputAfter = document.querySelector('input[aria-label="Find in document"]') as HTMLInputElement;
+    // Query must be cleared — not the stale "Hello" from the previous file
+    expect(inputAfter.value).toBe("");
+  });
+});
+
+// Bug 8: zoom state not reset when tabId changes
+describe("HtmlViewer — Bug 8: zoom not reset on tab switch", () => {
+  afterEach(() => {
+    // Reset the module-level zoom controller after each test
+    act(() => { fireZoom("reset"); });
+  });
+
+  it("zoom resets to 1.0 (zoom indicator disappears) when tabId changes", () => {
+    const commonProps = {
+      content: "<html><body><p>Hello</p></body></html>",
+      fileName: "page.html",
+      filePath: "/path/page.html",
+      isDirty: false,
+      updateTabContent: vi.fn(),
+      saveFileWithContent: vi.fn(),
+    };
+    const { rerender } = render(<HtmlViewer {...commonProps} tabId="tab-bug8-a" />);
+    // Trigger zoom in via the registered viewer zoom controller
+    act(() => { fireZoom("in"); });
+    // Zoom indicator should be visible (non-1.0 zoom)
+    expect(screen.getByText("110%")).toBeTruthy();
+    // Switch to a different tab
+    rerender(<HtmlViewer {...commonProps} tabId="tab-bug8-b" />);
+    // Zoom must reset — zoom indicator should disappear
+    expect(screen.queryByText("110%")).toBeNull();
+  });
+});
+
+// Bug 9: DOCTYPE declaration dropped by stripExternalResources
+describe("HtmlViewer — Bug 9: DOCTYPE dropped by stripExternalResources", () => {
+  beforeEach(() => {
+    useSettingsStore.setState({ htmlViewerAllowScripts: false, htmlViewerBlockExternalResources: false } as Parameters<typeof useSettingsStore.setState>[0]);
+  });
+  afterEach(() => {
+    useSettingsStore.setState({ htmlViewerAllowScripts: false, htmlViewerBlockExternalResources: false } as Parameters<typeof useSettingsStore.setState>[0]);
+  });
+
+  it("blockExternal ON + unsafe preview: DOCTYPE html is preserved in iframe srcdoc", () => {
+    useSettingsStore.setState({ htmlViewerBlockExternalResources: true } as Parameters<typeof useSettingsStore.setState>[0]);
+    render(
+      <HtmlViewer
+        content='<!DOCTYPE html><html><body><img src="https://evil.com/img.jpg"></body></html>'
+        fileName="page.html"
+        filePath="/path/page.html"
+        tabId="tab-bug9"
+        isDirty={false}
+        updateTabContent={vi.fn()}
+        saveFileWithContent={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /unsafe preview/i }));
+    fireEvent.click(screen.getByRole("button", { name: /accept|enable|confirm/i }));
+    const iframe = document.querySelector("iframe");
+    expect(iframe).not.toBeNull();
+    const srcdoc = iframe!.getAttribute("srcdoc") ?? "";
+    expect(srcdoc.toLowerCase()).toContain("<!doctype");
+  });
+});
+
+// Bug 10: Body extraction regex truncates on </body> inside HTML comments
+describe("HtmlViewer — Bug 10: Body extraction truncates on </body> inside HTML comment", () => {
+  it("renders content that appears after a comment containing </body>", () => {
+    render(
+      <HtmlViewer
+        content="<html><body><!-- </body> --><p>After comment</p></body></html>"
+        fileName="page.html"
+        filePath="/path/page.html"
+        tabId="tab-bug10"
+        isDirty={false}
+        updateTabContent={vi.fn()}
+        saveFileWithContent={vi.fn()}
+      />
+    );
+    expect(screen.getByText("After comment")).toBeTruthy();
   });
 });


### PR DESCRIPTION
Closes #375

## Summary

- **Bug 1**: `stripExternalResources()` now strips `url(https://...)` patterns from inline `style` attributes
- **Bug 2 & 3**: Strips `poster`, `action`, `formaction`, `ping`, and `data` attributes with external URLs
- **Bug 4 & 6**: `notesage:find-open` listener now guards against opening the find bar when rendering in allowScripts iframe or unsafe-preview iframe modes
- **Bug 5**: `EditorViewerContainer` resets `htmlSourceMode` to `false` when `activeTab.id` changes, preventing stale source-mode state from leaking across tab switches
- **Bug 7**: Content-change reset effect now also clears `searchQuery`, so a reopened find bar starts empty
- **Bug 8**: Tab-change reset effect now resets zoom to `1.0`
- **Bug 9**: `stripExternalResources()` detects and re-prepends the DOCTYPE declaration (previously dropped when reconstructing from `document.documentElement.outerHTML`)
- **Bug 10**: Body content extraction now uses `DOMParser` instead of a non-greedy regex, which correctly handles `</body>` appearing inside HTML comments

## Test plan

- [x] 10 new tests added to `HtmlViewer.test.tsx`, one per bug, verified RED before implementation
- [x] All 10 tests pass GREEN after implementation
- [x] Full test suite passes: `pnpm test` → 5089 tests / 287 files, 0 failures
- [x] TypeScript typecheck clean: `pnpm typecheck` → no errors
- [x] Only modified files listed in the subtask: `HtmlViewer.tsx`, `EditorViewerContainer.tsx`, `HtmlViewer.test.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)