### PR TITLE
chore: release v0.46.0-alpha.3

### DIFF
--- a/docs/history/128-release-v0.46.0-alpha.3.md
+++ b/docs/history/128-release-v0.46.0-alpha.3.md
@@ -1,0 +1,22 @@
+# Release v0.46.0-alpha.3
+
+**Date:** 2026-05-27
+**Previous version:** 0.46.0-alpha.2
+**Channel:** Alpha
+
+Auto-cut by `aw-alpha-cut` after Tier-A/B PRs landed. The auto-dump under "Under the hood" lists the merged PRs verbatim.
+
+Before promoting this alpha to stable, edit this file:
+  - Move anything user-visible from "Under the hood" into "## Changes" under `### Features`, `### Improvements`, or `### Fixes` — and rewrite each bullet in user-facing prose (drop PR titles, version triples, internal jargon).
+  - Leave "## Changes" as `_No user-visible changes._` for infra-only releases.
+  - See `feedback_user_facing_release_notes.md` and `scripts/generate-changelog.ts` linter rules.
+
+## Changes
+
+_No user-visible changes._
+
+## Under the hood
+
+Auto-generated dump of merged Tier-A/B PRs. Rewrite as prose grouped by area before stable promotion.
+
+- fix(html-viewer): fix 10 bugs from v0.46.0 code review (#375) (#377)

--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -131,3 +131,4 @@ Chronological log of major implementation milestones and changes.
 | 125 | [Release v0.45.0-alpha.6](125-release-v0.45.0-alpha.6.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
 | 126 | [Release v0.46.0-alpha.1](126-release-v0.46.0-alpha.1.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
 | 127 | [Release v0.46.0-alpha.2](127-release-v0.46.0-alpha.2.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
+| 128 | [Release v0.46.0-alpha.3](128-release-v0.46.0-alpha.3.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "notesage",
   "private": true,
-  "version": "0.46.0-alpha.2",
+  "version": "0.46.0-alpha.3",
   "license": "MIT",
   "author": "Peter Blenessy",
   "type": "module",


### PR DESCRIPTION
Auto-cut by `aw-alpha-cut`. The history file at `docs/history/128-release-v0.46.0-alpha.3.md` lists the merged PRs.

## PRs included

- #377

Auto-merge enabled. Once the 4 required status checks pass, this merges to main, and the `tag-after-merge` job in `aw-alpha-cut.yml` tags + pushes `v0.46.0-alpha.3`. `release.yml` then builds and publishes.
