### PR TITLE
feat(release): surface merged-PR dump in alpha release notes

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -34,7 +34,7 @@ Bump the version, generate a changelog, and create a release history entry.
 
 6. **Create a release history entry** at `docs/history/NNN-release-vX.Y.Z.md`.
 
-   **CRITICAL — tone for the three user-facing sections.** The `Features`, `Fixes`, and `Improvements` sections are extracted by `scripts/generate-changelog.ts` into `public/changelog.json`, which is shipped to end users as the in-app "What's new". Write those bullets for a non-technical user scrolling through versions. Any other `###` heading (like `Under the hood`) is **not** extracted — put task numbers, file paths, commit hashes, and implementation jargon there.
+   **CRITICAL — tone for the three user-facing sections.** The `Features`, `Fixes`, and `Improvements` sections are extracted by `scripts/generate-changelog.ts` into `public/changelog.json`, which is shipped to end users as the in-app "What's new". Write those bullets for a non-technical user scrolling through versions. For **stable** releases, any other `###` heading (like `Under the hood`) is **not** extracted — put task numbers, file paths, commit hashes, and implementation jargon there. (For **alpha** prereleases, `## Under the hood` IS surfaced — see §"User-facing copy vs Under the hood" for the exception.)
 
    **Before writing,** open the two most recent prior `docs/history/*.md` files and match their tone. Describe what the user will notice or can now do, not what file changed or which subsystem moved.
 
@@ -126,6 +126,17 @@ This monitoring should run in the background so it does not block other work.
 ## User-facing copy vs Under the hood
 
 The `### Features`, `### Improvements`, and `### Fixes` sections in every release history file are extracted by `scripts/generate-changelog.ts` and shipped to end users as the in-app "What's new" feed. A non-technical user scrolling through versions must be able to understand every bullet in those three sections without knowing what a crate, Dependabot alert, classDef, or IPC is.
+
+### Alpha exception — `## Under the hood` IS surfaced for prereleases
+
+For **stable** releases (no `-` in the version), `## Under the hood` is private — never extracted, never shown to users. This is where you put task numbers, file paths, and jargon.
+
+For **alpha** releases (prerelease versions like `0.46.0-alpha.5`), `## Under the hood` IS surfaced, in two places:
+
+- `scripts/generate-changelog.ts` attaches its bullet list to the entry as `underTheHood[]`, which the in-app Changelog renders as an "Under the hood" section (alpha channel only — the stable feed strips prerelease entries entirely).
+- `release.yml` includes the `## Under the hood` section in the GitHub Release body for prerelease tags.
+
+This is deliberate: alpha testers want to see exactly which merged PRs made each auto-cut, and `aw-alpha-cut` writes those PRs into `## Under the hood` verbatim. **When you promote an alpha to stable via this skill, you still must rewrite that dump into curated user-facing prose** — the stable release notes never carry the raw PR list.
 
 ### Forbidden in user-facing bullets (Features / Improvements / Fixes)
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,15 +54,30 @@ jobs:
             exit 1
           fi
 
-          # Extract user-facing content: everything between "## Changes" and
-          # "## Under the hood" (or end of file). The stop condition fires ONLY
-          # on "## Under the hood" — sections like "## Known issues" and
-          # "## Known limitations" are user-facing and must be included.
-          awk '
-            /^## Changes/{found=1; next}
-            found && /^## Under the hood/{exit}
-            found{print}
-          ' "$HISTORY_FILE" > /tmp/release_notes.md
+          # Release-note body depends on the channel:
+          #
+          #   Stable (no `-` in the version): user-facing content only —
+          #   everything between "## Changes" and "## Under the hood". The stop
+          #   fires ONLY on "## Under the hood"; sections like "## Known issues"
+          #   and "## Known limitations" are user-facing and must be included.
+          #
+          #   Alpha (prerelease, e.g. `0.46.0-alpha.5`): include "## Under the
+          #   hood" too, so the merged-PR dump is visible on the GitHub Release
+          #   page — that's what made the cut. Auto-cut alphas have no curated
+          #   "## Changes" yet, so without this the body reads only
+          #   "_No user-visible changes._".
+          if [[ "$VERSION" == *-* ]]; then
+            awk '
+              /^## Changes/{found=1; next}
+              found{print}
+            ' "$HISTORY_FILE" > /tmp/release_notes.md
+          else
+            awk '
+              /^## Changes/{found=1; next}
+              found && /^## Under the hood/{exit}
+              found{print}
+            ' "$HISTORY_FILE" > /tmp/release_notes.md
+          fi
 
           # Set as output using delimiter
           echo "notes<<NOTES_EOF" >> $GITHUB_OUTPUT

--- a/docs/agentic-workflow.md
+++ b/docs/agentic-workflow.md
@@ -173,7 +173,16 @@ Fifteen workflow files. One *pipeline* + one *sweep* + four *standalones* + one 
 | `aw-alpha-prep.yml` | `pull_request.ready_for_review`, `pull_request.opened` | Tier classifier. Labels bot PRs `tier:A` / `tier:B` / `tier:C` based on issue labels (hitl/visual), touched paths (load-bearing list), and diff size. `chore(deps):` PRs with prod_additions < 50 fast-path to Tier A. Single source of truth for the release routing decision. |
 | `aw-merge.yml` | `pull_request.labeled` (filter `tier:A` + `claude/*` head ref), `workflow_dispatch` | Enables GitHub native auto-merge (squash) on Tier-A bot PRs. Merge fires when CI green + required reviews satisfied. Tier B/C are NOT touched here. |
 | `aw-rebase.yml` | cron `*/15`, `workflow_dispatch` | Queue-collision recovery: when a Tier-A merge knocks other auto-merge PRs BEHIND main, this sweep calls `update-branch` (clean three-way merge). DIRTY conflicts or lockfile conflicts → disable auto-merge, add `needs-human`, post comment. |
-| `aw-alpha-cut.yml` | cron `0 */6 * * *`, `workflow_dispatch`, `pull_request.closed` (head ref `release/v*`) | Two-job release cutter. `cut` (cron + dispatch): bumps `package.json`, generates `docs/history/NNN-release-vX.Y.Z-alpha.M.md`, regenerates `public/changelog-alpha.json`, pushes to `release/v${NEXT_VERSION}`, opens an auto-merge PR. `tag-after-merge` (PR closed): tags the merge commit `v${NEXT_VERSION}` and pushes the tag, which fires `release.yml`. |
+| `aw-alpha-cut.yml` | cron `0 */6 * * *`, `workflow_dispatch`, `pull_request.closed` (head ref `release/v*`) | Two-job release cutter. `cut` (cron + dispatch): bumps `package.json`, generates `docs/history/NNN-release-vX.Y.Z-alpha.M.md` (merged PRs dumped verbatim under `## Under the hood`), regenerates `public/changelog-alpha.json`, pushes to `release/v${NEXT_VERSION}`, opens an auto-merge PR. `tag-after-merge` (PR closed): tags the merge commit `v${NEXT_VERSION}` and pushes the tag, which fires `release.yml`. |
+
+### Alpha release notes surface the merged-PR dump
+
+Auto-cut alphas have no curated `## Changes` yet, so their user-facing notes would otherwise read only "_No user-visible changes._". To let alpha testers see what made each cut, the `## Under the hood` PR dump is surfaced for **prerelease** versions only:
+
+- `scripts/generate-changelog.ts` attaches the dump to the entry as `underTheHood[]`; the in-app Changelog (alpha channel) renders it as an "Under the hood" section. The stable feed (`changelog.json`) strips prerelease entries entirely, so stable never carries it.
+- `release.yml` includes the `## Under the hood` section in the GitHub Release body when the tag is a prerelease; stable tags stop at `## Under the hood` exactly as before.
+
+Promotion to stable (the `release` skill) still rewrites the dump into curated prose — the raw PR list never reaches stable release notes.
 
 Each precheck-bearing workflow finds candidates with `gh + jq` before invoking the LLM (zero token cost on empty sweeps). Cron tick is every 15 minutes.
 

--- a/public/changelog-alpha.json
+++ b/public/changelog-alpha.json
@@ -1,6 +1,64 @@
 {
   "releases": [
     {
+      "version": "0.46.0-alpha.6",
+      "date": "2026-05-29",
+      "previousVersion": "0.46.0",
+      "sections": {},
+      "underTheHood": [
+        "feat(ai): plumb response_format for schema-constrained local LLM output (#383)"
+      ]
+    },
+    {
+      "version": "0.46.0-alpha.5",
+      "date": "2026-05-28",
+      "previousVersion": "0.46.0",
+      "sections": {},
+      "underTheHood": [
+        "feat(quiet-chrome): extend Aggressive preset with title bar + cmd bar fade and mouse-only unfade (#381)"
+      ]
+    },
+    {
+      "version": "0.46.0-alpha.4",
+      "date": "2026-05-27",
+      "previousVersion": "0.46.0",
+      "sections": {},
+      "underTheHood": [
+        "fix(ci): exclude release PRs from alpha cut to prevent infinite loop (#374)"
+      ]
+    },
+    {
+      "version": "0.46.0-alpha.3",
+      "date": "2026-05-27",
+      "previousVersion": "0.46.0",
+      "sections": {},
+      "underTheHood": [
+        "fix(html-viewer): fix 10 bugs from v0.46.0 code review (#375) (#377)"
+      ]
+    },
+    {
+      "version": "0.46.0-alpha.2",
+      "date": "2026-05-26",
+      "previousVersion": "0.46.0",
+      "sections": {},
+      "underTheHood": [
+        "chore: release v0.46.0-alpha.1 (#372)"
+      ]
+    },
+    {
+      "version": "0.46.0-alpha.1",
+      "date": "2026-05-26",
+      "previousVersion": "0.45.0",
+      "sections": {},
+      "underTheHood": [
+        "fix(ci): bump minor (not patch) when starting new alpha series (#367)",
+        "fix(ci): auto-label untiered merged PRs as tier:B in alpha cut (#365)",
+        "chore: release v0.45.0-alpha.6 (#364)",
+        "fix(viewer): replace HtmlViewer static toolbar with floating pill (#363)",
+        "fix(html-viewer): enforce blockExternal on all three render paths (#360) (#362)"
+      ]
+    },
+    {
       "version": "0.45.0",
       "date": "2026-05-24",
       "previousVersion": "0.44.0",
@@ -21,6 +79,16 @@
       }
     },
     {
+      "version": "0.45.0-alpha.6",
+      "date": "2026-05-26",
+      "previousVersion": "0.45.0",
+      "sections": {},
+      "underTheHood": [
+        "fix(viewer): replace HtmlViewer static toolbar with floating pill (#363)",
+        "fix(html-viewer): enforce blockExternal on all three render paths (#360) (#362)"
+      ]
+    },
+    {
       "version": "0.45.0-alpha.5",
       "date": "2026-05-24",
       "previousVersion": "0.45.0",
@@ -35,6 +103,27 @@
       }
     },
     {
+      "version": "0.45.0-alpha.4",
+      "date": "2026-05-22",
+      "previousVersion": "0.45.0",
+      "sections": {},
+      "underTheHood": [
+        "fix(release): generator writes honest placeholder; fix alpha-3 notes (#323)",
+        "chore: release v0.45.0-alpha.3 (#322)"
+      ]
+    },
+    {
+      "version": "0.45.0-alpha.3",
+      "date": "2026-05-22",
+      "previousVersion": "0.45.0",
+      "sections": {},
+      "underTheHood": [
+        "Corrected the alpha.2 release notes to remove placeholder text and add honest user-facing prose. (#320)",
+        "Documented the agentic-workflow release half in `docs/agentic-workflow.md` and fixed a Mermaid syntax error. (#319)",
+        "Split `docs/agentic-workflow.md` into an operational reference and a companion rationale file (`docs/agentic-workflow-rationale.md`) to keep session context lean. (#321)"
+      ]
+    },
+    {
       "version": "0.45.0-alpha.2",
       "date": "2026-05-21",
       "previousVersion": "0.45.0",
@@ -42,7 +131,11 @@
         "improvements": [
           "**Infrastructure-only release.** No user-visible changes vs. alpha.1 — same features, same behaviour. This alpha ships the CI plumbing that makes future auto-cuts actually work, plus two routine dependency patches."
         ]
-      }
+      },
+      "underTheHood": [
+        "`openssl` 0.10.79 → 0.10.80 (Rust transitive, security patch) — #314.",
+        "`ws` 8.19.0 → 8.20.1 inside the `bundled-skills/download-webpage` Node script — `npm audit fix` (#313)."
+      ]
     },
     {
       "version": "0.45.0-alpha.1",
@@ -141,7 +234,13 @@
           "**`Cmd+-` no longer toggles raw markdown mode on Swedish keyboards.** Source-mode chord was matching the physical key position (which is `-` on Swedish ISO). Now matches the produced character.",
           "**Image markdown serializer closes the block correctly.** Without a trailing `\\n\\n`, the next heading was concatenated and its `#` was backslash-escaped, corrupting the saved file."
         ]
-      }
+      },
+      "underTheHood": [
+        "`isLeaveAlphaDowngrade(current, manifest)` checks: current is prerelease AND manifest is stable AND the X.Y.Z triple of the manifest is strictly less than the triple of the current.",
+        "`checkStableChannel()` passes `allowDowngrades: true` to `check()` only when the running binary is a prerelease.",
+        "`UpdateInfo.isLeaveAlphaDowngrade?: boolean` is the discriminator that drives the dialog's switched copy.",
+        "`useAutoUpdate` adds a `useEffect` that re-runs `checkForUpdate()` when `releaseChannel` changes."
+      ]
     },
     {
       "version": "0.44.0-alpha.2",
@@ -170,7 +269,13 @@
           "**`Cmd+-` no longer toggles raw markdown mode on Swedish keyboards.** The source-mode chord was matching the physical key position (`event.code === \"Slash\"`), which on Swedish ISO is the `-` key. Now matches the produced character. *(Originally in alpha.0.)*",
           "**Image markdown serializer closes the block correctly.** Without the trailing `\\n\\n` separator, the next heading was concatenated to the same line and its `#` got backslash-escaped — corrupting the saved file. *(Originally in alpha.0.)*"
         ]
-      }
+      },
+      "underTheHood": [
+        "**#187 (`aw-pipeline`)** — every stage now reads human comments since the latest `refined` marker. Before this fix, override comments on issues only reached `aw-review`; `aw-refine` / `aw-slice` / `aw-tdd` worked from the body alone and silently dropped corrections, producing PRs that ignored explicit user feedback. Closes the \"I said that twice and the agent ignored it\" loop.",
+        "**#193 (`aw-review`)** — branch-prefix filter now matches `claude/*` instead of PR author. After the `WORKFLOW_PAT` switch, bot-authored PRs are authored by the PAT owner (not `claude[bot]`), so the old author-based filter rejected every bot PR and `aw-review` silently skipped them.",
+        "**#194 (PRD docs)** — the `aw-ci-repair` PRD + tasks breakdown land before the implementation, so the AW pipeline has filesystem references to read.",
+        "**#202 (`aw-ci-repair`)** — new pipeline addition that auto-fixes recurring CI perf-budget flakes. Two pieces compose: (a) a vitest regression-lock test (`no-bare-perf-budget.test.ts`) that fails when a perf assertion uses a bare numeric literal as its budget; (b) a new `aw-ci-repair` skill + workflow triggered by `workflow_run.completed: failure` on bot-authored draft PRs, auto-patching the same `PERF_BUDGET_MULTIPLIER` wrap on tests missing it. Comments-and-exits on snapshot drift / DOM-changed / anything else outside the documented pattern set. One repair attempt per PR."
+      ]
     },
     {
       "version": "0.44.0-alpha.1",
@@ -180,7 +285,11 @@
         "fixes": [
           "**Release pipeline unblocked.** Removed the obsolete"
         ]
-      }
+      },
+      "underTheHood": [
+        "`src/perf/status-tray.perf.test.ts` — segmented-picker benchmark deleted.",
+        "`package.json` — bumped to `0.44.0-alpha.1`."
+      ]
     },
     {
       "version": "0.44.0-alpha.0",
@@ -204,7 +313,21 @@
           "**`Cmd+-` no longer toggles raw markdown mode on Swedish keyboards.** The source-mode chord was matching the physical key position (`event.code === \"Slash\"`), which on Swedish ISO is the `-` key. Now matches the produced character; Nordic `Shift+7` fallback for true `Cmd+/` preserved.",
           "**Image markdown serializer closes the block correctly.** Without the trailing `\\n\\n`, the next heading was concatenated to the same line and its `#` got backslash-escaped — corrupting the saved file."
         ]
-      }
+      },
+      "underTheHood": [
+        "`0da4b00f` chart/drawing/link-preview block-size persistence + worker shim fix (#173)",
+        "`0d5ba65` zoom chord scope, Swedish keyboard collision, embedded-block breathing room (#188)",
+        "`33e1ef59` HtmlViewer rewrite — sanitised inline render via DOMPurify (#169)",
+        "`799582ae` StatusTray completion picker → dropdown (#181)",
+        "`408f1894` image block-size hover controls + persistence (later partially reverted for perf)",
+        "`f1548d4e` image alignment auto-default width",
+        "`c2d6f55` unified alignment via TextAlign expansion (later reverted for perf)",
+        "`ad8d1362` perf: conditional CSS zoom + image vanilla DOM revert",
+        "`2c9eb9f1` scroll-restore-from-saved-ratio fix",
+        "`ba4fe785` revert TextAlign expansion (perf bisect — confirmed cause of 494 KB book slowdown)",
+        "`19b9fdb5` revert image React NodeView restore (perf bisect — confirmed contribution to slowdown)",
+        "`20707bdc` image markdown serializer adds trailing block separator"
+      ]
     },
     {
       "version": "0.43.1",

--- a/scripts/__tests__/generate-changelog.test.ts
+++ b/scripts/__tests__/generate-changelog.test.ts
@@ -1,0 +1,103 @@
+// Tests for the alpha "Under the hood" surfacing in the changelog generator.
+//
+// Goal of the feature: alpha (prerelease) changelog entries carry the verbatim
+// merged-PR dump from the history file's "## Under the hood" section so the
+// in-app changelog shows what made each auto-cut. Stable entries must NEVER
+// carry it — that detail is rewritten into curated prose by `/release`.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { parseUnderTheHood, parseReleaseFile } from '../generate-changelog';
+
+const AUTO_CUT_ALPHA = `# Release v0.46.0-alpha.5
+
+**Date:** 2026-05-29
+**Previous version:** 0.46.0-alpha.4
+**Channel:** Alpha
+
+## Changes
+
+_No user-visible changes._
+
+## Under the hood
+
+Auto-generated dump of merged Tier-A/B PRs. Rewrite as prose grouped by area before stable promotion.
+
+- fix(ci): exclude release PRs from alpha cut to prevent infinite loop (#374)
+- feat(quiet-chrome): extend Aggressive preset (#372)
+`;
+
+const STABLE_RELEASE = `# Release v0.46.0
+
+**Date:** 2026-05-30
+**Previous version:** 0.45.0
+
+## Changes
+
+### Features
+
+- New thing for users
+
+## Under the hood
+
+- fix(ci): some internal plumbing (#999)
+`;
+
+describe('parseUnderTheHood', () => {
+  it('extracts only the bullet lines, dropping the lead paragraph', () => {
+    expect(parseUnderTheHood(AUTO_CUT_ALPHA)).toEqual([
+      'fix(ci): exclude release PRs from alpha cut to prevent infinite loop (#374)',
+      'feat(quiet-chrome): extend Aggressive preset (#372)',
+    ]);
+  });
+
+  it('returns an empty array when there is no Under the hood section', () => {
+    expect(parseUnderTheHood('# Release\n\n## Changes\n\n- x')).toEqual([]);
+  });
+});
+
+describe('parseReleaseFile — alpha vs stable Under the hood', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'changelog-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function write(name: string, body: string): string {
+    const p = join(dir, name);
+    writeFileSync(p, body);
+    return p;
+  }
+
+  it('attaches underTheHood to an alpha entry even with empty curated sections', () => {
+    const entry = parseReleaseFile(write('010-release-v0.46.0-alpha.5.md', AUTO_CUT_ALPHA));
+    // Previously this returned null (no curated sections) and the alpha vanished
+    // from the feed. It must now survive on the strength of its PR dump.
+    expect(entry).not.toBeNull();
+    expect(entry!.version).toBe('0.46.0-alpha.5');
+    expect(entry!.underTheHood).toEqual([
+      'fix(ci): exclude release PRs from alpha cut to prevent infinite loop (#374)',
+      'feat(quiet-chrome): extend Aggressive preset (#372)',
+    ]);
+  });
+
+  it('never attaches underTheHood to a stable entry, even when the section exists', () => {
+    const entry = parseReleaseFile(write('011-release-v0.46.0.md', STABLE_RELEASE));
+    expect(entry).not.toBeNull();
+    expect(entry!.version).toBe('0.46.0');
+    expect(entry!.sections.features).toEqual(['New thing for users']);
+    expect(entry!.underTheHood).toBeUndefined();
+  });
+
+  it('still skips a stable entry that has no curated sections', () => {
+    const body = `# Release v0.47.0\n\n**Date:** 2026-06-01\n\n## Changes\n\n_No user-visible changes._\n\n## Under the hood\n\n- internal (#1)\n`;
+    const entry = parseReleaseFile(write('012-release-v0.47.0.md', body));
+    expect(entry).toBeNull();
+  });
+});

--- a/scripts/generate-changelog.ts
+++ b/scripts/generate-changelog.ts
@@ -1,5 +1,6 @@
 import { readFileSync, readdirSync, writeFileSync, mkdirSync, existsSync } from 'fs';
 import { join, basename } from 'path';
+import { pathToFileURL } from 'url';
 
 interface ReleaseEntry {
   version: string;
@@ -10,6 +11,12 @@ interface ReleaseEntry {
     fixes?: string[];
     improvements?: string[];
   };
+  // Verbatim merged-PR dump from the history file's "## Under the hood"
+  // section. Populated ONLY for prerelease (alpha) entries so the alpha
+  // changelog feed shows what landed in each auto-cut. Stable entries never
+  // carry it — `main()` filters prereleases out of the stable feed, and
+  // `parseReleaseFile` only attaches it when the version has a `-` segment.
+  underTheHood?: string[];
 }
 
 interface Changelog {
@@ -33,7 +40,28 @@ function parseVersion(filename: string): string | null {
   return match ? match[1] : null;
 }
 
-function parseReleaseFile(filepath: string): ReleaseEntry | null {
+/**
+ * Extract the bullet list from the "## Under the hood" section.
+ *
+ * The section also carries a descriptive lead paragraph ("Auto-generated dump
+ * of merged Tier-A/B PRs…") which is intentionally dropped — only `- ` list
+ * items (the merged-PR lines) are returned.
+ */
+export function parseUnderTheHood(content: string): string[] {
+  const match = content.match(/##\s+Under the hood\s*\n([\s\S]*?)(?=\n## |$)/);
+  if (!match) return [];
+
+  const items: string[] = [];
+  for (const line of match[1].split('\n')) {
+    const itemMatch = line.match(/^- (.+)/);
+    if (itemMatch) {
+      items.push(itemMatch[1].trim());
+    }
+  }
+  return items;
+}
+
+export function parseReleaseFile(filepath: string): ReleaseEntry | null {
   const content = readFileSync(filepath, 'utf-8');
   const filename = basename(filepath);
   const version = parseVersion(filename);
@@ -71,12 +99,22 @@ function parseReleaseFile(filepath: string): ReleaseEntry | null {
     }
   }
 
-  // Skip releases with no sections
-  if (!sections.features && !sections.fixes && !sections.improvements) {
+  // Prerelease (alpha) entries surface the verbatim merged-PR dump so the
+  // alpha changelog shows what made the cut. Stable entries never do — the
+  // `/release` flow rewrites that detail into curated prose.
+  const isPrerelease = version.includes('-');
+  const uth = isPrerelease ? parseUnderTheHood(content) : [];
+  const underTheHood = uth.length > 0 ? uth : undefined;
+
+  // Skip releases with nothing to show. For alphas, an "Under the hood" dump
+  // counts as content even when the curated sections are empty — otherwise
+  // auto-cut alphas (which have no curated sections yet) would vanish from the
+  // feed entirely.
+  if (!sections.features && !sections.fixes && !sections.improvements && !underTheHood) {
     return null;
   }
 
-  return { version, date, previousVersion, sections };
+  return { version, date, previousVersion, sections, underTheHood };
 }
 
 /**
@@ -236,4 +274,8 @@ function main() {
   );
 }
 
-main();
+// Run only when executed directly (via `tsx scripts/generate-changelog.ts`),
+// not when imported by unit tests for the pure parse helpers above.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/src/components/UpdateDialog.tsx
+++ b/src/components/UpdateDialog.tsx
@@ -1,4 +1,4 @@
-import { ArrowUpCircle, Sparkles, Bug, Zap, ChevronDown } from "lucide-react";
+import { ArrowUpCircle, Sparkles, Bug, Zap, Wrench, ChevronDown } from "lucide-react";
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { openUrl } from '@tauri-apps/plugin-opener';
@@ -41,7 +41,8 @@ function VersionRelease({ release }: { release: Release }) {
   const hasMultipleSections =
     (release.sections.features?.length ?? 0) +
       (release.sections.fixes?.length ?? 0) +
-      (release.sections.improvements?.length ?? 0) >
+      (release.sections.improvements?.length ?? 0) +
+      (release.underTheHood?.length ?? 0) >
     0;
 
   if (!hasMultipleSections) return null;
@@ -82,6 +83,10 @@ function VersionRelease({ release }: { release: Release }) {
           <SectionItems
             icon={Zap}
             items={release.sections.improvements}
+          />
+          <SectionItems
+            icon={Wrench}
+            items={release.underTheHood}
           />
         </div>
       )}

--- a/src/components/settings/ChangelogDialog.tsx
+++ b/src/components/settings/ChangelogDialog.tsx
@@ -1,4 +1,4 @@
-import { Sparkles, Bug, Zap, ChevronDown } from 'lucide-react';
+import { Sparkles, Bug, Zap, Wrench, ChevronDown } from 'lucide-react';
 import { renderInlineMarkdown } from '@/lib/render-inline-markdown';
 import {
   Dialog,
@@ -97,6 +97,11 @@ function ReleaseCard({ release }: { release: Release }) {
             title="Improvements"
             icon={Zap}
             items={release.sections.improvements ?? []}
+          />
+          <ReleaseSection
+            title="Under the hood"
+            icon={Wrench}
+            items={release.underTheHood ?? []}
           />
         </div>
       )}

--- a/src/hooks/useChangelog.ts
+++ b/src/hooks/useChangelog.ts
@@ -11,6 +11,9 @@ export interface Release {
     fixes?: string[];
     improvements?: string[];
   };
+  // Merged-PR dump, present only on alpha (prerelease) entries. Lets the
+  // in-app changelog show what landed in each auto-cut alpha. Absent on stable.
+  underTheHood?: string[];
 }
 
 export interface Changelog {


### PR DESCRIPTION
## Summary

Alpha releases now show what made each cut. Auto-cut alphas have no curated `## Changes` yet, so their notes read only "No user-visible changes" on the GitHub Release page — and they were dropped from the in-app changelog entirely. This surfaces the `## Under the hood` merged-PR dump (already written by `aw-alpha-cut`) **for prerelease versions only**.

- **`scripts/generate-changelog.ts`** — parses `## Under the hood` into `underTheHood[]` and attaches it to prerelease entries. Auto-cut alphas with empty curated sections now survive on the strength of their PR dump (previously skipped). `main()` is guarded so the parse helpers are unit-testable.
- **`release.yml`** — GitHub Release body includes `## Under the hood` for prerelease tags; stable tags stop before it, exactly as before.
- **`useChangelog` + `ChangelogDialog` + `UpdateDialog`** — render an "Under the hood" section when present (only alphas carry it).
- **Docs** — `release` skill + `docs/agentic-workflow.md` document the alpha exception.

## Stable safety

- `public/changelog.json` (stable feed) regenerates **byte-for-byte identical** — only `changelog-alpha.json` changed.
- `underTheHood` is attached only when the version has a `-` segment; the stable feed filter strips prereleases anyway. 0 stable entries carry it.
- `release.yml` stable awk branch is untouched; only a new `if prerelease` branch was added.

## Test plan

- [x] New `scripts/__tests__/generate-changelog.test.ts` (5 tests): alpha keeps dump with empty sections, stable never gets it, empty stable still skipped
- [x] `pnpm typecheck` clean
- [x] Existing useChangelog / changelog-linter / UpdateDialog tests pass (32)
- [x] Verified both `release.yml` awk branches against real history files

🤖 Generated with [Claude Code](https://claude.com/claude-code)