### PR TITLE
chore: release v0.46.0-alpha.7

### DIFF
--- a/docs/history/132-release-v0.46.0-alpha.7.md
+++ b/docs/history/132-release-v0.46.0-alpha.7.md
@@ -1,0 +1,22 @@
+# Release v0.46.0-alpha.7
+
+**Date:** 2026-05-29
+**Previous version:** 0.46.0-alpha.6
+**Channel:** Alpha
+
+Auto-cut by `aw-alpha-cut` after Tier-A/B PRs landed. The auto-dump under "Under the hood" lists the merged PRs verbatim.
+
+Before promoting this alpha to stable, edit this file:
+  - Move anything user-visible from "Under the hood" into "## Changes" under `### Features`, `### Improvements`, or `### Fixes` — and rewrite each bullet in user-facing prose (drop PR titles, version triples, internal jargon).
+  - Leave "## Changes" as `_No user-visible changes._` for infra-only releases.
+  - See `feedback_user_facing_release_notes.md` and `scripts/generate-changelog.ts` linter rules.
+
+## Changes
+
+_No user-visible changes._
+
+## Under the hood
+
+Auto-generated dump of merged Tier-A/B PRs. Rewrite as prose grouped by area before stable promotion.
+
+- feat(release): surface merged-PR dump in alpha release notes (#385)

--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -135,3 +135,4 @@ Chronological log of major implementation milestones and changes.
 | 129 | [Release v0.46.0-alpha.4](129-release-v0.46.0-alpha.4.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
 | 130 | [Release v0.46.0-alpha.5](130-release-v0.46.0-alpha.5.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
 | 131 | [Release v0.46.0-alpha.6](131-release-v0.46.0-alpha.6.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
+| 132 | [Release v0.46.0-alpha.7](132-release-v0.46.0-alpha.7.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "notesage",
   "private": true,
-  "version": "0.46.0-alpha.6",
+  "version": "0.46.0-alpha.7",
   "license": "MIT",
   "author": "Peter Blenessy",
   "type": "module",

--- a/public/changelog-alpha.json
+++ b/public/changelog-alpha.json
@@ -1,6 +1,15 @@
 {
   "releases": [
     {
+      "version": "0.46.0-alpha.7",
+      "date": "2026-05-29",
+      "previousVersion": "0.46.0",
+      "sections": {},
+      "underTheHood": [
+        "feat(release): surface merged-PR dump in alpha release notes (#385)"
+      ]
+    },
+    {
       "version": "0.46.0-alpha.6",
       "date": "2026-05-29",
       "previousVersion": "0.46.0",


### PR DESCRIPTION
Auto-cut by `aw-alpha-cut`. The history file at `docs/history/132-release-v0.46.0-alpha.7.md` lists the merged PRs.

## PRs included

- #385

Auto-merge enabled. Once the 4 required status checks pass, this merges to main, and the `tag-after-merge` job in `aw-alpha-cut.yml` tags + pushes `v0.46.0-alpha.7`. `release.yml` then builds and publishes.
