### PR TITLE
fix(ci): fold auto-labelled PRs into alpha-cut ship list to dodge search lag

### DIFF
--- a/.github/workflows/aw-alpha-cut.yml
+++ b/.github/workflows/aw-alpha-cut.yml
@@ -116,10 +116,22 @@ jobs:
 
           # 2b. Tier-A or Tier-B PRs merged since previous_tag?
           echo "Looking for tier:A/B PRs merged since $since_iso"
-          pr_numbers=$(gh pr list \
+          searched_prs=$(gh pr list \
             --state merged --base main \
             --search "merged:>$since_iso label:tier:A,tier:B" \
-            --json number,title --jq "[.[] | $release_filter | .number] | join(\",\")")
+            --json number,title --jq ".[] | $release_filter | .number")
+
+          # Union the search hits with the PRs we just auto-labelled in 2a.
+          # GitHub's search index lags label writes by a few seconds, so a PR
+          # labelled tier:B moments ago in 2a does NOT reliably appear in this
+          # search yet. Without the union, an alpha triggered right after a
+          # human-merged (untiered) PR sees "nothing to ship" and skips even
+          # though real work landed — exactly the race that no-op'd the cut
+          # after PR #385 merged. The freshly-labelled set is already
+          # release-PR-filtered (the 2a query used $release_filter), so it is
+          # safe to fold in verbatim.
+          pr_numbers=$(printf '%s\n%s\n' "$searched_prs" "$unclassified_prs" \
+            | grep -E '^[0-9]+$' | sort -n -u | paste -sd, -)
 
           if [[ -z "$pr_numbers" ]]; then
             echo "No Tier-A/B PRs merged since $previous_tag — nothing to ship."


### PR DESCRIPTION
## Summary

The `aw-alpha-cut` preflight has a search-index race that can silently skip a cut.

Step **2a** auto-labels untiered merged PRs as `tier:B`. Step **2b** then runs `gh pr list --search "...label:tier:A,tier:B"` to build the ship list. GitHub's search index lags label writes by a few seconds, so a PR labelled moments earlier in 2a is often **not** returned by the 2b search. When that PR is the *only* work since the last alpha (e.g. a lone human-merged PR), 2b sees an empty result → "nothing to ship" → `should_cut=false` → the cut is skipped.

This is exactly what happened after #385 merged: the manual dispatch labelled #385 `tier:B` but the cut no-op'd; a re-dispatch a few minutes later (once the index caught up) cut `v0.46.0-alpha.7`.

## Fix

Union the 2b search hits with the freshly-labelled set from 2a (which is already release-PR-filtered via `$release_filter`) and dedupe, rather than trusting the search index to have caught up within the same run.

```bash
pr_numbers=$(printf '%s\n%s\n' "$searched_prs" "$unclassified_prs" \
  | grep -E '^[0-9]+$' | sort -n -u | paste -sd, -)
```

## Test plan

- [x] Verified the union/dedupe/join against representative inputs: race case (search empty, just-labelled #385) → `385`; overlap deduped; search-only unchanged; both-empty → empty (still skips correctly); multi-labelled merged+sorted
- [x] `yaml.safe_load` parses the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)