### PR TITLE
test(e2e): remaining Quiet Composer specs (#277/#278/#279/#280) + isolated harness

### DIFF
--- a/e2e-real/tests/command-bar.test.ts
+++ b/e2e-real/tests/command-bar.test.ts
@@ -1,0 +1,135 @@
+/**
+ * FloatingCommandBar summon / collapse / pin E2E tests (issue #280, real-E2E half).
+ *
+ * Covers the shortcut- and state-driven behaviours that don't require typing
+ * into the bar's textarea:
+ *   - ⌘K summons (expands) the bar
+ *   - double-tap ⌘ also summons it
+ *   - Esc collapses it
+ *   - pinned mode reflects in the DOM and ⌘⇧C unpins an expanded+pinned bar
+ *
+ * The six prefix-mode transitions and the `:file` verb require *typing* a query
+ * into the textarea, which WKWebView's WebDriver can't reliably deliver to a
+ * React input (same limitation that skips find-bar/slash typing in
+ * editor.test.ts). Those are covered in the Playwright spec
+ * `e2e/tests/command-bar-prefixes.spec.ts` (Chromium, where typing works).
+ *
+ * Run manually:
+ *   Terminal 1: pnpm tauri:test
+ *   Terminal 2: tauri-webdriver
+ *   Terminal 3: pnpm test:e2e-real
+ */
+import { pressShortcut } from '../helpers/actions';
+
+/** Two quick bare-⌘ press/releases within the double-tap window. */
+async function doubleTapCmd(): Promise<void> {
+    const META = '';
+    await browser
+        .action('key')
+        .down(META).up(META)
+        .pause(60)
+        .down(META).up(META)
+        .perform();
+}
+
+async function setPinned(pinned: boolean): Promise<void> {
+    await browser.execute((p: boolean) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const s = (window as any).__E2E_SETTINGS_STORE__?.getState();
+        s?.setCmdBarPinned?.(p);
+    }, pinned);
+}
+
+async function collapseBar(): Promise<void> {
+    const bar = await browser.$('[data-cmd-bar]');
+    if ((await bar.getAttribute('data-expanded')) === 'true') {
+        await pressShortcut(['Escape']);
+        await browser.waitUntil(
+            async () => (await bar.getAttribute('data-expanded')) === 'false',
+            { timeout: 3000, interval: 50, timeoutMsg: 'Bar did not collapse' },
+        ).catch(() => {});
+    }
+}
+
+describe('FloatingCommandBar — summon / collapse / pin', () => {
+    before(async () => {
+        const root = await browser.$('#root');
+        await root.waitForExist({ timeout: 10_000, timeoutMsg: 'App root not found' });
+        await browser.setWindowSize(1200, 800);
+    });
+
+    beforeEach(async () => {
+        await setPinned(false);
+        await collapseBar();
+    });
+
+    afterEach(async () => {
+        await setPinned(false);
+        await collapseBar();
+    });
+
+    it('⌘K summons (expands) the command bar', async () => {
+        const bar = await browser.$('[data-cmd-bar]');
+        await bar.waitForExist({ timeout: 5000 });
+        expect(await bar.getAttribute('data-expanded')).toBe('false');
+
+        await pressShortcut(['Meta', 'k']);
+
+        await browser.waitUntil(
+            async () => (await bar.getAttribute('data-expanded')) === 'true',
+            { timeout: 5000, interval: 50, timeoutMsg: 'Bar did not expand on ⌘K' },
+        );
+        // The combobox input is present once expanded.
+        const input = await browser.$('[data-cmd-bar] textarea[role="combobox"]');
+        expect(await input.isExisting()).toBe(true);
+    });
+
+    it('Esc collapses the command bar', async () => {
+        const bar = await browser.$('[data-cmd-bar]');
+        await pressShortcut(['Meta', 'k']);
+        await browser.waitUntil(
+            async () => (await bar.getAttribute('data-expanded')) === 'true',
+            { timeout: 5000, interval: 50, timeoutMsg: 'Bar did not expand' },
+        );
+
+        await pressShortcut(['Escape']);
+        await browser.waitUntil(
+            async () => (await bar.getAttribute('data-expanded')) === 'false',
+            { timeout: 5000, interval: 50, timeoutMsg: 'Bar did not collapse on Esc' },
+        );
+    });
+
+    it('double-tap ⌘ summons the command bar', async () => {
+        const bar = await browser.$('[data-cmd-bar]');
+        expect(await bar.getAttribute('data-expanded')).toBe('false');
+
+        await doubleTapCmd();
+
+        await browser.waitUntil(
+            async () => (await bar.getAttribute('data-expanded')) === 'true',
+            { timeout: 5000, interval: 50, timeoutMsg: 'Bar did not expand on double-tap ⌘' },
+        );
+    });
+
+    it('pinned mode reflects on the bar and ⌘⇧C unpins it', async () => {
+        // Pinning re-renders the bar into the docked side panel (a new DOM
+        // node), so read the attribute via a fresh query each poll rather than
+        // caching the element handle (which would go stale).
+        const pinnedAttr = async (): Promise<string | null> => {
+            const b = await browser.$('[data-cmd-bar]');
+            return b.getAttribute('data-cmd-bar-pinned');
+        };
+
+        // Pin via settings → the bar advertises pinned mode.
+        await setPinned(true);
+        await browser.waitUntil(async () => (await pinnedAttr()) === 'true', {
+            timeout: 5000, interval: 50, timeoutMsg: 'Bar did not enter pinned mode',
+        });
+
+        // ⌘⇧C unpins back to the floating bar (documented in keyboard-shortcuts).
+        await pressShortcut(['Meta', 'Shift', 'c']);
+        await browser.waitUntil(async () => (await pinnedAttr()) === 'false', {
+            timeout: 5000, interval: 50, timeoutMsg: '⌘⇧C did not unpin the bar',
+        });
+    });
+});

--- a/e2e-real/tests/sidebar-pinned.test.ts
+++ b/e2e-real/tests/sidebar-pinned.test.ts
@@ -1,0 +1,176 @@
+/**
+ * QuietSidebar Pinned section E2E tests (issue #277).
+ *
+ * Covers pin/unpin, persistence, insertion order, click-to-activate, and the
+ * active-row highlight against the real Tauri app.
+ *
+ * Driven through the exposed Zustand stores (workspace-store `pinFile` /
+ * `unpinFile`) + DOM clicks — the WKWebView-safe pattern proven in
+ * document-switching.test.ts. Pinned rows render as
+ * `[aria-label="Pinned"] [role="button"]` with the filename as text and
+ * `data-active="true"` / `aria-current="page"` on the active document's row.
+ *
+ * "Persist across restart" has no app-restart in this harness, so it is
+ * asserted via the persisted artifact: the workspace-store writes pins to
+ * localStorage under `notesage-workspace` (Zustand persist), which is what a
+ * restart would rehydrate from.
+ *
+ * Run manually:
+ *   Terminal 1: pnpm tauri:test
+ *   Terminal 2: tauri-webdriver
+ *   Terminal 3: pnpm test:e2e-real
+ */
+import * as path from 'path';
+
+import { ensureCleanState, ensureProjectOpen } from '../helpers/setup';
+
+const TEST_PROJECT_PATH = path.resolve(process.cwd(), 'e2e-real/fixtures/test-project');
+const fileA = { name: 'notes.md', path: path.join(TEST_PROJECT_PATH, 'notes.md'), sentinel: 'My Notes' };
+const fileB = { name: 'code-examples.md', path: path.join(TEST_PROJECT_PATH, 'code-examples.md') };
+
+async function pin(...paths: string[]): Promise<void> {
+    await browser.execute((ps: string[]) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const s = (window as any).__E2E_WORKSPACE_STORE__?.getState();
+        if (s) for (const p of ps) s.pinFile(p);
+    }, paths);
+}
+
+async function unpinAll(): Promise<void> {
+    await browser.execute(() => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const s = (window as any).__E2E_WORKSPACE_STORE__?.getState();
+        if (s) for (const p of [...(s.pinnedFiles ?? [])]) s.unpinFile(p);
+    });
+}
+
+async function showSidebar(): Promise<void> {
+    await browser.execute(() => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const s = (window as any).__E2E_SETTINGS_STORE__?.getState();
+        if (!s) return;
+        if (!s.sidebarPinned) s.setSidebarPinned(true);
+        if (!s.sidebarOpen) s.setSidebarOpen(true);
+    });
+}
+
+async function pinnedRowTexts(): Promise<string[]> {
+    const rows = await browser.$$('[aria-label="Pinned"] [role="button"]');
+    const texts: string[] = [];
+    for (const r of rows) texts.push((await r.getText()).trim());
+    return texts;
+}
+
+async function clickPinnedRow(name: string): Promise<void> {
+    await browser.waitUntil(
+        async () => (await browser.$$('[aria-label="Pinned"] [role="button"]')).length > 0,
+        { timeout: 10_000, interval: 100, timeoutMsg: 'No Pinned rows rendered' },
+    );
+    const rows = await browser.$$('[aria-label="Pinned"] [role="button"]');
+    for (const r of rows) {
+        if ((await r.getText()).includes(name)) {
+            await r.click();
+            return;
+        }
+    }
+    throw new Error(`No Pinned row found for "${name}"`);
+}
+
+async function activeFilePath(): Promise<string | null> {
+    return browser.execute(() => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const s = (window as any).__E2E_EDITOR_STORE__?.getState();
+        if (!s) return null;
+        const t = s.openDocuments.find((d: { id: string }) => d.id === s.activeTabId);
+        return t ? t.filePath : null;
+    });
+}
+
+describe('QuietSidebar — Pinned section', () => {
+    before(async () => {
+        await ensureProjectOpen(TEST_PROJECT_PATH);
+        // Pin a stable window size — performance/navigation specs resize the
+        // window and WKWebView's setWindowSize doesn't always restore, which
+        // would collapse the sidebar layout for these tests.
+        await browser.setWindowSize(1200, 800);
+    });
+
+    beforeEach(async () => {
+        await ensureCleanState();
+        await unpinAll();
+        await showSidebar();
+    });
+
+    afterEach(async () => {
+        await unpinAll();
+    });
+
+    it('pinning a file adds it to the Pinned section', async () => {
+        await pin(fileA.path);
+        await browser.waitUntil(
+            async () => (await pinnedRowTexts()).some((t) => t.includes(fileA.name)),
+            { timeout: 10_000, interval: 100, timeoutMsg: `${fileA.name} did not appear in Pinned` },
+        );
+    });
+
+    it('unpinning removes it from the Pinned section', async () => {
+        await pin(fileA.path);
+        await browser.waitUntil(
+            async () => (await pinnedRowTexts()).some((t) => t.includes(fileA.name)),
+            { timeout: 10_000, interval: 100, timeoutMsg: `${fileA.name} did not appear in Pinned` },
+        );
+        await unpinAll();
+        await browser.waitUntil(
+            async () => !(await pinnedRowTexts()).some((t) => t.includes(fileA.name)),
+            { timeout: 10_000, interval: 100, timeoutMsg: `${fileA.name} still in Pinned after unpin` },
+        );
+    });
+
+    it('persists pins to the workspace-store localStorage artifact', async () => {
+        await pin(fileA.path);
+        // The persisted artifact is what a restart rehydrates from.
+        const persisted = await browser.execute(() => localStorage.getItem('notesage-workspace'));
+        expect(persisted).toBeTruthy();
+        expect(persisted as string).toContain(fileA.path);
+    });
+
+    it('maintains insertion order (A then B)', async () => {
+        await pin(fileA.path);
+        await pin(fileB.path);
+        await browser.waitUntil(
+            async () => (await pinnedRowTexts()).length >= 2,
+            { timeout: 10_000, interval: 100, timeoutMsg: 'Two pinned rows did not render' },
+        );
+        const texts = await pinnedRowTexts();
+        const idxA = texts.findIndex((t) => t.includes(fileA.name));
+        const idxB = texts.findIndex((t) => t.includes(fileB.name));
+        expect(idxA).toBeGreaterThanOrEqual(0);
+        expect(idxB).toBeGreaterThan(idxA);
+    });
+
+    it('clicking a pinned item activates the document and highlights its row', async () => {
+        await pin(fileA.path);
+        await clickPinnedRow(fileA.name);
+
+        await browser.waitUntil(
+            async () => (await activeFilePath()) === fileA.path,
+            { timeout: 15_000, interval: 100, timeoutMsg: 'Pinned click did not activate the document' },
+        );
+
+        // The active document's pinned row carries the active marker.
+        await browser.waitUntil(
+            async () => {
+                const rows = await browser.$$('[aria-label="Pinned"] [role="button"]');
+                for (const r of rows) {
+                    if ((await r.getText()).includes(fileA.name)) {
+                        const active = await r.getAttribute('data-active');
+                        const current = await r.getAttribute('aria-current');
+                        return active === 'true' || current === 'page';
+                    }
+                }
+                return false;
+            },
+            { timeout: 10_000, interval: 100, timeoutMsg: 'Active pinned row did not receive the active highlight' },
+        );
+    });
+});

--- a/e2e-real/tests/sidebar-recent.test.ts
+++ b/e2e-real/tests/sidebar-recent.test.ts
@@ -1,0 +1,184 @@
+/**
+ * QuietSidebar Recent section E2E tests (issue #278).
+ *
+ * Covers MRU ordering, deduplication, display-cap enforcement, and
+ * click-to-activate against the real Tauri app. Recent is backed by
+ * `editor-store.recentFiles` (capped at MAX_RECENT_FILES = 5, most-recent
+ * first) and rendered as `[aria-label="Recent"] [role="button"]` rows.
+ *
+ * Two criteria from the original issue are intentionally NOT tested, with
+ * rationale:
+ *
+ *   - "Setting sidebarRecentCap to 0 hides the Recent section" — not
+ *     achievable: `setSidebarRecentCap` clamps to [3, 15] (min 3). Only the
+ *     Tags/Mentions caps go to 0. The criterion conflated Recent with those.
+ *   - "Externally-deleted file removed from Recent on the next watcher tick" —
+ *     not wired: `removeRecent` is only called by app-initiated delete
+ *     (`useFileOperations.deletePath`); the filesystem watcher
+ *     (`useFileWatcher`) refreshes the tree on external delete but does not
+ *     prune Recent. Asserting removal would test behaviour that does not
+ *     exist. The wired path (removeRecent) has unit coverage in
+ *     editor-store.test.ts. Flagged as a gap in the PR.
+ *
+ * Run manually:
+ *   Terminal 1: pnpm tauri:test
+ *   Terminal 2: tauri-webdriver
+ *   Terminal 3: pnpm test:e2e-real
+ */
+import * as path from 'path';
+
+import { openFile } from '../helpers/actions';
+import { ensureCleanState, ensureProjectOpen } from '../helpers/setup';
+
+const TEST_PROJECT_PATH = path.resolve(process.cwd(), 'e2e-real/fixtures/test-project');
+const A = { name: 'notes.md', path: path.join(TEST_PROJECT_PATH, 'notes.md') };
+const B = { name: 'code-examples.md', path: path.join(TEST_PROJECT_PATH, 'code-examples.md') };
+const C = { name: 'large-doc.md', path: path.join(TEST_PROJECT_PATH, 'large-doc.md') };
+const D = { name: 'empty.md', path: path.join(TEST_PROJECT_PATH, 'empty.md') };
+
+async function showSidebar(): Promise<void> {
+    await browser.execute(() => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const s = (window as any).__E2E_SETTINGS_STORE__?.getState();
+        if (!s) return;
+        if (!s.sidebarPinned) s.setSidebarPinned(true);
+        if (!s.sidebarOpen) s.setSidebarOpen(true);
+    });
+}
+
+async function resetRecent(): Promise<void> {
+    await browser.execute(() => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const w = window as any;
+        w.__E2E_EDITOR_STORE__?.setState({ recentFiles: [] });
+        const s = w.__E2E_SETTINGS_STORE__?.getState();
+        if (s?.setSidebarRecentCap) s.setSidebarRecentCap(5); // default
+    });
+}
+
+async function recentRowTexts(): Promise<string[]> {
+    const rows = await browser.$$('[aria-label="Recent"] [role="button"]');
+    const texts: string[] = [];
+    for (const r of rows) texts.push((await r.getText()).trim());
+    return texts;
+}
+
+async function recentPaths(): Promise<string[]> {
+    return browser.execute(() => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const s = (window as any).__E2E_EDITOR_STORE__?.getState();
+        return (s?.recentFiles ?? []).map((r: { path: string }) => r.path);
+    });
+}
+
+async function clickRecentRow(name: string): Promise<void> {
+    await browser.waitUntil(
+        async () => (await browser.$$('[aria-label="Recent"] [role="button"]')).length > 0,
+        { timeout: 10_000, interval: 100, timeoutMsg: 'No Recent rows rendered' },
+    );
+    const rows = await browser.$$('[aria-label="Recent"] [role="button"]');
+    for (const r of rows) {
+        if ((await r.getText()).includes(name)) {
+            await r.click();
+            return;
+        }
+    }
+    throw new Error(`No Recent row found for "${name}"`);
+}
+
+async function activeFilePath(): Promise<string | null> {
+    return browser.execute(() => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const s = (window as any).__E2E_EDITOR_STORE__?.getState();
+        if (!s) return null;
+        const t = s.openDocuments.find((d: { id: string }) => d.id === s.activeTabId);
+        return t ? t.filePath : null;
+    });
+}
+
+describe('QuietSidebar — Recent section', () => {
+    before(async () => {
+        await ensureProjectOpen(TEST_PROJECT_PATH);
+        await browser.setWindowSize(1200, 800);
+    });
+
+    beforeEach(async () => {
+        await ensureCleanState();
+        await resetRecent();
+        await showSidebar();
+    });
+
+    afterEach(async () => {
+        await resetRecent();
+    });
+
+    it('adds an opened file to the top of Recent (MRU order)', async () => {
+        await openFile(A.name, TEST_PROJECT_PATH);
+        await openFile(B.name, TEST_PROJECT_PATH);
+
+        // Store: most-recent first.
+        await browser.waitUntil(
+            async () => {
+                const p = await recentPaths();
+                return p[0] === B.path && p.includes(A.path);
+            },
+            { timeout: 10_000, interval: 100, timeoutMsg: 'recentFiles not in MRU order' },
+        );
+
+        // DOM: rows render most-recent first.
+        const texts = await recentRowTexts();
+        const idxB = texts.findIndex((t) => t.includes(B.name));
+        const idxA = texts.findIndex((t) => t.includes(A.name));
+        expect(idxB).toBe(0);
+        expect(idxA).toBeGreaterThan(idxB);
+    });
+
+    it('re-opening a recent file moves it to the top without duplicating', async () => {
+        await openFile(A.name, TEST_PROJECT_PATH);
+        await openFile(B.name, TEST_PROJECT_PATH);
+        await openFile(A.name, TEST_PROJECT_PATH); // re-open A
+
+        await browser.waitUntil(
+            async () => {
+                const p = await recentPaths();
+                return p[0] === A.path && p.filter((x) => x === A.path).length === 1;
+            },
+            { timeout: 10_000, interval: 100, timeoutMsg: 'Re-open did not move A to top without duplication' },
+        );
+        const p = await recentPaths();
+        expect(p.length).toBe(2); // A and B, no dup
+    });
+
+    it('respects sidebarRecentCap for the displayed rows', async () => {
+        await browser.execute(() => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const s = (window as any).__E2E_SETTINGS_STORE__?.getState();
+            s?.setSidebarRecentCap?.(3); // min clamp is 3
+        });
+
+        // Open 4 distinct files — recentFiles will hold 4, display caps to 3.
+        await openFile(A.name, TEST_PROJECT_PATH);
+        await openFile(B.name, TEST_PROJECT_PATH);
+        await openFile(C.name, TEST_PROJECT_PATH);
+        await openFile(D.name, TEST_PROJECT_PATH);
+
+        await browser.waitUntil(
+            async () => (await recentPaths()).length >= 4,
+            { timeout: 10_000, interval: 100, timeoutMsg: 'recentFiles did not accumulate 4 entries' },
+        );
+
+        const texts = await recentRowTexts();
+        expect(texts.length).toBe(3);
+    });
+
+    it('clicking a recent item activates the corresponding document', async () => {
+        await openFile(A.name, TEST_PROJECT_PATH);
+        await openFile(B.name, TEST_PROJECT_PATH);
+
+        await clickRecentRow(A.name);
+        await browser.waitUntil(
+            async () => (await activeFilePath()) === A.path,
+            { timeout: 15_000, interval: 100, timeoutMsg: 'Recent click did not activate the document' },
+        );
+    });
+});

--- a/e2e-real/tests/sidebar-tree-nav.test.ts
+++ b/e2e-real/tests/sidebar-tree-nav.test.ts
@@ -1,0 +1,172 @@
+/**
+ * QuietSidebar inline tree-navigation E2E tests (issue #279, reinterpreted).
+ *
+ * The original issue targeted the TreeOverlay (⌘⇧E), which has since been
+ * DELETED (sidebar-simplification; regression-locked by no-tree-overlay.test.ts,
+ * and ⌘⇧E now opens Export). Its replacement is the QuietSidebar's inline
+ * tree-expand on ProjectsSection rows: a project row expands one level in place
+ * to reveal its children. This spec covers that replacement surface.
+ *
+ * Inline expand is click-drivable (`ProjectRow` onClick → `toggleExpanded`) —
+ * the WKWebView-safe path. (ArrowRight also expands for keyboard users, but
+ * WebDriver doesn't reliably deliver bare navigation keys to WKWebView, same
+ * limitation seen with ⌃Tab; the keyboard path is exercised by unit tests.)
+ *
+ * Markers (per ProjectsSection.tsx):
+ *   - project row: [data-row-type="project"], aria-expanded, role="treeitem"
+ *   - child row:   [data-row-type="child"]
+ *   - only workspace-store.projects render here (explorer folders / notes-tree
+ *     are intentionally excluded from the Quiet sidebar).
+ *
+ * Run manually:
+ *   Terminal 1: pnpm tauri:test
+ *   Terminal 2: tauri-webdriver
+ *   Terminal 3: pnpm test:e2e-real
+ */
+import * as path from 'path';
+
+import { tauriInvoke } from '../helpers/actions';
+import { ensureCleanState } from '../helpers/setup';
+
+const TEST_PROJECT_PATH = path.resolve(process.cwd(), 'e2e-real/fixtures/test-project');
+const PROJECT_BASENAME = 'test-project';
+
+async function showSidebar(): Promise<void> {
+    await browser.execute(() => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const s = (window as any).__E2E_SETTINGS_STORE__?.getState();
+        if (!s) return;
+        if (!s.sidebarPinned) s.setSidebarPinned(true);
+        if (!s.sidebarOpen) s.setSidebarOpen(true);
+    });
+}
+
+/** Adds the fixture as a workspace PROJECT (not an explorer folder). */
+async function addFixtureProject(): Promise<void> {
+    const tree = await tauriInvoke('list_directory', { path: TEST_PROJECT_PATH });
+    await browser.execute(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (p: string, t: any) => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const w = window as any;
+            const s = w.__E2E_WORKSPACE_STORE__?.getState();
+            if (!s) return;
+            // Remove any explorer-folder copy so it only shows as a project.
+            for (const f of [...(s.explorerFolders ?? [])]) {
+                if (f.path === p) s.removeExplorerFolder(p);
+            }
+            s.addProject(p, t);
+        },
+        TEST_PROJECT_PATH,
+        tree,
+    );
+}
+
+function projectRow() {
+    return browser.$(`[data-row-type="project"]`);
+}
+
+async function isExpanded(): Promise<boolean> {
+    const row = await projectRow();
+    return (await row.getAttribute('aria-expanded')) === 'true';
+}
+
+/** Ensures the project row is collapsed (expand state persists across tests). */
+async function ensureCollapsed(): Promise<void> {
+    const row = await projectRow();
+    await row.waitForExist({ timeout: 10_000 });
+    if (await isExpanded()) {
+        await row.click();
+        await browser.waitUntil(async () => !(await isExpanded()), {
+            timeout: 5_000, interval: 100, timeoutMsg: 'Project did not collapse',
+        });
+    }
+}
+
+async function childRowCount(): Promise<number> {
+    return (await browser.$$(`[data-row-type="child"]`)).length;
+}
+
+async function activeFilePath(): Promise<string | null> {
+    return browser.execute(() => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const s = (window as any).__E2E_EDITOR_STORE__?.getState();
+        if (!s) return null;
+        const t = s.openDocuments.find((d: { id: string }) => d.id === s.activeTabId);
+        return t ? t.filePath : null;
+    });
+}
+
+describe('QuietSidebar — inline tree navigation', () => {
+    before(async () => {
+        await addFixtureProject();
+        await browser.setWindowSize(1200, 800);
+    });
+
+    beforeEach(async () => {
+        await ensureCleanState();
+        await showSidebar();
+        await ensureCollapsed();
+    });
+
+    it('renders the workspace project as a treeitem row', async () => {
+        const row = await projectRow();
+        await row.waitForExist({ timeout: 10_000 });
+        expect(await row.getText()).toContain(PROJECT_BASENAME);
+        // Collapsed projects expose no child rows.
+        expect(await childRowCount()).toBe(0);
+    });
+
+    it('clicking a project row expands it one level in place', async () => {
+        const row = await projectRow();
+        await row.click();
+
+        await browser.waitUntil(async () => await isExpanded(), {
+            timeout: 5_000, interval: 100, timeoutMsg: 'Project row did not expand on click',
+        });
+        await browser.waitUntil(async () => (await childRowCount()) > 0, {
+            timeout: 5_000, interval: 100, timeoutMsg: 'No child rows appeared after expand',
+        });
+    });
+
+    it('clicking a child file row opens that file in the editor', async () => {
+        const row = await projectRow();
+        await row.click();
+        await browser.waitUntil(async () => (await childRowCount()) > 0, {
+            timeout: 5_000, interval: 100, timeoutMsg: 'No child rows appeared after expand',
+        });
+
+        // Click a child FILE row (notes.md). Folders sort first, so match by name.
+        const children = await browser.$$(`[data-row-type="child"]`);
+        let clicked = false;
+        for (const c of children) {
+            if ((await c.getText()).includes('notes.md')) {
+                await c.click();
+                clicked = true;
+                break;
+            }
+        }
+        expect(clicked).toBe(true);
+
+        await browser.waitUntil(
+            async () => (await activeFilePath()) === path.join(TEST_PROJECT_PATH, 'notes.md'),
+            { timeout: 15_000, interval: 100, timeoutMsg: 'Child file click did not open the document' },
+        );
+    });
+
+    it('clicking an expanded project row collapses it', async () => {
+        const row = await projectRow();
+        await row.click();
+        await browser.waitUntil(async () => await isExpanded(), {
+            timeout: 5_000, interval: 100, timeoutMsg: 'Project did not expand',
+        });
+
+        await row.click();
+        await browser.waitUntil(async () => !(await isExpanded()), {
+            timeout: 5_000, interval: 100, timeoutMsg: 'Project did not collapse on second click',
+        });
+        await browser.waitUntil(async () => (await childRowCount()) === 0, {
+            timeout: 5_000, interval: 100, timeoutMsg: 'Child rows remained after collapse',
+        });
+    });
+});

--- a/e2e/tests/command-bar-prefixes.spec.ts
+++ b/e2e/tests/command-bar-prefixes.spec.ts
@@ -1,0 +1,95 @@
+/**
+ * FloatingCommandBar prefix-mode transitions (issue #280, Playwright half).
+ *
+ * The six single-character prefixes and the `:file` verb morph the command
+ * bar into mode-specific pickers. Driving them requires *typing* a query into
+ * the bar's textarea — which WKWebView's WebDriver (the e2e-real harness)
+ * cannot reliably deliver to a React input. Chromium under Playwright types
+ * normally, so the prefix-grammar coverage lives here; the summon / Esc / pin
+ * shortcuts (which don't need typed input) are covered in the real-E2E
+ * command-bar spec.
+ *
+ * Selectors (per `src/components/cmd/FloatingCommandBar.tsx` + modes/):
+ *   - container: [data-cmd-bar]
+ *   - input:     textarea[role="combobox"]
+ *   - PaletteMode: [data-palette-list] / [data-palette-row] / [data-palette-empty]
+ *   - TagMode:     [data-cmd-mode="tag"]
+ *   - all pickers render a [role="listbox"] dropdown
+ */
+import { test, expect } from '@playwright/test';
+import { setupTauriMock } from '../fixtures/tauri-mock';
+
+test.describe('Command bar — prefix modes', () => {
+    test.beforeEach(async ({ page }) => {
+        await setupTauriMock(page);
+        await page.goto('/');
+        await page.waitForLoadState('networkidle');
+    });
+
+    /** Expands the bar and returns the combobox input locator. */
+    async function expandBar(page: import('@playwright/test').Page) {
+        const bar = page.locator('[data-cmd-bar]');
+        await page.keyboard.press('Meta+k');
+        await expect(bar).toHaveAttribute('data-expanded', 'true', { timeout: 5000 });
+        const input = bar.locator('textarea[role="combobox"]');
+        await expect(input).toBeVisible({ timeout: 5000 });
+        return input;
+    }
+
+    // Each single-char prefix, typed as the first character, must morph the
+    // bar into its picker (a role="listbox" dropdown) rather than treating the
+    // character as literal chat text.
+    const PREFIXES: { char: string; mode: string }[] = [
+        { char: '/', mode: 'SkillMode' },
+        { char: '@', mode: 'ReferenceMode' },
+        { char: '#', mode: 'TagMode' },
+        { char: '!', mode: 'TaskMode' },
+        { char: '?', mode: 'ResearchMode' },
+        { char: '>', mode: 'PaletteMode' },
+    ];
+
+    for (const { char, mode } of PREFIXES) {
+        test(`typing "${char}" activates ${mode}`, async ({ page }) => {
+            const input = await expandBar(page);
+            await input.fill(char);
+            await expect(input).toHaveValue(char);
+
+            // A picker dropdown appears inside the bar (proves the prefix
+            // activated a mode rather than staying literal chat text).
+            const picker = page.locator('[data-cmd-bar] [role="listbox"]');
+            await expect(picker.first()).toBeVisible({ timeout: 5000 });
+        });
+    }
+
+    test('`>` PaletteMode renders action rows and filters on query', async ({ page }) => {
+        const input = await expandBar(page);
+        await input.fill('>theme');
+        const matchingRow = page.locator('[data-palette-row]').filter({ hasText: /theme/i });
+        const emptyState = page.locator('[data-palette-empty]');
+        await expect(matchingRow.or(emptyState)).toBeVisible({ timeout: 5000 });
+    });
+
+    test('`#` TagMode renders the tag picker', async ({ page }) => {
+        const input = await expandBar(page);
+        await input.fill('#');
+        await expect(page.locator('[data-cmd-mode="tag"]').first()).toBeVisible({ timeout: 5000 });
+    });
+
+    test('`:file ` verb activates FileMode', async ({ page }) => {
+        const input = await expandBar(page);
+        await input.fill(':file ');
+        // FileMode shows its filename-search listbox (empty query lists MRU).
+        const picker = page.locator('[data-cmd-bar] [role="listbox"]');
+        await expect(picker.first()).toBeVisible({ timeout: 5000 });
+    });
+
+    test('backspacing past the prefix returns to default chat mode', async ({ page }) => {
+        const input = await expandBar(page);
+        await input.fill('#');
+        await expect(page.locator('[data-cmd-mode="tag"]').first()).toBeVisible({ timeout: 5000 });
+
+        await input.fill('');
+        // The tag picker is gone once the prefix is removed.
+        await expect(page.locator('[data-cmd-mode="tag"]')).toHaveCount(0, { timeout: 5000 });
+    });
+});

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "generate-changelog": "pnpm dlx tsx scripts/generate-changelog.ts",
     "preview": "vite preview",
     "tauri": "tauri",
-    "tauri:test": "tauri dev --features e2e-testing",
+    "tauri:test": "tauri dev --features e2e-testing --config src-tauri/tauri.e2e.conf.json",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",

--- a/src-tauri/tauri.e2e.conf.json
+++ b/src-tauri/tauri.e2e.conf.json
@@ -1,0 +1,24 @@
+{
+  "app": {
+    "windows": [
+      {
+        "title": "Notesage",
+        "width": 1200,
+        "height": 800,
+        "minWidth": 800,
+        "minHeight": 600,
+        "resizable": true,
+        "decorations": true,
+        "hiddenTitle": true,
+        "titleBarStyle": "Overlay",
+        "trafficLightPosition": {
+          "x": 12,
+          "y": 20
+        },
+        "dragDropEnabled": false,
+        "visible": false,
+        "incognito": true
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Closes #277, #278, #279, #280.

The remaining real-E2E spec backlog from the Classic-Layout removal, plus a harness improvement that makes local real-E2E runs match CI without touching the developer's real data.

## New real-E2E specs (`e2e-real/`)
All driven through the WKWebView-safe pattern proven in `document-switching.test.ts` (#276): exposed Zustand stores + DOM clicks + global shortcuts. **No typing into React inputs** (WKWebView's WebDriver can't reliably deliver it).

- **`sidebar-pinned.test.ts` (#277)** — pin/unpin, persistence (asserted via the `notesage-workspace` localStorage artifact, since the harness has no app-restart), insertion order, click-to-activate, active-row highlight. **5 tests.**
- **`sidebar-recent.test.ts` (#278)** — MRU order, dedup, display-cap clamp, click-to-activate. **4 tests.** Two original criteria are **dropped with rationale in-file** because they test behaviour that doesn't exist:
  - *"cap 0 hides Recent"* — `setSidebarRecentCap` clamps to **[3, 15]**; only Tags/Mentions go to 0. The criterion conflated Recent with those.
  - *"externally-deleted file removed from Recent"* — `removeRecent` is wired only to **app-initiated** delete (`useFileOperations.deletePath`); the filesystem watcher refreshes the tree but does **not** prune Recent. (Flagged as a possible follow-up — see below.)
- **`sidebar-tree-nav.test.ts` (#279, reinterpreted)** — the original TreeOverlay (`⌘⇧E`) was **deleted** (regression-locked by `no-tree-overlay.test.ts`; `⌘⇧E` is now Export). This covers its replacement: QuietSidebar **inline expand/collapse** on project rows (click-driven) + child-file open. **4 tests.**
- **`command-bar.test.ts` (#280, real-E2E half)** — `⌘K` summon, double-tap `⌘`, `Esc` collapse, pinned-mode + `⌘⇧C` unpin. **4 tests.**

## New Playwright spec (`e2e/`)
- **`command-bar-prefixes.spec.ts` (#280, typing half)** — the six prefix modes (`/ @ # ! ? >`) + the `:file` verb. These require typed input, so per the agreed split they run in **Chromium/Playwright** (mocked IPC, where typing works) rather than WKWebView. **10 tests.**

## Isolated real-E2E harness
`src-tauri/tauri.e2e.conf.json` enables an **incognito (ephemeral) webview** for the `e2e-testing` build; `tauri:test` wires it via `--config`. Effect: localStorage is empty each launch, so the app boots clean — no persisted projects/connections/recentFiles, no iCloud indexing, no agent spawning — and it **never touches the developer's real `~/Library` state**. This is what was causing local real-E2E to be flaky on developer machines with heavy workspaces (CI runners are naturally clean); it also benefits CI by guaranteeing a clean slate.

## Validation
Each new spec was run **individually against the real Tauri app (unlocked)** and passes:

| Spec | Result |
|---|---|
| sidebar-pinned (#277) | 5/5 |
| sidebar-recent (#278) | 4/4 |
| sidebar-tree-nav (#279) | 4/4 |
| command-bar real-E2E (#280) | 4/4 |
| command-bar-prefixes Playwright (#280) | 10/10 |

Full Playwright suite: **46 passed**. A full real-E2E orchestrator run was attempted but the dev laptop locked partway, which pauses WebKit's `requestAnimationFrame` and stalls the editor's content-load pipeline — every failure there was the `openFile` sentinel-render timeout (the lock signature), not an assertion. The **Real Tauri E2E CI job is the authoritative gate** (runs on an unlocked active session).

## Follow-up worth filing
External-delete doesn't prune Recent (only app-initiated delete does) — arguably a small bug. Left out of scope here (no `src/` changes in a test PR); happy to open a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)