### PR TITLE
test(e2e): expand Playwright coverage for input-driven flows + WebKit project

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -147,7 +147,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install --with-deps chromium webkit
 
       - name: Run E2E tests
         env:

--- a/e2e/fixtures/sample-data.ts
+++ b/e2e/fixtures/sample-data.ts
@@ -92,3 +92,165 @@ export const SAMPLE_FILE_TREE = [
     ],
   },
 ];
+
+// ---------------------------------------------------------------------------
+// Document-index fixtures — back the FloatingCommandBar's index-backed prefix
+// modes (`#` tags, `@` references, `?` research, `:file` filename search).
+//
+// Shapes mirror the TS interfaces in `src/lib/tauri.ts` exactly:
+//   IndexedTag, IndexTagOccurrence, IndexedMention, IndexResearchResult,
+//   IndexFilenameSearchResult.
+// The Rust commands these mock (`index_tags`, `index_tag_occurrences`,
+// `index_mentions`, `index_mention_occurrences`, `index_search_research`,
+// `index_search_filenames`) serialize the same snake_case fields.
+// ---------------------------------------------------------------------------
+
+/** Rows from `index_tags` — `{ tag, file_count }`, ordered file_count desc. */
+export const SAMPLE_TAGS = [
+  { tag: 'roadmap', file_count: 3 },
+  { tag: 'research', file_count: 2 },
+  { tag: 'bug', file_count: 1 },
+];
+
+/**
+ * Rows from `index_tag_occurrences` — `{ path, file_name, context_before,
+ * context_after }`. Keyed in the mock by the requested `tag` arg.
+ */
+export const SAMPLE_TAG_OCCURRENCES: Record<
+  string,
+  Array<{
+    path: string;
+    file_name: string;
+    context_before: string;
+    context_after: string;
+  }>
+> = {
+  roadmap: [
+    {
+      path: `${SAMPLE_PROJECT_PATH}/notes.md`,
+      file_name: 'notes.md',
+      context_before: 'the new feature ',
+      context_after: ' before quarter',
+    },
+    {
+      path: `${SAMPLE_PROJECT_PATH}/welcome.md`,
+      file_name: 'welcome.md',
+      context_before: 'see the ',
+      context_after: ' for details',
+    },
+  ],
+  research: [
+    {
+      path: `${SAMPLE_PROJECT_PATH}/welcome.md`,
+      file_name: 'welcome.md',
+      context_before: 'ongoing ',
+      context_after: ' notes',
+    },
+  ],
+  bug: [
+    {
+      path: `${SAMPLE_PROJECT_PATH}/todo.md`,
+      file_name: 'todo.md',
+      context_before: 'fix the sidebar ',
+      context_after: ' soon',
+    },
+  ],
+};
+
+/** Rows from `index_mentions` — `{ mention, file_count }`, file_count desc. */
+export const SAMPLE_MENTIONS = [
+  { mention: 'alice', file_count: 2 },
+  { mention: 'bob', file_count: 1 },
+];
+
+/**
+ * Rows from `index_mention_occurrences` — same shape as tag occurrences
+ * (`IndexTagOccurrence`). Keyed in the mock by the requested `mention` arg.
+ */
+export const SAMPLE_MENTION_OCCURRENCES: Record<
+  string,
+  Array<{
+    path: string;
+    file_name: string;
+    context_before: string;
+    context_after: string;
+  }>
+> = {
+  alice: [
+    {
+      path: `${SAMPLE_PROJECT_PATH}/notes.md`,
+      file_name: 'notes.md',
+      context_before: 'assigned to ',
+      context_after: ' for review',
+    },
+    {
+      path: `${SAMPLE_PROJECT_PATH}/todo.md`,
+      file_name: 'todo.md',
+      context_before: 'ping ',
+      context_after: ' about the PR',
+    },
+  ],
+  bob: [
+    {
+      path: `${SAMPLE_PROJECT_PATH}/welcome.md`,
+      file_name: 'welcome.md',
+      context_before: 'thanks ',
+      context_after: ' for the help',
+    },
+  ],
+};
+
+/**
+ * Rows from `index_search_research` — `IndexResearchResult`. Field set:
+ * `{ file, title, tags, source_url, snippet, date_saved, word_count }`
+ * (`project_name` optional). ResearchMode keys on `file` (open path) and
+ * renders `title`, `date_saved`, and the source hostname.
+ */
+export const SAMPLE_RESEARCH = [
+  {
+    file: `${SAMPLE_PROJECT_PATH}/research/climate-policy.md`,
+    title: 'Climate Policy Overview',
+    tags: ['climate', 'policy'],
+    source_url: 'https://example.com/climate',
+    snippet: 'A survey of recent climate policy proposals.',
+    date_saved: '2026-03-01',
+    word_count: 1200,
+    project_name: 'E2E Project',
+  },
+  {
+    file: `${SAMPLE_PROJECT_PATH}/research/ai-safety.md`,
+    title: 'AI Safety Notes',
+    tags: ['ai', 'safety'],
+    source_url: 'https://example.org/ai-safety',
+    snippet: 'Collected notes on AI alignment approaches.',
+    date_saved: '2026-02-14',
+    word_count: 850,
+    project_name: 'E2E Project',
+  },
+];
+
+/**
+ * Rows from `index_search_filenames` — `IndexFilenameSearchResult`. Field set:
+ * `{ path, file_name, parent_dir, project_root }`. FileMode renders
+ * `file_name` + `parent_dir` and opens `path` on selection.
+ */
+export const SAMPLE_FILENAME_RESULTS = [
+  {
+    path: `${SAMPLE_PROJECT_PATH}/notes.md`,
+    file_name: 'notes.md',
+    parent_dir: SAMPLE_PROJECT_PATH,
+    project_root: SAMPLE_PROJECT_PATH,
+  },
+  {
+    path: `${SAMPLE_PROJECT_PATH}/todo.md`,
+    file_name: 'todo.md',
+    parent_dir: SAMPLE_PROJECT_PATH,
+    project_root: SAMPLE_PROJECT_PATH,
+  },
+  {
+    path: `${SAMPLE_PROJECT_PATH}/welcome.md`,
+    file_name: 'welcome.md',
+    parent_dir: SAMPLE_PROJECT_PATH,
+    project_root: SAMPLE_PROJECT_PATH,
+  },
+];

--- a/e2e/fixtures/tauri-mock.ts
+++ b/e2e/fixtures/tauri-mock.ts
@@ -6,7 +6,17 @@
  * commands and allows per-test overrides.
  */
 import type { Page } from '@playwright/test';
-import { SAMPLE_FILE_TREE, SAMPLE_FILES, SAMPLE_PROJECT_PATH } from './sample-data';
+import {
+  SAMPLE_FILE_TREE,
+  SAMPLE_FILES,
+  SAMPLE_PROJECT_PATH,
+  SAMPLE_TAGS,
+  SAMPLE_TAG_OCCURRENCES,
+  SAMPLE_MENTIONS,
+  SAMPLE_MENTION_OCCURRENCES,
+  SAMPLE_RESEARCH,
+  SAMPLE_FILENAME_RESULTS,
+} from './sample-data';
 
 export interface TauriMockOptions {
   /** Override default command handlers. Key = command name, value = return value or function body string. */
@@ -37,8 +47,19 @@ export async function setupTauriMock(page: Page, options: TauriMockOptions = {})
 
   const overrides = options.overrides ?? {};
 
+  // Document-index sample data, passed into the page context so the index
+  // handlers below can return realistic shapes for the command-bar modes.
+  const indexData = {
+    tags: SAMPLE_TAGS,
+    tagOccurrences: SAMPLE_TAG_OCCURRENCES,
+    mentions: SAMPLE_MENTIONS,
+    mentionOccurrences: SAMPLE_MENTION_OCCURRENCES,
+    research: SAMPLE_RESEARCH,
+    filenames: SAMPLE_FILENAME_RESULTS,
+  };
+
   await page.addInitScript(
-    ({ fileTree, fileContents, overrides, projectPath }) => {
+    ({ fileTree, fileContents, overrides, projectPath, indexData }) => {
       // ---------------------------------------------------------------------------
       // Callback registry — implements transformCallback for @tauri-apps/api
       // ---------------------------------------------------------------------------
@@ -153,6 +174,9 @@ export async function setupTauriMock(page: Page, options: TauriMockOptions = {})
 
         // Document index
         index_init: () => null,
+        // Legacy mock entries (command names the app does NOT actually invoke).
+        // Kept so existing callers don't regress; the real commands below are
+        // what TagMode/ReferenceMode/ResearchMode/FileMode call.
         index_query_tags: () => [],
         index_query_mentions: () => [],
         index_query_headings: () => [],
@@ -161,6 +185,65 @@ export async function setupTauriMock(page: Page, options: TauriMockOptions = {})
         index_reindex_directory: () => null,
         index_tasks: () => [],
         index_goals: () => [],
+
+        // ---- Real document-index commands (the ones the app invokes) ----
+        // `index_tags` → IndexedTag[] `{ tag, file_count }`, file_count desc.
+        // Optional `query` substring-filters the tag name (mirrors Rust).
+        index_tags: (args) => {
+          const q = ((args?.query as string | null) ?? '').trim().toLowerCase();
+          const rows = indexData.tags;
+          return q ? rows.filter((r) => r.tag.toLowerCase().includes(q)) : rows;
+        },
+        // `index_tag_occurrences` → IndexTagOccurrence[]
+        // `{ path, file_name, context_before, context_after }`, keyed by `tag`.
+        index_tag_occurrences: (args) => {
+          const tag = (args?.tag as string) ?? '';
+          return indexData.tagOccurrences[tag] ?? [];
+        },
+        // `index_mentions` → IndexedMention[] `{ mention, file_count }`.
+        index_mentions: (args) => {
+          const q = ((args?.query as string | null) ?? '').trim().toLowerCase();
+          const rows = indexData.mentions;
+          return q
+            ? rows.filter((r) => r.mention.toLowerCase().includes(q))
+            : rows;
+        },
+        // `index_mention_occurrences` → IndexTagOccurrence[], keyed by `mention`.
+        index_mention_occurrences: (args) => {
+          const mention = (args?.mention as string) ?? '';
+          return indexData.mentionOccurrences[mention] ?? [];
+        },
+        // `index_search_research` → IndexResearchResult[]. Substring-filters
+        // title/snippet/tags by `query`; `tag` exact-matches a tag if present.
+        index_search_research: (args) => {
+          const q = ((args?.query as string | null) ?? '').trim().toLowerCase();
+          const tag = ((args?.tag as string | null) ?? '').trim().toLowerCase();
+          let rows = indexData.research;
+          if (q) {
+            rows = rows.filter(
+              (r) =>
+                r.title.toLowerCase().includes(q) ||
+                r.snippet.toLowerCase().includes(q) ||
+                r.tags.some((t) => t.toLowerCase().includes(q)),
+            );
+          }
+          if (tag) {
+            rows = rows.filter((r) =>
+              r.tags.some((t) => t.toLowerCase() === tag),
+            );
+          }
+          return rows;
+        },
+        // `index_search_filenames` → IndexFilenameSearchResult[]
+        // `{ path, file_name, parent_dir, project_root }`. Substring-filters
+        // the basename by the required `query`.
+        index_search_filenames: (args) => {
+          const q = ((args?.query as string) ?? '').trim().toLowerCase();
+          const rows = indexData.filenames;
+          return q
+            ? rows.filter((r) => r.file_name.toLowerCase().includes(q))
+            : rows;
+        },
 
         // Actions
         scan_actions: () => [],
@@ -246,7 +329,7 @@ export async function setupTauriMock(page: Page, options: TauriMockOptions = {})
         }
       };
     },
-    { fileTree, fileContents, overrides, projectPath: SAMPLE_PROJECT_PATH },
+    { fileTree, fileContents, overrides, projectPath: SAMPLE_PROJECT_PATH, indexData },
   );
 }
 

--- a/e2e/tests/command-bar/file-research-journeys.spec.ts
+++ b/e2e/tests/command-bar/file-research-journeys.spec.ts
@@ -1,0 +1,140 @@
+/**
+ * Command bar — `:file` FileMode and `?` ResearchMode journeys.
+ *
+ * Both are SQLite-index-backed. The mock now answers the real commands these
+ * modes invoke (`index_search_filenames`, `index_search_research`) with
+ * fixtures from `e2e/fixtures/sample-data.ts`.
+ *
+ * Journey: type the prefix + query → assert index-backed rows appear → select
+ * a row → assert the file opens.
+ *   - FileMode opens via `useFileOperations.openFile` directly (→ `read_file`).
+ *   - ResearchMode fires `notesage:open-file`, App.tsx routes to `openFile`
+ *     (→ `read_file`).
+ *
+ * Selectors (both modes render a [role="listbox"] with [role="option"][data-index] rows):
+ *   - FileMode:     [role="listbox"][aria-label="File search results"]
+ *   - ResearchMode: [role="listbox"][aria-label="Research results"]
+ */
+import { test, expect } from '@playwright/test';
+import { setupTauriMock, trackInvokeCalls } from '../../fixtures/tauri-mock';
+import { SAMPLE_PROJECT_PATH } from '../../fixtures/sample-data';
+
+test.describe('Command bar — FileMode (`:file`) journeys', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupTauriMock(page);
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+  });
+
+  async function expandBar(page: import('@playwright/test').Page) {
+    const bar = page.locator('[data-cmd-bar]');
+    await page.keyboard.press('Meta+k');
+    await expect(bar).toHaveAttribute('data-expanded', 'true', { timeout: 5000 });
+    const input = bar.locator('textarea[role="combobox"]');
+    await expect(input).toBeVisible({ timeout: 5000 });
+    return input;
+  }
+
+  // `:file note` → filename search lists the `notes.md` fixture row.
+  test('`:file note` lists matching filename rows from the index', async ({ page }) => {
+    const input = await expandBar(page);
+    await input.fill(':file note');
+
+    const fileList = page.locator('[role="listbox"][aria-label="File search results"]');
+    await expect(fileList).toBeVisible({ timeout: 5000 });
+    await expect(
+      fileList.locator('[role="option"]').filter({ hasText: 'notes.md' }),
+    ).toBeVisible({ timeout: 5000 });
+  });
+
+  // Full journey: search → select a result → the file opens (read_file fires).
+  test('`:file note` → select result opens the file', async ({ page }) => {
+    const getCalls = await trackInvokeCalls(page);
+    const input = await expandBar(page);
+    await input.fill(':file notes');
+
+    const row = page
+      .locator('[role="listbox"][aria-label="File search results"] [role="option"]')
+      .filter({ hasText: 'notes.md' });
+    await expect(row).toBeVisible({ timeout: 5000 });
+    await row.click();
+
+    await expect
+      .poll(async () => {
+        const calls = await getCalls();
+        return calls.some(
+          (c) =>
+            c.cmd === 'read_file' &&
+            (c.args as { path?: string })?.path === `${SAMPLE_PROJECT_PATH}/notes.md`,
+        );
+      }, { timeout: 5000 })
+      .toBe(true);
+  });
+
+  // A query that matches no filename shows FileMode's empty state.
+  test('`:file zzznomatch` shows the no-results state', async ({ page }) => {
+    const input = await expandBar(page);
+    await input.fill(':file zzznomatch');
+
+    const fileList = page.locator('[role="listbox"][aria-label="File search results"]');
+    await expect(fileList).toBeVisible({ timeout: 5000 });
+    await expect(fileList).toContainText('No files matching', { timeout: 5000 });
+  });
+});
+
+test.describe('Command bar — ResearchMode (`?`) journeys', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupTauriMock(page);
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+  });
+
+  async function expandBar(page: import('@playwright/test').Page) {
+    const bar = page.locator('[data-cmd-bar]');
+    await page.keyboard.press('Meta+k');
+    await expect(bar).toHaveAttribute('data-expanded', 'true', { timeout: 5000 });
+    const input = bar.locator('textarea[role="combobox"]');
+    await expect(input).toBeVisible({ timeout: 5000 });
+    return input;
+  }
+
+  // `?climate` → research search lists the "Climate Policy Overview" fixture.
+  // ResearchMode debounces the backend query 300 ms, so allow the extra time.
+  test('`?climate` lists matching research rows from the index', async ({ page }) => {
+    const input = await expandBar(page);
+    await input.fill('?climate');
+
+    const researchList = page.locator('[role="listbox"][aria-label="Research results"]');
+    await expect(researchList).toBeVisible({ timeout: 5000 });
+    await expect(
+      researchList.locator('[role="option"]').filter({ hasText: 'Climate Policy Overview' }),
+    ).toBeVisible({ timeout: 5000 });
+  });
+
+  // Full journey: search → select a research row → the research file opens.
+  test('`?climate` → select result opens the research file', async ({ page }) => {
+    const getCalls = await trackInvokeCalls(page);
+    const input = await expandBar(page);
+    await input.fill('?climate');
+
+    const row = page
+      .locator('[role="listbox"][aria-label="Research results"] [role="option"]')
+      .filter({ hasText: 'Climate Policy Overview' });
+    await expect(row).toBeVisible({ timeout: 5000 });
+    await row.click();
+
+    // ResearchMode → notesage:open-file → openFile → read_file on the
+    // research fixture's `file` path.
+    await expect
+      .poll(async () => {
+        const calls = await getCalls();
+        return calls.some(
+          (c) =>
+            c.cmd === 'read_file' &&
+            (c.args as { path?: string })?.path ===
+              `${SAMPLE_PROJECT_PATH}/research/climate-policy.md`,
+        );
+      }, { timeout: 5000 })
+      .toBe(true);
+  });
+});

--- a/e2e/tests/command-bar/palette-execute.spec.ts
+++ b/e2e/tests/command-bar/palette-execute.spec.ts
@@ -1,0 +1,104 @@
+/**
+ * Command bar — PaletteMode (`>`) execute journeys.
+ *
+ * PaletteMode is static (no IPC): the `>` prefix morphs the FloatingCommandBar
+ * into a command-action picker. Picking a row fires `notesage:palette-command`,
+ * which App.tsx maps to the same callbacks the keyboard chords use. This spec
+ * drives "type `>query` → pick the row → observe the real side effect".
+ *
+ * No mock changes needed — these actions are pure frontend state.
+ *
+ * Selectors (per `src/components/cmd/modes/PaletteMode.tsx`):
+ *   - list:  [data-palette-list]
+ *   - row:   [data-palette-row="<id>"]
+ *   - empty: [data-palette-empty]
+ */
+import { test, expect } from '@playwright/test';
+import { setupTauriMock } from '../../fixtures/tauri-mock';
+
+test.describe('Command bar — PaletteMode execute', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupTauriMock(page);
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+  });
+
+  /** Expands the bar and returns the combobox input locator. */
+  async function expandBar(page: import('@playwright/test').Page) {
+    const bar = page.locator('[data-cmd-bar]');
+    await page.keyboard.press('Meta+k');
+    await expect(bar).toHaveAttribute('data-expanded', 'true', { timeout: 5000 });
+    const input = bar.locator('textarea[role="combobox"]');
+    await expect(input).toBeVisible({ timeout: 5000 });
+    return input;
+  }
+
+  // `>theme` filters to the theme-toggle action; clicking the row toggles the
+  // `dark` class on <html> — the same side effect as the ⌘T chord.
+  test('`>theme` → click toggles the theme (dark class flips)', async ({ page }) => {
+    const html = page.locator('html');
+    const initialHasDark = await html.evaluate((el) => el.classList.contains('dark'));
+
+    const input = await expandBar(page);
+    await input.fill('>theme');
+
+    const themeRow = page.locator('[data-palette-row="toggle-theme"]');
+    await expect(themeRow).toBeVisible({ timeout: 5000 });
+
+    await themeRow.click();
+
+    if (initialHasDark) {
+      await expect(html).not.toHaveClass(/\bdark\b/, { timeout: 5000 });
+    } else {
+      await expect(html).toHaveClass(/\bdark\b/, { timeout: 5000 });
+    }
+  });
+
+  // The bar stays open after a palette pick (documented behaviour), so a second
+  // pick on the same row toggles the theme back — Enter on the highlighted row.
+  test('`>theme` → Enter toggles the theme via keyboard', async ({ page }) => {
+    const html = page.locator('html');
+    const initialHasDark = await html.evaluate((el) => el.classList.contains('dark'));
+
+    const input = await expandBar(page);
+    await input.fill('>theme');
+
+    const themeRow = page.locator('[data-palette-row="toggle-theme"]');
+    await expect(themeRow).toBeVisible({ timeout: 5000 });
+
+    // First palette row is auto-highlighted; Enter picks it.
+    await page.keyboard.press('Enter');
+
+    if (initialHasDark) {
+      await expect(html).not.toHaveClass(/\bdark\b/, { timeout: 5000 });
+    } else {
+      await expect(html).toHaveClass(/\bdark\b/, { timeout: 5000 });
+    }
+  });
+
+  // `>sidebar` filters to the sidebar-toggle action and picking it runs without
+  // error (settings-store side effect isn't externally observable in the DOM,
+  // so we assert the app stays functional through the pick).
+  test('`>sidebar` → click toggles the sidebar without crashing', async ({ page }) => {
+    const input = await expandBar(page);
+    await input.fill('>sidebar');
+
+    const sidebarRow = page.locator('[data-palette-row="toggle-sidebar"]');
+    await expect(sidebarRow).toBeVisible({ timeout: 5000 });
+
+    await sidebarRow.click();
+
+    // App remains responsive after the command fires.
+    await expect(page.locator('body')).toBeVisible();
+    await expect(page.locator('[data-cmd-bar]')).toBeVisible();
+  });
+
+  // A query that matches nothing shows the empty state rather than stale rows.
+  test('`>zzznotacommand` shows the palette empty state', async ({ page }) => {
+    const input = await expandBar(page);
+    await input.fill('>zzznotacommand');
+
+    await expect(page.locator('[data-palette-empty]')).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('[data-palette-row]')).toHaveCount(0);
+  });
+});

--- a/e2e/tests/command-bar/tag-reference-journeys.spec.ts
+++ b/e2e/tests/command-bar/tag-reference-journeys.spec.ts
@@ -1,0 +1,169 @@
+/**
+ * Command bar — `#` TagMode and `@` ReferenceMode journeys.
+ *
+ * Both modes are SQLite-index-backed. The mock (`e2e/fixtures/tauri-mock.ts`)
+ * now answers the real commands these modes invoke (`index_tags`,
+ * `index_tag_occurrences`, `index_mentions`, `index_mention_occurrences`)
+ * with fixtures from `e2e/fixtures/sample-data.ts`.
+ *
+ * Journey: type the prefix + query → assert index-backed rows appear → drill
+ * into a tag/person → select an occurrence → assert the file opens (the
+ * occurrence pick fires `notesage:open-file-at-tag`, App.tsx routes it to
+ * `openFileAtTag`, which reads the file via `read_file`).
+ *
+ * Selectors:
+ *   - TagMode L1:  [data-cmd-mode="tag"][data-cmd-mode-level="tags"], rows [role="option"]
+ *   - TagMode L2:  [data-cmd-mode="tag"][data-cmd-mode-level="occurrences"], rows [role="option"]
+ *   - ReferenceMode L1: [data-reference-list], rows [role="option"][data-result-kind]
+ *   - ReferenceMode L2: [data-cmd-mode-level="occurrences"], rows [role="option"]
+ */
+import { test, expect } from '@playwright/test';
+import { setupTauriMock, trackInvokeCalls } from '../../fixtures/tauri-mock';
+import { SAMPLE_PROJECT_PATH } from '../../fixtures/sample-data';
+
+test.describe('Command bar — TagMode (`#`) journeys', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupTauriMock(page);
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+  });
+
+  async function expandBar(page: import('@playwright/test').Page) {
+    const bar = page.locator('[data-cmd-bar]');
+    await page.keyboard.press('Meta+k');
+    await expect(bar).toHaveAttribute('data-expanded', 'true', { timeout: 5000 });
+    const input = bar.locator('textarea[role="combobox"]');
+    await expect(input).toBeVisible({ timeout: 5000 });
+    return input;
+  }
+
+  // `#road` → TagMode level 1 shows the `roadmap` tag row from the fixtures.
+  test('`#road` lists matching tag rows from the index', async ({ page }) => {
+    const input = await expandBar(page);
+    await input.fill('#road');
+
+    const tagList = page.locator('[data-cmd-mode="tag"][data-cmd-mode-level="tags"]');
+    await expect(tagList).toBeVisible({ timeout: 5000 });
+    await expect(tagList.locator('[role="option"]').filter({ hasText: 'roadmap' })).toBeVisible({
+      timeout: 5000,
+    });
+  });
+
+  // Full journey: pick a tag → occurrences level → pick an occurrence → file opens.
+  test('`#` → select tag → select occurrence opens the file', async ({ page }) => {
+    const getCalls = await trackInvokeCalls(page);
+    const input = await expandBar(page);
+    await input.fill('#roadmap');
+
+    // Level 1 — pick the roadmap tag.
+    const tagRow = page
+      .locator('[data-cmd-mode="tag"][data-cmd-mode-level="tags"] [role="option"]')
+      .filter({ hasText: 'roadmap' });
+    await expect(tagRow).toBeVisible({ timeout: 5000 });
+    await tagRow.click();
+
+    // Level 2 — occurrences for #roadmap.
+    const occList = page.locator('[data-cmd-mode="tag"][data-cmd-mode-level="occurrences"]');
+    await expect(occList).toBeVisible({ timeout: 5000 });
+    const firstOcc = occList.locator('[role="option"]').first();
+    await expect(firstOcc).toBeVisible({ timeout: 5000 });
+    await firstOcc.click();
+
+    // Picking the occurrence routes through openFileAtTag → read_file on the
+    // occurrence's path (notes.md is the first #roadmap occurrence fixture).
+    await expect
+      .poll(async () => {
+        const calls = await getCalls();
+        return calls.some(
+          (c) =>
+            c.cmd === 'read_file' &&
+            (c.args as { path?: string })?.path === `${SAMPLE_PROJECT_PATH}/notes.md`,
+        );
+      }, { timeout: 5000 })
+      .toBe(true);
+  });
+
+  // Esc at the occurrences level returns to the tag list (does not dismiss).
+  test('`#` → select tag → Esc returns to the tag list', async ({ page }) => {
+    const input = await expandBar(page);
+    await input.fill('#roadmap');
+
+    const tagRow = page
+      .locator('[data-cmd-mode="tag"][data-cmd-mode-level="tags"] [role="option"]')
+      .filter({ hasText: 'roadmap' });
+    await expect(tagRow).toBeVisible({ timeout: 5000 });
+    await tagRow.click();
+
+    await expect(
+      page.locator('[data-cmd-mode="tag"][data-cmd-mode-level="occurrences"]'),
+    ).toBeVisible({ timeout: 5000 });
+
+    await page.keyboard.press('Escape');
+
+    await expect(
+      page.locator('[data-cmd-mode="tag"][data-cmd-mode-level="tags"]'),
+    ).toBeVisible({ timeout: 5000 });
+  });
+});
+
+test.describe('Command bar — ReferenceMode (`@`) journeys', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupTauriMock(page);
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+  });
+
+  async function expandBar(page: import('@playwright/test').Page) {
+    const bar = page.locator('[data-cmd-bar]');
+    await page.keyboard.press('Meta+k');
+    await expect(bar).toHaveAttribute('data-expanded', 'true', { timeout: 5000 });
+    const input = bar.locator('textarea[role="combobox"]');
+    await expect(input).toBeVisible({ timeout: 5000 });
+    return input;
+  }
+
+  // `@alice` → ReferenceMode surfaces a "person" row from the mention index.
+  test('`@alice` lists a person reference from the mention index', async ({ page }) => {
+    const input = await expandBar(page);
+    await input.fill('@alice');
+
+    const refList = page.locator('[data-reference-list]');
+    await expect(refList.first()).toBeVisible({ timeout: 5000 });
+    const personRow = refList
+      .locator('[role="option"][data-result-kind="person"]')
+      .filter({ hasText: 'alice' });
+    await expect(personRow).toBeVisible({ timeout: 5000 });
+  });
+
+  // Full journey: pick the person → occurrences drilldown → pick occurrence → file opens.
+  test('`@` → select person → select occurrence opens the file', async ({ page }) => {
+    const getCalls = await trackInvokeCalls(page);
+    const input = await expandBar(page);
+    await input.fill('@alice');
+
+    const personRow = page
+      .locator('[data-reference-list] [role="option"][data-result-kind="person"]')
+      .filter({ hasText: 'alice' });
+    await expect(personRow).toBeVisible({ timeout: 5000 });
+    await personRow.click();
+
+    // Level 2 — @alice occurrences across files.
+    const occList = page.locator('[data-cmd-mode-level="occurrences"]');
+    await expect(occList).toBeVisible({ timeout: 5000 });
+    const firstOcc = occList.locator('[role="option"]').first();
+    await expect(firstOcc).toBeVisible({ timeout: 5000 });
+    await firstOcc.click();
+
+    // notes.md is the first @alice occurrence fixture.
+    await expect
+      .poll(async () => {
+        const calls = await getCalls();
+        return calls.some(
+          (c) =>
+            c.cmd === 'read_file' &&
+            (c.args as { path?: string })?.path === `${SAMPLE_PROJECT_PATH}/notes.md`,
+        );
+      }, { timeout: 5000 })
+      .toBe(true);
+  });
+});

--- a/e2e/tests/editor/find-replace.spec.ts
+++ b/e2e/tests/editor/find-replace.spec.ts
@@ -1,0 +1,162 @@
+/**
+ * Editor — find AND replace.
+ *
+ * Covers the Cmd+Shift+H flow that opens the find bar with the replace row
+ * already expanded, plus replace / replace-all / match navigation. This path
+ * can't run under the real WKWebView E2E harness (it can't type into inputs),
+ * so it lives here where Chromium drives the keyboard reliably.
+ *
+ * The `welcome.md` sample contains the repeated word "Item" three times
+ * (`Item one`, `Item two`, `Item three`), which is what these tests
+ * find/replace against.
+ */
+import { tauriTest, expect, openFileInEditor } from '../../fixtures';
+
+const findInputSel = 'input[aria-label="Find in document"]';
+const replaceInputSel = 'input[aria-label="Replace"]';
+
+tauriTest.describe('Editor — find and replace', () => {
+  tauriTest.beforeEach(async ({ waitForAppReady }) => {
+    await waitForAppReady();
+  });
+
+  tauriTest('Cmd+Shift+H opens the find bar with the replace row visible', async ({ page }) => {
+    await openFileInEditor(page, 'welcome.md', 'Welcome to Notesage');
+
+    await page.keyboard.press('Meta+Shift+h');
+
+    const findInput = page.locator(findInputSel);
+    await expect(findInput).toBeVisible({ timeout: 3000 });
+    await expect(findInput).toBeFocused();
+
+    // The replace row is expanded by the Cmd+Shift+H entry point.
+    const replaceInput = page.locator(replaceInputSel);
+    await expect(replaceInput).toBeVisible({ timeout: 3000 });
+  });
+
+  tauriTest('typing a query highlights matches and shows a match count', async ({ page }) => {
+    await openFileInEditor(page, 'welcome.md', 'Welcome to Notesage');
+
+    await page.keyboard.press('Meta+Shift+h');
+
+    const findInput = page.locator(findInputSel);
+    await expect(findInput).toBeVisible({ timeout: 3000 });
+
+    await findInput.fill('Item');
+
+    const matchLabel = page.locator('text=/\\d+ of \\d+/');
+    await expect(matchLabel).toBeVisible({ timeout: 3000 });
+
+    const matchText = await matchLabel.textContent();
+    expect(matchText).toMatch(/\d+ of \d+/);
+    const totalMatches = parseInt(matchText!.split(' of ')[1], 10);
+    // "Item" appears three times in welcome.md.
+    expect(totalMatches).toBe(3);
+
+    // Visual highlight decorations should be present.
+    await expect(page.locator('.find-match').first()).toBeVisible({ timeout: 3000 });
+  });
+
+  tauriTest('Replace replaces a single occurrence', async ({ page }) => {
+    await openFileInEditor(page, 'welcome.md', 'Welcome to Notesage');
+
+    const editor = page.locator('.ProseMirror[contenteditable="true"]');
+    await expect(editor).toContainText('Item one');
+
+    await page.keyboard.press('Meta+Shift+h');
+
+    const findInput = page.locator(findInputSel);
+    await expect(findInput).toBeVisible({ timeout: 3000 });
+    await findInput.fill('Item');
+
+    const matchLabel = page.locator('text=/\\d+ of \\d+/');
+    await expect(matchLabel).toBeVisible({ timeout: 3000 });
+
+    const replaceInput = page.locator(replaceInputSel);
+    await replaceInput.fill('Task');
+
+    // Replace the current (first) match only.
+    await page.locator('button[title^="Replace ("]').click();
+
+    // One occurrence becomes "Task"; the rest stay "Item".
+    await expect(editor).toContainText('Task one');
+    await expect(editor).toContainText('Item two');
+    await expect(editor).toContainText('Item three');
+
+    // Match count drops from 3 to 2.
+    await expect(page.locator('text=/\\d+ of 2/')).toBeVisible({ timeout: 3000 });
+  });
+
+  tauriTest('Replace All replaces every occurrence', async ({ page }) => {
+    await openFileInEditor(page, 'welcome.md', 'Welcome to Notesage');
+
+    const editor = page.locator('.ProseMirror[contenteditable="true"]');
+    await expect(editor).toContainText('Item one');
+
+    await page.keyboard.press('Meta+Shift+h');
+
+    const findInput = page.locator(findInputSel);
+    await expect(findInput).toBeVisible({ timeout: 3000 });
+    await findInput.fill('Item');
+
+    await expect(page.locator('text=/\\d+ of 3/')).toBeVisible({ timeout: 3000 });
+
+    const replaceInput = page.locator(replaceInputSel);
+    await replaceInput.fill('Task');
+
+    await page.locator('button[title^="Replace All"]').click();
+
+    // Every "Item" is replaced; none remain.
+    await expect(editor).toContainText('Task one');
+    await expect(editor).toContainText('Task two');
+    await expect(editor).toContainText('Task three');
+    await expect(editor).not.toContainText('Item');
+  });
+
+  tauriTest('Next and Previous navigate between matches', async ({ page }) => {
+    await openFileInEditor(page, 'welcome.md', 'Welcome to Notesage');
+
+    await page.keyboard.press('Meta+Shift+h');
+
+    const findInput = page.locator(findInputSel);
+    await expect(findInput).toBeVisible({ timeout: 3000 });
+    await findInput.fill('Item');
+
+    const matchLabel = page.locator('text=/\\d+ of 3/');
+    await expect(matchLabel).toBeVisible({ timeout: 3000 });
+
+    const readIndex = async (): Promise<number> => {
+      const text = await matchLabel.textContent();
+      return parseInt(text!.split(' of ')[0], 10);
+    };
+
+    const start = await readIndex();
+
+    // Next advances the current-match index.
+    await page.locator('button[aria-label="Next match"]').click();
+    await expect
+      .poll(async () => readIndex(), { timeout: 3000 })
+      .not.toBe(start);
+    const afterNext = await readIndex();
+
+    // Previous returns to the starting index.
+    await page.locator('button[aria-label="Previous match"]').click();
+    await expect
+      .poll(async () => readIndex(), { timeout: 3000 })
+      .toBe(start);
+    expect(afterNext).not.toBe(start);
+  });
+
+  tauriTest('Escape closes the find bar', async ({ page }) => {
+    await openFileInEditor(page, 'welcome.md', 'Welcome to Notesage');
+
+    await page.keyboard.press('Meta+Shift+h');
+
+    const findInput = page.locator(findInputSel);
+    await expect(findInput).toBeVisible({ timeout: 3000 });
+
+    await page.keyboard.press('Escape');
+
+    await expect(findInput).not.toBeVisible({ timeout: 3000 });
+  });
+});

--- a/e2e/tests/settings/settings-search.spec.ts
+++ b/e2e/tests/settings/settings-search.spec.ts
@@ -1,0 +1,81 @@
+/**
+ * Settings dialog search / filter (Playwright).
+ *
+ * Covers the Settings search text-entry flow, which the real WKWebView E2E
+ * harness can't test (can't type into inputs). Chromium/WebKit type fine.
+ *
+ * Search model (SettingsDialogV2): a non-empty query switches the dialog into
+ * a global cross-panel "leaf search" — every panel renders at once and each
+ * `SettingsRow` self-hides when its label/description doesn't match. Matched
+ * labels are wrapped in highlight segments, so assert row presence with
+ * non-exact text matching. The sr-only `role="status"` readout shows
+ * "N of M matches" (nav-label based) while a query is active.
+ */
+import { test, expect } from '@playwright/test';
+import { setupTauriMock } from '../../fixtures/tauri-mock';
+
+async function openSettings(page: import('@playwright/test').Page) {
+    await page.keyboard.press('Meta+,');
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible({ timeout: 10000 });
+    return dialog;
+}
+
+test.describe('Settings — search / filter', () => {
+    test.beforeEach(async ({ page }) => {
+        await setupTauriMock(page);
+        await page.goto('/');
+        await page.waitForLoadState('networkidle');
+    });
+
+    test('Cmd+, opens the settings dialog with a search box', async ({ page }) => {
+        const dialog = await openSettings(page);
+        await expect(dialog.getByRole('searchbox')).toBeVisible({ timeout: 5000 });
+    });
+
+    test('typing a query filters settings rows to matches', async ({ page }) => {
+        const dialog = await openSettings(page);
+        await dialog.getByRole('searchbox').fill('Accent color');
+
+        // The matching row (Appearance panel) stays; matched label text is
+        // highlight-wrapped, so match non-exact.
+        await expect(dialog.getByText('Accent color')).toBeVisible({ timeout: 5000 });
+        // An unrelated row from another panel self-hides.
+        await expect(dialog.getByText('Show in menu bar', { exact: true })).toHaveCount(0, {
+            timeout: 5000,
+        });
+    });
+
+    test('the result-count status reflects the query', async ({ page }) => {
+        const dialog = await openSettings(page);
+        const status = dialog.getByRole('status');
+
+        await dialog.getByRole('searchbox').fill('Voice');
+        await expect(status).toHaveText(/^1 of \d+ matches$/, { timeout: 5000 });
+
+        await dialog.getByRole('searchbox').fill('zzqqxx-no-such-setting');
+        await expect(status).toHaveText(/^0 of \d+ matches$/, { timeout: 5000 });
+    });
+
+    test('the clear button resets the search', async ({ page }) => {
+        const dialog = await openSettings(page);
+        const search = dialog.getByRole('searchbox');
+
+        await search.fill('Accent color');
+        await expect(dialog.getByText('Show in menu bar', { exact: true })).toHaveCount(0, {
+            timeout: 5000,
+        });
+
+        // The clear button renders only while the query is non-empty.
+        const clear = dialog.getByRole('button', { name: 'Clear search' });
+        await expect(clear).toBeVisible();
+        await clear.click();
+
+        // Search resets: input empties, the clear button disappears, and the
+        // dialog leaves leaf-search back to the single active panel (Appearance,
+        // whose "Accent color" row is shown again).
+        await expect(search).toHaveValue('');
+        await expect(clear).toHaveCount(0);
+        await expect(dialog.getByText('Accent color')).toBeVisible({ timeout: 5000 });
+    });
+});

--- a/e2e/tests/sidebar/inline-create.spec.ts
+++ b/e2e/tests/sidebar/inline-create.spec.ts
@@ -1,0 +1,269 @@
+import { test, expect, type Page } from '@playwright/test';
+import { setupTauriMock, trackInvokeCalls } from '../../fixtures/tauri-mock';
+import { SAMPLE_PROJECT_PATH, SAMPLE_FILE_TREE } from '../../fixtures/sample-data';
+
+/**
+ * Sidebar inline-create E2E coverage (QuietSidebar / ProjectsSection).
+ *
+ * The real WKWebView E2E harness can't type into React-controlled inputs, so
+ * the new-note / new-project text-entry flows are covered here under Chromium.
+ *
+ * Trigger surface (verified against source):
+ *   - `⌘N` (new note) — `QuietLayout`'s capture-phase keydown handler resolves
+ *     the active tab's parent dir via `resolveCreateParent`, then sets
+ *     `quiet-sidebar-store.pendingCreate = { parentDir }`. `ProjectsSection`
+ *     renders a `SidebarInlineEdit` (mode="create", `aria-label="Create"`)
+ *     under the owning project. Commit appends `.md` if no extension, then
+ *     `createFile` → invoke('create_file', { path }).
+ *     IMPORTANT: `resolveCreateParent` returns null unless the ACTIVE TAB is a
+ *     file inside an open project — `⌘N` with no active tab only toasts. So the
+ *     note-create tests open a file first, then press `⌘N`.
+ *   - The per-project `+` button (`aria-label="New note in <project>"`) sets
+ *     `pendingCreate` to the project root directly — used here as a
+ *     no-active-tab path to open the same inline create row.
+ *   - `⌘⇧N` (new project) — `QuietLayout` sets
+ *     `quiet-sidebar-store.pendingCreateProject = true`. `ProjectsSection`
+ *     renders a top-of-list `SidebarInlineEdit` (`aria-label="Create"`).
+ *     Commit calls `createFolder(libraryRoot, name)` →
+ *     invoke('create_directory', { path }). The commit bails with a toast if
+ *     `notesRootPath` still carries a leading `~`, so we seed an absolute
+ *     library root in settings-store.
+ *
+ * The mock returns success for `create_file` / `create_directory` without
+ * touching a filesystem, so we assert the command was INVOKED with the right
+ * args via `trackInvokeCalls`.
+ */
+
+const LIBRARY_ROOT = '/tmp/notesage-e2e-home/Notesage';
+
+/**
+ * Seed the workspace-store with a project so the Projects section renders.
+ */
+async function injectWorkspaceState(page: Page): Promise<void> {
+  await page.addInitScript(
+    ({ projectPath, fileTree }) => {
+      const state = {
+        state: {
+          explorerFolders: [],
+          projects: [{ path: projectPath, fileTree }],
+          recentProjects: [],
+          notesTree: [],
+          pinnedFiles: [],
+          expandedFolders: [projectPath],
+          explorerCollapsed: false,
+          projectsCollapsed: false,
+          notesCollapsed: false,
+        },
+        version: 0,
+      };
+      localStorage.setItem('notesage-workspace', JSON.stringify(state));
+    },
+    { projectPath: SAMPLE_PROJECT_PATH, fileTree: SAMPLE_FILE_TREE },
+  );
+}
+
+/**
+ * Seed an ABSOLUTE notesRootPath into settings-store so the project-create
+ * commit doesn't bail on the leading-`~` guard. We only set the single field
+ * the flow reads; the persist `merge` fills in every other default.
+ */
+async function injectAbsoluteLibraryRoot(page: Page, libraryRoot: string): Promise<void> {
+  await page.addInitScript(
+    ({ libraryRoot }) => {
+      localStorage.setItem(
+        'notesage-settings',
+        JSON.stringify({ state: { notesRootPath: libraryRoot }, version: 21 }),
+      );
+    },
+    { libraryRoot },
+  );
+}
+
+/** Expand the project and return the project treeitem row. */
+async function getProjectRow(page: Page) {
+  const projectRow = page.getByRole('treeitem', {
+    name: /Open project notesage-e2e-project/i,
+  });
+  await expect(projectRow).toBeVisible({ timeout: 10000 });
+  return projectRow;
+}
+
+/** Open a file so an active tab exists inside the project (required by ⌘N). */
+async function openSampleFile(page: Page): Promise<void> {
+  const projectRow = await getProjectRow(page);
+  await projectRow.click(); // inline-expand
+  const fileRow = page.getByRole('treeitem', { name: 'Open file welcome.md' });
+  await expect(fileRow).toBeVisible({ timeout: 10000 });
+  await fileRow.click();
+  await expect(page.locator('.ProseMirror')).toContainText('Welcome to Notesage', {
+    timeout: 10000,
+  });
+}
+
+test.describe('Sidebar — inline create', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupTauriMock(page);
+    await injectWorkspaceState(page);
+    await injectAbsoluteLibraryRoot(page, LIBRARY_ROOT);
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    await page.waitForFunction(
+      () => {
+        const root = document.getElementById('root');
+        return !!root && root.children.length > 0;
+      },
+      { timeout: 10000 },
+    );
+  });
+
+  test('Cmd+N opens an inline create row under the active project', async ({ page }) => {
+    // ⌘N resolves the parent from the active tab — open a file first.
+    await openSampleFile(page);
+
+    // Press ⌘N. The handler is capture-phase at window level; pressing from
+    // the body (not a text input) lets it fire. Click the project row first to
+    // move focus out of the editor's contenteditable (⌘N is skipped while a
+    // text input / contentEditable is focused).
+    await (await getProjectRow(page)).focus();
+    await page.keyboard.press('Meta+n');
+
+    const createInput = page.getByRole('textbox', { name: 'Create' });
+    await expect(createInput).toBeVisible({ timeout: 5000 });
+    // Create mode starts empty.
+    await expect(createInput).toHaveValue('');
+  });
+
+  test('typing a note name + Enter invokes create_file under the project', async ({ page }) => {
+    await openSampleFile(page);
+
+    await (await getProjectRow(page)).focus();
+    await page.keyboard.press('Meta+n');
+
+    const createInput = page.getByRole('textbox', { name: 'Create' });
+    await expect(createInput).toBeVisible({ timeout: 5000 });
+
+    const getCalls = await trackInvokeCalls(page);
+
+    await createInput.fill('my-new-note');
+    await createInput.press('Enter');
+
+    await page.waitForFunction(
+      () => {
+        const log = (window as Record<string, unknown>).__TAURI_INVOKE_LOG__ as
+          | Array<{ cmd: string }>
+          | undefined;
+        return log?.some((c) => c.cmd === 'create_file');
+      },
+      { timeout: 5000 },
+    );
+
+    const calls = await getCalls();
+    const createCalls = calls.filter((c) => c.cmd === 'create_file');
+    expect(createCalls.length).toBeGreaterThanOrEqual(1);
+
+    // `.md` is appended when the typed name has no extension. The parent dir is
+    // the active tab's directory (the project root, since welcome.md sits at
+    // the project root).
+    const args = createCalls[createCalls.length - 1].args as { path?: string };
+    expect(args.path).toBe(`${SAMPLE_PROJECT_PATH}/my-new-note.md`);
+  });
+
+  test('the per-project "+" button also opens an inline create row', async ({ page }) => {
+    // Independent of ⌘N: hovering a project row reveals a "New note in
+    // <project>" button that sets pendingCreate to the project root. This is
+    // the no-active-tab path to the same inline create surface.
+    const projectRow = await getProjectRow(page);
+    await projectRow.click(); // expand so the row + its + button are present
+    await expect(
+      page.getByRole('treeitem', { name: 'Open file welcome.md' }),
+    ).toBeVisible({ timeout: 10000 });
+
+    const addButton = page.getByRole('button', {
+      name: /New note in notesage-e2e-project/i,
+    });
+    // The button is hover-revealed (opacity-0 until hover); force the click
+    // since Playwright's actionability check can race the opacity transition.
+    await addButton.click({ force: true });
+
+    const createInput = page.getByRole('textbox', { name: 'Create' });
+    await expect(createInput).toBeVisible({ timeout: 5000 });
+
+    const getCalls = await trackInvokeCalls(page);
+    await createInput.fill('from-plus-button');
+    await createInput.press('Enter');
+
+    await page.waitForFunction(
+      () => {
+        const log = (window as Record<string, unknown>).__TAURI_INVOKE_LOG__ as
+          | Array<{ cmd: string }>
+          | undefined;
+        return log?.some((c) => c.cmd === 'create_file');
+      },
+      { timeout: 5000 },
+    );
+
+    const calls = await getCalls();
+    const createCalls = calls.filter((c) => c.cmd === 'create_file');
+    const args = createCalls[createCalls.length - 1].args as { path?: string };
+    // The + button routes the create to the project ROOT.
+    expect(args.path).toBe(`${SAMPLE_PROJECT_PATH}/from-plus-button.md`);
+  });
+
+  test('Cmd+Shift+N opens a new-project row; typing + Enter invokes create_directory', async ({ page }) => {
+    // No active tab required for project create. Focus a non-input element so
+    // the capture-phase handler isn't skipped by the text-input guard.
+    await (await getProjectRow(page)).focus();
+    await page.keyboard.press('Meta+Shift+n');
+
+    const createInput = page.getByRole('textbox', { name: 'Create' });
+    await expect(createInput).toBeVisible({ timeout: 5000 });
+
+    const getCalls = await trackInvokeCalls(page);
+
+    await createInput.fill('Fresh Project');
+    await createInput.press('Enter');
+
+    await page.waitForFunction(
+      () => {
+        const log = (window as Record<string, unknown>).__TAURI_INVOKE_LOG__ as
+          | Array<{ cmd: string }>
+          | undefined;
+        return log?.some((c) => c.cmd === 'create_directory');
+      },
+      { timeout: 5000 },
+    );
+
+    const calls = await getCalls();
+    const dirCalls = calls.filter((c) => c.cmd === 'create_directory');
+    expect(dirCalls.length).toBeGreaterThanOrEqual(1);
+
+    // Project bootstrap fires multiple create_directory calls — the project
+    // root AND its `.notesage` metadata subdir. Assert the project root is
+    // among them (don't assume ordering / which is last).
+    const dirPaths = dirCalls.map((c) => (c.args as { path?: string }).path);
+    expect(dirPaths).toContain(`${LIBRARY_ROOT}/Fresh Project`);
+  });
+
+  test('Esc cancels project create — no create command invoked', async ({ page }) => {
+    await (await getProjectRow(page)).focus();
+    await page.keyboard.press('Meta+Shift+n');
+
+    const createInput = page.getByRole('textbox', { name: 'Create' });
+    await expect(createInput).toBeVisible({ timeout: 5000 });
+
+    const getCalls = await trackInvokeCalls(page);
+
+    await createInput.fill('Should Not Create');
+    await createInput.press('Escape');
+
+    await expect(createInput).toBeHidden({ timeout: 5000 });
+
+    await page.waitForTimeout(300);
+    const calls = await getCalls();
+    expect(
+      calls.filter(
+        (c) => c.cmd === 'create_directory' || c.cmd === 'create_file',
+      ),
+    ).toHaveLength(0);
+  });
+});

--- a/e2e/tests/sidebar/inline-rename.spec.ts
+++ b/e2e/tests/sidebar/inline-rename.spec.ts
@@ -1,0 +1,204 @@
+import { test, expect, type Page } from '@playwright/test';
+import { setupTauriMock, trackInvokeCalls } from '../../fixtures/tauri-mock';
+import { SAMPLE_PROJECT_PATH, SAMPLE_FILE_TREE } from '../../fixtures/sample-data';
+
+/**
+ * Sidebar inline-rename E2E coverage (QuietSidebar / ProjectsSection).
+ *
+ * The real WKWebView E2E harness (e2e-real) can't drive React-controlled
+ * text inputs, so the inline-edit text-entry flows are covered here under
+ * Chromium where Playwright can type into the `<input>` directly.
+ *
+ * Trigger surface (verified against source):
+ *   - Rename is started by a row-level F2 keypress (files) or a double-click
+ *     (files + non-system folders) — `ChildRow.handleRowKeyDown` /
+ *     `handleRowClick` in `ProjectsSection.tsx`. Both call `onStartRename`,
+ *     which flips `renamingPath` and renders a `SidebarInlineEdit`
+ *     (`aria-label="Rename"`).
+ *   - Commit-on-Enter calls `commitRename` → `useFileOperations.renamePath`
+ *     → `tauriApi.renamePath` → invoke('rename_path', { oldPath, newPath }).
+ *   - Cancel-on-Esc / empty-input call `onCancel`, which never invokes
+ *     `rename_path`.
+ *   - `validateRenameBasename` rejects names containing `/` with the message
+ *     "Name cannot contain slashes" rendered in a `role="alert"` element.
+ *
+ * The mock's `rename_path` returns success without touching a filesystem, so
+ * we assert the command was INVOKED with the right args via `trackInvokeCalls`.
+ */
+
+/**
+ * Seed the workspace-store with a project so the Projects section renders.
+ * Mirrors `injectWorkspaceState` in file-operations.spec.ts — the Zustand
+ * persist merge keeps the inline `fileTree`, so the rows are available
+ * without an extra list_directory round-trip.
+ */
+async function injectWorkspaceState(page: Page): Promise<void> {
+  await page.addInitScript(
+    ({ projectPath, fileTree }) => {
+      const state = {
+        state: {
+          explorerFolders: [],
+          projects: [{ path: projectPath, fileTree }],
+          recentProjects: [],
+          notesTree: [],
+          pinnedFiles: [],
+          expandedFolders: [projectPath],
+          explorerCollapsed: false,
+          projectsCollapsed: false,
+          notesCollapsed: false,
+        },
+        version: 0,
+      };
+      localStorage.setItem('notesage-workspace', JSON.stringify(state));
+    },
+    { projectPath: SAMPLE_PROJECT_PATH, fileTree: SAMPLE_FILE_TREE },
+  );
+}
+
+/**
+ * Expand the project so its child file rows render, then return the locator
+ * for a specific child file row (a `[role="treeitem"]` whose accessible name
+ * is "Open file <name>").
+ */
+async function expandProjectAndGetFileRow(page: Page, fileName: string) {
+  const projectRow = page.getByRole('treeitem', {
+    name: new RegExp(`Open project notesage-e2e-project`, 'i'),
+  });
+  await expect(projectRow).toBeVisible({ timeout: 10000 });
+
+  // Click the project row to inline-expand it (click toggles expand).
+  await projectRow.click();
+
+  const fileRow = page.getByRole('treeitem', {
+    name: `Open file ${fileName}`,
+  });
+  await expect(fileRow).toBeVisible({ timeout: 10000 });
+  return fileRow;
+}
+
+test.describe('Sidebar — inline rename', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupTauriMock(page);
+    await injectWorkspaceState(page);
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    // Wait for React to mount.
+    await page.waitForFunction(
+      () => {
+        const root = document.getElementById('root');
+        return !!root && root.children.length > 0;
+      },
+      { timeout: 10000 },
+    );
+  });
+
+  test('F2 on a file row shows an inline rename input', async ({ page }) => {
+    const fileRow = await expandProjectAndGetFileRow(page, 'welcome.md');
+
+    await fileRow.focus();
+    await page.keyboard.press('F2');
+
+    // The inline edit renders with aria-label="Rename" and is pre-filled with
+    // the current filename, all selected.
+    const renameInput = page.getByRole('textbox', { name: 'Rename' });
+    await expect(renameInput).toBeVisible({ timeout: 5000 });
+    await expect(renameInput).toHaveValue('welcome.md');
+  });
+
+  test('typing a new name + Enter invokes rename_path with old and new paths', async ({ page }) => {
+    const fileRow = await expandProjectAndGetFileRow(page, 'welcome.md');
+
+    await fileRow.focus();
+    await page.keyboard.press('F2');
+
+    const renameInput = page.getByRole('textbox', { name: 'Rename' });
+    await expect(renameInput).toBeVisible({ timeout: 5000 });
+
+    // Start tracking invokes only after the rename input is open so we don't
+    // capture unrelated startup traffic.
+    const getCalls = await trackInvokeCalls(page);
+
+    // Replace the selected name and commit.
+    await renameInput.fill('renamed-note');
+    await renameInput.press('Enter');
+
+    await page.waitForFunction(
+      () => {
+        const log = (window as Record<string, unknown>).__TAURI_INVOKE_LOG__ as
+          | Array<{ cmd: string }>
+          | undefined;
+        return log?.some((c) => c.cmd === 'rename_path');
+      },
+      { timeout: 5000 },
+    );
+
+    const calls = await getCalls();
+    const renameCalls = calls.filter((c) => c.cmd === 'rename_path');
+    expect(renameCalls.length).toBeGreaterThanOrEqual(1);
+
+    // The original extension (.md) is preserved by resolveRenamePath when the
+    // typed name has none.
+    const args = renameCalls[renameCalls.length - 1].args as {
+      oldPath?: string;
+      newPath?: string;
+    };
+    expect(args.oldPath).toBe(`${SAMPLE_PROJECT_PATH}/welcome.md`);
+    expect(args.newPath).toBe(`${SAMPLE_PROJECT_PATH}/renamed-note.md`);
+  });
+
+  test('Esc cancels rename — no rename_path call, original name stays', async ({ page }) => {
+    const fileRow = await expandProjectAndGetFileRow(page, 'welcome.md');
+
+    await fileRow.focus();
+    await page.keyboard.press('F2');
+
+    const renameInput = page.getByRole('textbox', { name: 'Rename' });
+    await expect(renameInput).toBeVisible({ timeout: 5000 });
+
+    const getCalls = await trackInvokeCalls(page);
+
+    // Type something, then bail out with Escape.
+    await renameInput.fill('should-not-commit');
+    await renameInput.press('Escape');
+
+    // The input closes...
+    await expect(renameInput).toBeHidden({ timeout: 5000 });
+    // ...and the original row reappears unchanged.
+    await expect(
+      page.getByRole('treeitem', { name: 'Open file welcome.md' }),
+    ).toBeVisible();
+
+    // Give any (incorrect) async invoke a beat to land, then assert none did.
+    await page.waitForTimeout(300);
+    const calls = await getCalls();
+    expect(calls.filter((c) => c.cmd === 'rename_path')).toHaveLength(0);
+  });
+
+  test('invalid name (slash) surfaces an error and does not invoke rename_path', async ({ page }) => {
+    const fileRow = await expandProjectAndGetFileRow(page, 'welcome.md');
+
+    await fileRow.focus();
+    await page.keyboard.press('F2');
+
+    const renameInput = page.getByRole('textbox', { name: 'Rename' });
+    await expect(renameInput).toBeVisible({ timeout: 5000 });
+
+    const getCalls = await trackInvokeCalls(page);
+
+    // A slash is rejected by validateRenameBasename — the input stays open and
+    // a role="alert" error appears. Enter does NOT commit.
+    await renameInput.fill('bad/name');
+    await renameInput.press('Enter');
+
+    const error = page.getByRole('alert');
+    await expect(error).toBeVisible({ timeout: 5000 });
+    await expect(error).toContainText(/slash/i);
+
+    // The input remains open (validation kept it from committing).
+    await expect(renameInput).toBeVisible();
+
+    await page.waitForTimeout(300);
+    const calls = await getCalls();
+    expect(calls.filter((c) => c.cmd === 'rename_path')).toHaveLength(0);
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,6 +16,16 @@ export default defineConfig({
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
     },
+    // WebKit project for engine fidelity. Notesage ships on WKWebView
+    // (WebKit); Chromium (Blink) can mask engine-specific bugs in
+    // contenteditable/ProseMirror, CSS, and selection behaviour. Playwright's
+    // WebKit is its own build (not Apple's embedded WKWebView), so it's close
+    // but not identical — the real-E2E (e2e-real/) suite remains the truth for
+    // the embedded webview + the Tauri IPC boundary.
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
   ],
   webServer: {
     command: 'pnpm dev',

--- a/src/components/settings/McpServersSettings.tsx
+++ b/src/components/settings/McpServersSettings.tsx
@@ -443,7 +443,9 @@ function ImportDialog({ open, onOpenChange }: { open: boolean; onOpenChange: (op
   // Check which sources are available on mount
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
-    invoke<string[]>('mcp_check_import_sources').then(setAvailableSources).catch(() => {});
+    invoke<string[]>('mcp_check_import_sources')
+      .then((sources) => setAvailableSources(sources ?? []))
+      .catch(() => {});
   }, []);
 
   const handleSelectSource = async (sourceId: string) => {


### PR DESCRIPTION
Orchestrated as an agent workflow (4 parallel authoring agents + a research pass), validated locally on both engines.

## Why Playwright for these
The real WKWebView E2E harness (`e2e-real/`) can't reliably type into React inputs, so input-driven flows are either `it.skip`'d there or untestable. Chromium/WebKit under Playwright type fine, making it the right home for these.

## New specs (7 files, 33 tests — all green on chromium AND webkit)
- **`editor/find-replace.spec.ts`** — `Cmd+Shift+H` find+replace, Replace / Replace All, match navigation, Esc.
- **`sidebar/inline-rename.spec.ts`** — F2 rename, commit/cancel, invalid-name `role="alert"`, asserts `rename_path` args.
- **`sidebar/inline-create.spec.ts`** — `Cmd+N` new note, `Cmd+Shift+N` new project, asserts `create_file`/`create_directory`, Esc cancel.
- **`command-bar/palette-execute.spec.ts`** — `>command` → select → action executes, empty-state.
- **`command-bar/tag-reference-journeys.spec.ts`** — `#tag` / `@mention` → select → occurrences → open file.
- **`command-bar/file-research-journeys.spec.ts`** — `:file` and `?` query → select → open.
- **`settings/settings-search.spec.ts`** — `Cmd+,` open, query filters rows (global leaf-search), `role="status"` count, clear resets.

## Bug fix (surfaced by the settings-search spec)
`McpServersSettings` ImportDialog set `availableSources` directly from `invoke('mcp_check_import_sources')`; when that resolves to `null`, the later `availableSources.includes(...)` throws and crashes the panel. The settings global leaf-search renders every panel at once, so it hit this under empty/mocked data. Coalesced to `[]`. The settings-search spec exercises that exact path, so it doubles as the regression lock.

## Mock additions (`e2e/fixtures/`)
The index-backed command-bar modes returned nothing because the mock registered legacy command names (`index_query_*`) while the app invokes `index_tags`, `index_tag_occurrences`, `index_mentions`, `index_mention_occurrences`, `index_search_research`, `index_search_filenames`. Added those real handlers + `SAMPLE_TAGS/MENTIONS/RESEARCH/FILENAME` fixtures (shapes mirror the Rust structs), so full "type → select → open" journeys are drivable.

## WebKit project (`playwright.config.ts` + CI install)
Notesage ships on WKWebView (WebKit); Chromium alone can mask engine-specific bugs. Added a `webkit` project so the suite runs on a WebKit engine too — close to what ships, though not identical to the embedded WKWebView (real-E2E stays the truth for the embedded webview + IPC boundary). Updated the CI workflow to install the webkit browser.

## Validation
Full suite: **79 passed on `chromium`, 79 passed on `webkit`** locally. `pnpm typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)