### PR TITLE
chore: release v0.46.0-alpha.11

### DIFF
--- a/docs/history/136-release-v0.46.0-alpha.11.md
+++ b/docs/history/136-release-v0.46.0-alpha.11.md
@@ -1,0 +1,26 @@
+# Release v0.46.0-alpha.11
+
+**Date:** 2026-05-31
+**Previous version:** 0.46.0-alpha.10
+**Channel:** Alpha
+
+Auto-cut by `aw-alpha-cut` after Tier-A/B PRs landed. The auto-dump under "Under the hood" lists the merged PRs verbatim.
+
+Before promoting this alpha to stable, edit this file:
+  - Move anything user-visible from "Under the hood" into "## Changes" under `### Features`, `### Improvements`, or `### Fixes` — and rewrite each bullet in user-facing prose (drop PR titles, version triples, internal jargon).
+  - Leave "## Changes" as `_No user-visible changes._` for infra-only releases.
+  - See `feedback_user_facing_release_notes.md` and `scripts/generate-changelog.ts` linter rules.
+
+## Changes
+
+_No user-visible changes._
+
+## Under the hood
+
+Auto-generated dump of merged Tier-A/B PRs. Rewrite as prose grouped by area before stable promotion.
+
+- feat(transcription): meeting recording with background transcription (#398)
+- Fix Claude Code agent auto-install by routing through npm (#399)
+- Route OpenAI Codex agent install through npm (#400)
+- Route Copilot CLI + LSP through npm and remove the GitHub-binary installer (#401)
+- Add opt-in smoke test for the managed agent install flow (#402)

--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -139,3 +139,4 @@ Chronological log of major implementation milestones and changes.
 | 133 | [Release v0.46.0-alpha.8](133-release-v0.46.0-alpha.8.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
 | 134 | [Release v0.46.0-alpha.9](134-release-v0.46.0-alpha.9.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
 | 135 | [Release v0.46.0-alpha.10](135-release-v0.46.0-alpha.10.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
+| 136 | [Release v0.46.0-alpha.11](136-release-v0.46.0-alpha.11.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "notesage",
   "private": true,
-  "version": "0.46.0-alpha.10",
+  "version": "0.46.0-alpha.11",
   "license": "MIT",
   "author": "Peter Blenessy",
   "type": "module",

--- a/public/changelog-alpha.json
+++ b/public/changelog-alpha.json
@@ -1,6 +1,19 @@
 {
   "releases": [
     {
+      "version": "0.46.0-alpha.11",
+      "date": "2026-05-31",
+      "previousVersion": "0.46.0",
+      "sections": {},
+      "underTheHood": [
+        "feat(transcription): meeting recording with background transcription (#398)",
+        "Fix Claude Code agent auto-install by routing through npm (#399)",
+        "Route OpenAI Codex agent install through npm (#400)",
+        "Route Copilot CLI + LSP through npm and remove the GitHub-binary installer (#401)",
+        "Add opt-in smoke test for the managed agent install flow (#402)"
+      ]
+    },
+    {
       "version": "0.46.0-alpha.10",
       "date": "2026-05-30",
       "previousVersion": "0.46.0",


### PR DESCRIPTION
Auto-cut by `aw-alpha-cut`. The history file at `docs/history/136-release-v0.46.0-alpha.11.md` lists the merged PRs.

## PRs included

- #398
- #399
- #400
- #401
- #402

Auto-merge enabled. Once the 4 required status checks pass, this merges to main, and the `tag-after-merge` job in `aw-alpha-cut.yml` tags + pushes `v0.46.0-alpha.11`. `release.yml` then builds and publishes.
