### PR TITLE
refactor(acp): migrate to agent-client-protocol 0.12.1 builder API

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -64,7 +64,7 @@ note-sage/
 │   │   │   ├── link_preview.rs # OpenGraph metadata fetch for link preview cards
 │   │   │   ├── constants.rs    # Shared constants (app paths, defaults)
 │   │   │   ├── acp_binary.rs   # ACP agent binary path resolution (PATH, Homebrew, npm, bundled)
-│   │   │   ├── acp_client.rs   # ACP Client trait impl (Tauri event forwarding, permission channels)
+│   │   │   ├── acp_client.rs   # ACP inbound handlers (on_receive_request/notification → Tauri event forwarding, permission channels)
 │   │   │   ├── agent_manager.rs # Agent binary installation, versioning, progress tracking
 │   │   │   ├── model_management.rs # Local LLM model lifecycle (catalog, download, custom models)
 │   │   │   ├── model_providers/   # Extracted from model_management

--- a/docs/features/ai-providers.md
+++ b/docs/features/ai-providers.md
@@ -47,7 +47,7 @@ interface AIProvider {
 - Tiered permission UI: PermissionCard with split Allow button + dropdown for session/always; session approvals non-persisted, always approvals persisted via Zustand persist
 - Thinking effort slider for Codex ACP: Default / Low / Medium / High / Extra High (hidden for free accounts)
 - Dynamic model dedup: strips `/low`, `/medium`, `/high`, `/xhigh` reasoning effort variants from model lists
-- ACP crate version 0.10/0.11 with `usage_update` event support
+- ACP crate version 0.12.1 (schema 0.13.2) with `usage_update` event support. The 0.12.x line is a builder/component API (`role::acp::Client.builder()…connect_with(transport, |conn| …)`) replacing the old `ClientSideConnection`; inbound `request_permission` / `session/update` are handled via registered `on_receive_request` / `on_receive_notification` handlers instead of a `Client` trait impl, and the connection handle is `Send + Clone` (no `!Send` thread isolation needed). `session/close` and `session/resume` are now stable (their `unstable_*` cargo features were dropped)
 - Network sandboxing: agent traffic routed through localhost HTTP proxy with per-agent domain allowlists (see Network Sandboxing section)
 - Context-aware chat footer: "Search" toggle for direct API connections
 - **Session modes**: Permission-level mode picker (Shield icon) in chat footer (hidden by default, toggle in Settings > Advanced). Agent-specific mode IDs mapped to common permission levels: Read Only (can read, must ask for writes), Agent (can read and edit, asks for risky ops), Full Access (no permission prompts), Plan (read-only, proposes without executing). Mode-sandbox conflict dialog when selecting Full Access with active restrictions.

--- a/docs/prds/2026-05-31-acp-0.12-migration.md
+++ b/docs/prds/2026-05-31-acp-0.12-migration.md
@@ -1,0 +1,70 @@
+# PRD: ACP Crate Migration — 0.10.4 → 0.12.1 (builder/component API)
+
+|  |  |
+| --- | --- |
+| **Date** | 2026-05-31 |
+| **Status** | Implemented — `cargo build`/`cargo test` green; live agent matrix (#10) + review pending before PR |
+| **Priority** | Medium — no user-facing feature; buys deserialization robustness, stabilized session ops, and `#[non_exhaustive]` future-proofing, and stops our ACP integration drifting further behind upstream. |
+| **Type** | Dependency migration (breaking upstream API redesign) — **not** a routine `chore(deps)` bump. |
+| **Tasks** | [acp-0.12-migration-tasks](../tasks/2026-05-31-acp-0.12-migration-tasks.md) |
+| **Upstream refs** | docs.rs `agent-client-protocol/0.12.1` (crate root) · cookbook crate modules `connecting_as_client` + `one_shot_prompt` · upstream `CHANGELOG.md` (0.11.5 → 0.13.2) |
+
+## Problem
+
+We pin `agent-client-protocol = 0.10.4` / `agent-client-protocol-schema = 0.11.4`. The latest matched pair is **0.12.1 / 0.13.2** (the Rust crate `0.12.1` pins the schema crate to exactly `=0.13.2`, so the two move together; schema 0.13.3/0.13.4 are **not** compatible with protocol 0.12.1).
+
+A naive version bump fails to compile with **43 errors** because the 0.12.x line is a breaking API redesign, not a reorg:
+
+- **Connection model replaced.** `agent_client_protocol::ClientSideConnection::new(client_impl, io)` no longer exists. The new model is a builder/component pattern — `Client.builder().name(…)…connect_with(transport, …)`. (`Client` at the crate root is now a **marker struct** `role::acp::Client`, which is why the old `impl Client for …` errors with "expected trait, found struct".)
+- **Inbound handling replaced.** We currently `impl Client for NotesageClient` to receive `request_permission` and `session_notification` from the agent. The new model registers a handler/component instead (see cookbook `connecting_as_client`).
+- **Schema types relocated.** `SessionId`, `ContentBlock`, `PromptRequest`, `RequestPermissionRequest/Response`, `SessionNotification`, `TextContent`, and every `*Request`/`*Response` type moved out of the crate root into `agent_client_protocol::schema::*`.
+- **All types are now `#[non_exhaustive]`** and enum variants are tuple variants wrapping structs → our struct literals need builders/`..Default::default()` and our `match`es need wildcard arms.
+- **`ProtocolVersion`** exposes associated constants instead of free-floating `V0`/`V1`.
+
+Two stabilizations also change our feature set: `session/close` and `session/resume` were stabilized (schema 0.12.2), so their `unstable_session_close` / `unstable_session_resume` **cargo features were removed** — keeping them in `Cargo.toml` is itself a hard error.
+
+The blast radius is small and well-contained: **only two files import the crate** — `src-tauri/src/commands/acp.rs` (1930 lines: the dedicated agent thread that owns the `!Send` connection + the command-channel loop dispatching all session operations) and `src-tauri/src/commands/acp_client.rs` (270 lines: the `impl Client` that turns inbound agent calls into Tauri events + permission channels). The TypeScript frontend talks only to our Tauri commands, so it has **no compile-time coupling** to the crate — but its runtime behavior (permission cards, streamed session updates, the full session lifecycle) must be preserved exactly.
+
+## Goals
+
+1. **Land the latest matched ACP pair** — protocol `0.12.1`, schema `0.13.2` — with **zero behavioral regression** in agent chat, sessions, permissions, sandboxing, and session resilience.
+2. **Re-architect the connection layer** (`acp.rs`) onto the new builder/component model, and **port inbound handling** (`acp_client.rs`) from the `Client` trait to the new handler/component.
+3. **Preserve every capability we ship today:** the 13 agent operations (initialize/authenticate, `new_session`, `load_session`, `prompt`, `cancel`, `set_session_mode`, `set_session_config_option`, `set_session_model`, `close_session`, `list_sessions`, `resume_session`, `fork_session`), inbound `request_permission` + `session/update` streaming, capability gating, and the reconnect/retry resilience path.
+4. **Drop the two stabilized feature flags** (`unstable_session_close`, `unstable_session_resume`) and confirm the stabilized functionality still works by default.
+5. **Capture the upside:** the 0.12.0 deserialization-robustness fix (tolerate malformed optional fields), `#[non_exhaustive]` forward-compat, and the cleaner stabilized session API.
+
+## Non-Goals
+
+- **Adopting new optional capabilities** introduced in this range — MCP-over-ACP, `session/delete`, LLM providers, elicitation, plan operations, session "additional directories", `boolean_config`. Each is a separate, independently-scoped follow-up.
+- **The experimental v2 protocol/schema scaffolding** (`unstable_protocol_v2`) — explicitly out of scope; we migrate the stable v1 surface only.
+- **Any frontend feature change.** The TS side should see identical behavior; only internal type/field renames (if any leak through Tauri command payloads, e.g. capability field names) are in scope.
+- **Schema 0.13.3 / 0.13.4.** Not compatible with protocol 0.12.1; revisit when a newer protocol crate pins them.
+
+## Strategy — spike first
+
+The single biggest unknown is the **new connection + inbound-handler wiring and its `Send`/threading model**. Today `acp.rs` deliberately isolates a `!Send` `ClientSideConnection` on a dedicated thread and drives it through a command channel; if the new handle is `Send`, the architecture can simplify, and if it isn't, the thread/command-loop pattern must be re-fitted to the builder API. Rather than discover this halfway through a 1900-line rewrite, **Task #1 is a throwaway spike**: stand up a minimal client (initialize → `new_session` → `prompt` → one inbound permission) against the new API using the `connecting_as_client` + `one_shot_prompt` cookbook modules, and write up the exact builder call, the handler registration shape, and the `Send`/threading verdict. Every subsequent task is parameterized by that spike.
+
+## User Stories / Acceptance
+
+- **As an agent user**, chat with each ACP agent (Claude Code, Codex, Copilot, Gemini) works exactly as before: connect, prompt + streamed updates, permission cards (allow once/session/always), mode + model switching, usage display, cancel.
+- **As a user reopening a conversation**, the resume → load → list → new restoration chain still works, and branching still forks an agent-side session.
+- **As a user on a flaky agent**, the unresponsive banner + reconnect/retry path still restores context.
+- **As a maintainer**, `cargo build` + `cargo test` are green, the two stale feature flags are gone, and `docs/` reflects the new crate version.
+
+## Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| New connection handle's `Send`/threading model differs from our `!Send`-on-a-thread design | Spike (#1) resolves it before the big rewrite; #4 adapts the thread/command loop accordingly |
+| Inbound permission/notification semantics subtly change (ordering, response shape) | Port (#5) against `connecting_as_client`; live smoke matrix (#10) exercises real permission cards |
+| `#[non_exhaustive]` + tuple-struct variants cause wide mechanical churn | #3 is a dedicated compile-driven sweep; rustc enumerates every site |
+| Capability/field renames leak into Tauri payloads the frontend reads (e.g. `sessionCapabilities`) | #7 audits schema field renames; check the TS capability gating still matches |
+| Session resilience (reconnect + `session/load`) regresses | #8 explicitly re-validates the retry path; #10 includes a kill-and-retry case |
+| Real-agent behavior can't be unit-tested | #10 is a mandatory manual smoke matrix across all four agents before merge |
+
+## Definition of done
+
+- `cargo build` + `cargo test` green; `unstable_session_close`/`unstable_session_resume` removed from `Cargo.toml`.
+- All 13 operations + inbound permission/notification verified against at least Claude Code and one other agent (#10).
+- No TS changes required, or if a Tauri payload field renamed, the frontend updated to match.
+- `docs/architecture.md` + `docs/features/ai-providers.md` updated to the new crate versions; this PRD's design reflected in the living docs.

--- a/docs/tasks/2026-05-31-acp-0.12-migration-tasks.md
+++ b/docs/tasks/2026-05-31-acp-0.12-migration-tasks.md
@@ -1,0 +1,109 @@
+# ACP Crate Migration (0.10.4 → 0.12.1) — Task Breakdown
+
+|  |  |
+| --- | --- |
+| **Date** | 2026-05-31 |
+| **Status** | Code complete & green (#1–#9, #11). Live agent matrix (#10) pending; review pending before PR |
+| **PRD** | [acp-0.12-migration](../prds/2026-05-31-acp-0.12-migration.md) |
+| **Total** | 11 tasks: 3S, 4M, 4L |
+| **Suggested order** | Spike (#1) → deps (#2) → mechanical sweep (#3) → core rewrite (#4–#6) → details (#7–#8) → gate (#9) → live matrix (#10) → docs (#11) |
+
+## Risks & notes
+
+- **All Rust changes are confined to two files:** `src-tauri/src/commands/acp.rs` (connection thread + command loop + 13 session ops) and `src-tauri/src/commands/acp_client.rs` (`impl Client` inbound handler). Do not parallelize agents across these — they're tightly coupled.
+- **Matched versions are mandatory:** protocol `0.12.1` pins schema `=0.13.2`. Don't pin schema to 0.13.4 (incompatible).
+- **Canonical references for the new API:** docs.rs `agent-client-protocol/0.12.1` crate root; cookbook crate modules `connecting_as_client` (connection + permission handling) and `one_shot_prompt`. The crate source is in the local cargo registry once #2 lands (`~/.cargo/registry/src/*/agent-client-protocol-0.12.1/`) — read `lib.rs`, `role/acp.rs`, `handler.rs`, `session.rs`, `concepts/` directly.
+- **Spike-first:** #1 de-risks the `Send`/threading + builder/handler unknowns before the big rewrite. Do not skip it.
+- **Frontend:** no compile-time coupling. Only touch `src/` if a renamed schema field surfaces in a Tauri command payload the TS reads (capability gating — see #7).
+
+---
+
+## Spike findings (#1 — resolved)
+
+The new crate is a generic JSON-RPC component/handler framework. Concrete patterns (verified against the 0.12.1 source):
+
+- **Connection handle is `Send + Clone`** (`ConnectionTo<Agent>` wraps mpsc senders; `spawn` requires `Send + 'static` futures). → **Drop the old `!Send` dedicated-thread isolation** in `acp.rs`; the command loop can hold a cloned `ConnectionTo<Agent>` and call it from normal tokio tasks.
+- **Construct:** `agent_client_protocol::role::acp::Client.builder()` → register inbound handlers → `.connect_with(transport, async |conn: ConnectionTo<Agent>| { /* our command loop lives here */ }) -> Result<R, Error>`. The `connect_with` future drives the connection for the closure's duration, so the agent's whole lifetime runs inside that closure.
+- **Transport:** the re-exported `agent_client_protocol::Stdio` over the child process stdin/stdout (a `ConnectTo<Client>`).
+- **Outbound agent calls:** `conn.send_request(NewSessionRequest{..}).block_task().await?` → typed response (keyed by the `JsonRpcRequest` trait). `cancel` is a notification: `conn.send_notification(CancelNotification{..})?`. Replaces every old `conn.new_session(req)/prompt(req)/…`.
+- **Inbound handling (replaces `impl Client`):** on the builder, `.on_receive_request(async |req: RequestPermissionRequest, responder, cx| { …; responder.respond(RequestPermissionResponse{..}) }, on_receive_request!())` and `.on_receive_notification(async |n: SessionNotification, cx| {..}, on_receive_notification!())`. Offload expensive work with `cx.spawn(async move {..})`.
+- **Schema types:** all from `agent_client_protocol::schema::*`; everything is `#[non_exhaustive]` (construct via `..Default::default()`; add `_ =>` match arms). `ProtocolVersion` uses associated constants.
+
+---
+
+## #1 — Spike: minimal client on the new builder/component API
+- **Description:** In a throwaway scratch binary or a `#[cfg(test)]`/`examples/` file (NOT in `acp.rs` yet), stand up a minimal ACP **client**: spawn a stub agent over stdio, `initialize`, `new_session`, send one `prompt`, and handle one inbound `request_permission`. Use the cookbook `connecting_as_client` + `one_shot_prompt` modules as the template. **Deliverable is knowledge, not shipped code:** write up (a) the exact `Client.builder()…connect_with(transport, …)` call + stdio transport setup, (b) the handler/component shape for inbound `request_permission` + `session/update`, (c) whether the connection handle is `Send`/`Sync` or single-threaded, and (d) how agent methods (`prompt`, etc.) are invoked on the handle. This verdict parameterizes #4 and #5.
+- **Complexity:** L
+- **Category:** backend (spike)
+- **Dependencies:** #2 (needs the crate resolved to read/compile against it) — or do #2 first, then #1
+- **Files:** scratch only (delete before merge); findings recorded in the PR description / a comment
+
+## #2 — Bump deps to the matched pair + drop stabilized features
+- **Description:** In `src-tauri/Cargo.toml`: `agent-client-protocol = 0.12.1`, `agent-client-protocol-schema = 0.13.2`; remove `unstable_session_close` and `unstable_session_resume` from BOTH features lists (keep `unstable_session_model`, `unstable_session_usage`, `unstable_session_fork`, `unstable_message_id`, `unstable_auth_methods`). Update the explanatory comment. Run `cargo update -p agent-client-protocol -p agent-client-protocol-schema` so `Cargo.lock` resolves. Expect the build to fail (that's #3–#6); success criterion here is only that **dependency resolution** succeeds.
+- **Complexity:** S
+- **Category:** backend
+- **Dependencies:** —
+- **Files:** `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`
+
+## #3 — Mechanical sweep: relocate schema imports + non_exhaustive fixes
+- **Description:** Compile-driven cleanup across `acp.rs` + `acp_client.rs`: repoint schema type imports to `agent_client_protocol::schema::*` (`SessionId`, `ContentBlock`, `PromptRequest`, `RequestPermissionRequest/Response`, `SessionNotification`, `TextContent`, all `*Request`/`*Response`). Fix `#[non_exhaustive]` construction sites (use the type's builder or `..Default::default()`) and add wildcard `_ =>` arms to `match`es over now-non-exhaustive enums. Update enum-variant usage for the tuple-struct variant shape. This won't fully compile until #4–#6, but resolves all the import/type-path/exhaustiveness errors.
+- **Complexity:** M
+- **Category:** backend
+- **Dependencies:** #2
+- **Files:** `src-tauri/src/commands/acp.rs`, `src-tauri/src/commands/acp_client.rs`
+
+## #4 — Rewrite connection construction + agent thread (acp.rs)
+- **Description:** Replace `ClientSideConnection::new(client, io)` (acp.rs ~line 497) with the new `Client.builder()…connect_with(transport, …)` model from the spike. Adapt the dedicated agent thread + command-channel loop (`acp.rs` ~lines 323–1020) to drive the new connection handle: if the handle is `Send`, simplify the `!Send`-isolation thread; if not, keep the thread and fit the builder/handle into it. Preserve the command-loop's responsiveness for cancel/permission while a prompt is in flight (the existing `io_task` split). Keep `kill_on_drop` + the exit cleanup semantics.
+- **Complexity:** L
+- **Category:** backend
+- **Dependencies:** #1, #3
+- **Files:** `src-tauri/src/commands/acp.rs`
+
+## #5 — Port inbound handler (acp_client.rs)
+- **Description:** Replace `impl Client for NotesageClient` (the trait that received `request_permission` + `session_notification`) with the new handler/component registration from the spike. **Behavior must be identical:** `request_permission` still drives the permission channel + emits the permission-request Tauri event with tiered options; `session/update` (`SessionNotification`) still forwards agent_message/thought/tool_call/plan/etc. as `acp-session-update` events. Preserve the permission-waiter cancellation on session end.
+- **Complexity:** L
+- **Category:** backend
+- **Dependencies:** #1, #3
+- **Files:** `src-tauri/src/commands/acp_client.rs`, `src-tauri/src/commands/acp.rs` (wiring)
+
+## #6 — Map the 13 agent operations to the new API
+- **Description:** Update every `conn.<op>(req).await` call (acp.rs ~lines 659–1012) to the new connection handle's method surface: `authenticate`, `new_session`, `load_session`, `prompt`, `cancel`, `set_session_mode`, `set_session_config_option`, `set_session_model`, `close_session`, `list_sessions`, `resume_session`, `fork_session`. Note `close_session`/`resume_session` are now **stable** (no longer feature-gated) — confirm their request/response types and that the calls compile without the dropped features. Keep the per-op error strings + reply-channel contract intact so the Tauri command wrappers (`acp_session_*`) are unchanged.
+- **Complexity:** M
+- **Category:** backend
+- **Dependencies:** #4
+- **Files:** `src-tauri/src/commands/acp.rs`
+
+## #7 — ProtocolVersion + capability/field renames audit
+- **Description:** Switch `ProtocolVersion` usage to the new associated constants. Audit schema field/type renames that affect what we send over Tauri to the frontend — especially the capability surface the TS reads for gating (`sessionCapabilities.{list,fork,resume,close}` in `restoreOrCreateAcpSession` and the session-lifecycle docs). If a field renamed, update the Rust serialization AND the matching TS consumer so the capability gating still resolves. If nothing leaks to TS, record that explicitly.
+- **Complexity:** S
+- **Category:** both (backend; frontend only if a payload field renamed)
+- **Dependencies:** #3
+- **Files:** `src-tauri/src/commands/acp.rs`; possibly `src/lib/ai/acp-*.ts` / capability-gating call sites
+
+## #8 — Session resilience path
+- **Description:** Re-validate the reconnect/retry resilience flow against the new API: `acp_agent_reconnect` (kill → respawn → re-authenticate → `session/load`, acp.rs ~line 1330) and the `restoreOrCreateAcpSession` preference chain (resume → load → list → new). Ensure the rebuilt connection (from #4) is what reconnect produces, and that `load_session`/`resume_session` still restore context.
+- **Complexity:** M
+- **Category:** backend
+- **Dependencies:** #4, #6
+- **Files:** `src-tauri/src/commands/acp.rs`
+
+## #9 — Build + test gate
+- **Description:** `cd src-tauri && cargo test` green; `cargo build` clean (no warnings in the acp modules). Update/extend any Rust tests touching ACP types. Delete the #1 spike artifact. Run `pnpm typecheck` if #7 touched TS.
+- **Complexity:** M
+- **Category:** backend
+- **Dependencies:** #4, #5, #6, #7, #8
+- **Files:** `src-tauri/src/commands/acp.rs`, `acp_client.rs`, tests
+
+## #10 — Live agent smoke matrix (mandatory before merge)
+- **Description:** Real-agent verification (cannot be unit-tested). For **Claude Code** + at least one of **Codex / Copilot / Gemini**: connect + authenticate; prompt with streamed updates; trigger a permission card and exercise allow-once / allow-session / deny; switch mode + model; show usage; cancel mid-prompt; reopen a conversation (resume/load); branch (fork); delete (close); kill the agent and confirm the unresponsive banner + retry restores context. Capture any behavioral diffs vs. 0.10.4.
+- **Complexity:** L
+- **Category:** manual / QA
+- **Dependencies:** #9
+- **Files:** —
+
+## #11 — Docs
+- **Description:** Update living docs: `docs/architecture.md` (ACP module note) and `docs/features/ai-providers.md` (the "ACP crate version 0.10/0.11" line → 0.12.1/0.13.2; note the builder/component model + that session/close+resume are now stable). Reflect any behavior nuance found in #10. Leave PRDs/snapshots alone per the "PRDs are historical" rule.
+- **Complexity:** S
+- **Category:** docs
+- **Dependencies:** #10
+- **Files:** `docs/architecture.md`, `docs/features/ai-providers.md`

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -21,33 +21,53 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol"
-version = "0.10.4"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10eeef5e80864f9c3c148a3f395c3e35a66d37ec7561c7845b2bffae8e841759"
+checksum = "4361ba6627e51de955b10f3c77fb9eb959c85191a236c1c2c84e32f4ff240faf"
 dependencies = [
+ "agent-client-protocol-derive",
  "agent-client-protocol-schema",
- "anyhow",
- "async-broadcast",
- "async-trait",
- "derive_more",
+ "async-process",
+ "blocking",
  "futures",
- "log",
+ "futures-concurrency",
+ "jsonrpcmsg",
+ "rmcp",
+ "rustc-hash",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
+ "shell-words",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "agent-client-protocol-derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cabdc9d845d08ec7ed2d0c9de1ae4a1b198301407d55855261572761be90ec9f"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "agent-client-protocol-schema"
-version = "0.11.4"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca68e7e55681ce56546c0cecc6bc8f20493d24b44c6d93ec46174f310730bba2"
+checksum = "b957d8391ac3933e2a940446171c508d2b8ffc386d8fa7d0b9c936a2575b463e"
 dependencies = [
  "anyhow",
  "derive_more",
  "schemars 1.2.1",
  "serde",
  "serde_json",
+ "serde_with",
  "strum 0.28.0",
+ "tracing",
 ]
 
 [[package]]
@@ -169,7 +189,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -180,7 +200,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1634,7 +1654,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1666,7 +1686,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
- "libloading 0.7.4",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -1943,7 +1963,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2075,6 +2095,12 @@ name = "finl_unicode"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -2289,6 +2315,19 @@ checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
+]
+
+[[package]]
+name = "futures-concurrency"
+version = "7.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175cd8cca9e1d45b87f18ffa75088f2099e3c4fe5e2f83e42de112560bea8ea6"
+dependencies = [
+ "fixedbitset",
+ "futures-core",
+ "futures-lite",
+ "pin-project",
+ "smallvec",
 ]
 
 [[package]]
@@ -2587,7 +2626,7 @@ dependencies = [
  "gobject-sys 0.21.5",
  "libc",
  "system-deps 7.0.8",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3733,6 +3772,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpcmsg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d833a15225c779251e13929203518c2ff26e2fe0f322d584b213f4f4dad37bd"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "kamadak-exif"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4168,7 +4217,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4433,7 +4482,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4985,6 +5034,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5097,6 +5152,26 @@ name = "pico-args"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -5886,6 +5961,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmcp"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "chrono",
+ "futures",
+ "pastey",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "roman-numerals-rs"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5964,7 +6074,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6021,7 +6131,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6122,6 +6232,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "ref-cast",
  "schemars_derive 1.2.1",
@@ -6494,6 +6605,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6584,7 +6701,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6669,7 +6786,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7484,7 +7601,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7662,6 +7779,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -7931,7 +8049,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8280,7 +8398,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8995,7 +9113,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -69,8 +69,12 @@ fs_extra = "1.3"
 libc = "0.2"
 
 # ACP - Agent Client Protocol (Phase 6)
-agent-client-protocol = { version = "0.10.4", features = ["unstable_session_model", "unstable_session_usage", "unstable_session_close", "unstable_session_fork", "unstable_session_resume", "unstable_message_id", "unstable_auth_methods"] }
-agent-client-protocol-schema = { version = "0.11.4", features = ["unstable_session_model", "unstable_session_usage", "unstable_session_close", "unstable_session_fork", "unstable_session_resume", "unstable_message_id", "unstable_auth_methods"] }
+# session/close + session/resume were stabilized upstream (0.12.2); their
+# unstable_* feature flags were removed — the functionality is now default.
+# agent-client-protocol 0.12.1 pins the schema crate to exactly =0.13.2, so the
+# two versions must move together (0.13.3/0.13.4 aren't compatible with 0.12.1).
+agent-client-protocol = { version = "0.12.1", features = ["unstable_session_model", "unstable_session_usage", "unstable_session_fork", "unstable_message_id", "unstable_auth_methods"] }
+agent-client-protocol-schema = { version = "0.13.2", features = ["unstable_session_model", "unstable_session_usage", "unstable_session_fork", "unstable_message_id", "unstable_auth_methods"] }
 async-trait = "0.1"
 tokio-util = { version = "0.7", features = ["compat"] }
 

--- a/src-tauri/src/commands/acp.rs
+++ b/src-tauri/src/commands/acp.rs
@@ -1,13 +1,12 @@
 use serde::{Deserialize, Serialize};
-use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::rc::Rc;
+use std::sync::{Arc, Mutex as StdMutex};
 use tauri::{AppHandle, Emitter, Manager, State};
 use tokio::sync::{mpsc, oneshot, Mutex};
 
 use super::acp_binary::resolve_agent_binary;
-use super::acp_client::{InitInfo, JsonLineFilter, NotesageClient, PermissionReply};
+use super::acp_client::{ClientContext, InitInfo, JsonLineFilter, PermissionReply, PermissionWaiters};
 use super::shell_path::get_shell_path;
 
 // ---------------------------------------------------------------------------
@@ -320,11 +319,17 @@ enum AgentCmd {
 
 
 // ---------------------------------------------------------------------------
-// Agent thread: owns the !Send ClientSideConnection
+// Agent thread: owns the (now Send) ConnectionTo<Agent>
 // ---------------------------------------------------------------------------
 
-/// Runs on a dedicated OS thread with a single-threaded tokio runtime + LocalSet.
-/// This is necessary because ClientSideConnection is !Send (uses LocalBoxFuture).
+/// Runs on a dedicated OS thread with a single-threaded tokio runtime.
+///
+/// As of agent-client-protocol 0.12 the connection handle (`ConnectionTo<Agent>`)
+/// is `Send + Clone`, so the old `!Send` `LocalSet` isolation is no longer
+/// required. We still run on a dedicated OS thread so that `AgentHandle` can hold
+/// a `std::thread::JoinHandle` (used by liveness checks and `stop_all_sync`), and
+/// so the child process / cleanup all live on one runtime. A `current_thread`
+/// runtime is sufficient.
 fn run_agent_thread(
     app: AppHandle,
     instance_id: String,
@@ -336,12 +341,13 @@ fn run_agent_thread(
     sandbox_writable_paths: Vec<String>,
     network_config: Option<super::network_proxy::NetworkSandboxConfig>,
     kernel_network_deny: bool,
-    mut cmd_rx: mpsc::Receiver<AgentCmd>,
+    cmd_rx: mpsc::Receiver<AgentCmd>,
     init_tx: oneshot::Sender<Result<InitInfo, String>>,
     // Shared PID cell — written after spawn, readable from AgentHandle for SIGKILL
     captured_pid: std::sync::Arc<std::sync::atomic::AtomicU32>,
 ) {
-    use agent_client_protocol::*;
+    use agent_client_protocol::schema::*;
+    use agent_client_protocol::{ByteStreams, ConnectionTo};
     use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
     // Clone for cleanup after the command loop exits
@@ -362,25 +368,23 @@ fn run_agent_thread(
         }
     };
 
-    let local = tokio::task::LocalSet::new();
-
-    local.block_on(&rt, async move {
+    rt.block_on(async move {
         // Flag to distinguish intentional Stop from unexpected process exit
         let stopped_intentionally = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
 
-        // Shared permission waiters for client ↔ command loop communication
-        let permission_waiters: Rc<RefCell<HashMap<String, oneshot::Sender<PermissionReply>>>> =
-            Rc::new(RefCell::new(HashMap::new()));
+        // Shared permission waiters for inbound handler ↔ command loop communication.
+        // Send + Sync now that the connection is Send.
+        let permission_waiters: PermissionWaiters =
+            Arc::new(StdMutex::new(HashMap::new()));
 
         let sandbox_instance_id = instance_id.clone();
         let exit_app = app.clone();
         let exit_instance_id = instance_id.clone();
-        let client = NotesageClient {
-            app,
-            instance_id,
-            permission_waiters: Rc::clone(&permission_waiters),
-            next_request_id: Cell::new(0),
-        };
+        // Context shared into the inbound ACP handlers (permission + session update).
+        let client_ctx =
+            ClientContext::new(app.clone(), instance_id.clone(), Arc::clone(&permission_waiters));
+        // Used for sandbox-monitor registration before the connection is built.
+        let monitor_app = app.clone();
 
         // Spawn agent process — optionally wrapped in OS-level sandbox
         // Inject login shell PATH so the agent (and child processes) can find tools
@@ -438,9 +442,9 @@ fn run_agent_thread(
             if sandbox_enabled {
                 #[cfg(target_os = "macos")]
                 {
-                    let monitor_state = client.app.state::<super::sandbox_monitor::SandboxMonitorState>();
+                    let monitor_state = monitor_app.state::<super::sandbox_monitor::SandboxMonitorState>();
                     monitor_state.register_and_start(
-                        &client.app,
+                        &monitor_app,
                         sandbox_instance_id.clone(),
                         agent_binary.clone(),
                         pid,
@@ -475,9 +479,9 @@ fn run_agent_thread(
             });
         }
 
-        // Bridge tokio IO → futures IO for ACP
+        // Bridge tokio IO → futures IO for ACP.
         // Wrap stdout in a filter that strips non-JSON lines — some agents
-        // (e.g., Gemini CLI) write interactive prompts to stdout in ACP mode
+        // (e.g., Gemini CLI) write interactive prompts to stdout in ACP mode.
         let stdin = match child.stdin.take() {
             Some(s) => s.compat_write(),
             None => {
@@ -494,124 +498,160 @@ fn run_agent_thread(
         };
         let stdout = JsonLineFilter::new(raw_stdout).compat();
 
-        let (conn, io_task) = ClientSideConnection::new(
-            client,
-            stdin,  // outgoing: client writes to agent's stdin
-            stdout, // incoming: client reads from agent's stdout
-            |fut| {
-                tokio::task::spawn_local(fut);
-            },
-        );
+        // Transport: the child's stdio. `ByteStreams::new(outgoing_write, incoming_read)`
+        // — we write to the agent's stdin and read from its (filtered) stdout.
+        let transport = ByteStreams::new(stdin, stdout);
 
-        // Wrap connection in Rc so prompt can run via spawn_local while
-        // the command loop stays responsive for cancel/permission commands.
-        let conn = Rc::new(conn);
+        // Inbound handler context, cloned into each registered handler closure.
+        let notif_ctx = client_ctx.clone();
+        let perm_ctx = client_ctx.clone();
 
-        // Spawn the I/O task on the LocalSet
-        let io_binary = agent_binary.clone();
-        tokio::task::spawn_local(async move {
-            match io_task.await {
-                Ok(_) => {
-                    log::info!(target: "notesage::acp", "[{}] IO task completed normally", io_binary);
-                }
-                Err(e) => {
-                    log::error!(
-                        target: "notesage::acp",
-                        "[{}] IO task error (agent may have crashed or closed its stdio): {}",
-                        io_binary, e,
-                    );
-                }
-            }
-        });
+        // The command loop and initialize handshake live inside `connect_with`'s
+        // closure — the future returned by `connect_with` drives the connection for
+        // the closure's lifetime, then shuts it down when the closure returns.
+        let stopped_for_loop = std::sync::Arc::clone(&stopped_intentionally);
+        let loop_binary = agent_binary.clone();
+        let perm_waiters_loop = Arc::clone(&permission_waiters);
 
-        // Initialize handshake
-        log::info!(target: "notesage::acp", "Sending ACP initialize for {}", agent_binary);
-        let init_req = InitializeRequest::new(ProtocolVersion::V1).client_info(
-            Implementation::new("Notesage", env!("CARGO_PKG_VERSION")),
-        );
-
-        // Store auth methods from init response for later use — variant-aware so the
-        // authenticate command can look up EnvVar vs Agent methods without a second
-        // round-trip to the agent.
-        let auth_methods_info: Vec<AuthMethodInfo>;
-
-        match conn.initialize(init_req).await {
-            Ok(resp) => {
-                log::info!(
-                    target: "notesage::acp",
-                    "ACP initialize succeeded for {}: agent={:?}, auth_methods={:?}",
-                    agent_binary,
-                    resp.agent_info.as_ref().map(|i| format!("{} {}", i.name, i.version)),
-                    resp.auth_methods.iter().map(|m| format!("{}({})", m.id(), m.name())).collect::<Vec<_>>(),
+        let connect_result = agent_client_protocol::Client
+            .builder()
+            .name(format!("notesage-acp:{}", agent_binary))
+            // Inbound: session updates → `acp-session-update` Tauri event.
+            .on_receive_notification(
+                move |notification: SessionNotification, _cx: ConnectionTo<agent_client_protocol::Agent>| {
+                    let ctx = notif_ctx.clone();
+                    async move {
+                        ctx.emit_session_update(&notification);
+                        Ok(())
+                    }
+                },
+                agent_client_protocol::on_receive_notification!(),
+            )
+            // Inbound: permission requests → `acp-permission-request` event + await user.
+            // The round-trip to the user must not block the event loop, so the wait +
+            // response is offloaded to `cx.spawn`.
+            .on_receive_request(
+                move |request: RequestPermissionRequest,
+                      responder: agent_client_protocol::Responder<RequestPermissionResponse>,
+                      cx: ConnectionTo<agent_client_protocol::Agent>| {
+                    let ctx = perm_ctx.clone();
+                    async move {
+                        let rx = ctx.begin_permission_request(&request);
+                        cx.spawn(async move {
+                            let outcome = match rx.await {
+                                Ok(reply) => match reply.option_id {
+                                    Some(oid) => RequestPermissionOutcome::Selected(
+                                        SelectedPermissionOutcome::new(PermissionOptionId::new(oid)),
+                                    ),
+                                    None => RequestPermissionOutcome::Cancelled,
+                                },
+                                // Waiter dropped (agent stopped / cancelled) — cancel.
+                                Err(_) => RequestPermissionOutcome::Cancelled,
+                            };
+                            responder.respond(RequestPermissionResponse::new(outcome))?;
+                            Ok(())
+                        })?;
+                        Ok(())
+                    }
+                },
+                agent_client_protocol::on_receive_request!(),
+            )
+            .connect_with(transport, async move |conn: ConnectionTo<agent_client_protocol::Agent>| {
+                // Initialize handshake
+                log::info!(target: "notesage::acp", "Sending ACP initialize for {}", loop_binary);
+                let init_req = InitializeRequest::new(ProtocolVersion::V1).client_info(
+                    Implementation::new("Notesage", env!("CARGO_PKG_VERSION")),
                 );
-                auth_methods_info = resp
-                    .auth_methods
-                    .iter()
-                    .map(|m| match m {
-                        AuthMethod::EnvVar(e) => AuthMethodInfo::EnvVar {
-                            id: e.id.to_string(),
-                            name: e.name.clone(),
-                            description: e.description.clone(),
-                            vars: e
-                                .vars
-                                .iter()
-                                .map(|v| super::acp::AuthEnvVar {
-                                    name: v.name.clone(),
-                                    label: v.label.clone(),
-                                    secret: v.secret,
-                                    optional: v.optional,
-                                })
-                                .collect(),
-                            link: e.link.clone(),
-                        },
-                        AuthMethod::Terminal(_) => {
-                            // Terminal variant support is Batch F territory — surface it as
-                            // a plain `Agent`-style info block so the UI still shows the ID/name.
-                            AuthMethodInfo::Agent {
-                                id: m.id().to_string(),
-                                name: m.name().to_string(),
-                                description: m.description().map(|s| s.to_string()),
-                            }
-                        }
-                        AuthMethod::Agent(_) => AuthMethodInfo::Agent {
-                            id: m.id().to_string(),
-                            name: m.name().to_string(),
-                            description: m.description().map(|s| s.to_string()),
-                        },
-                        // Non-exhaustive guard: any future ACP variant surfaces as Agent.
-                        _ => AuthMethodInfo::Agent {
-                            id: m.id().to_string(),
-                            name: m.name().to_string(),
-                            description: m.description().map(|s| s.to_string()),
-                        },
-                    })
-                    .collect();
 
-                let supports_images_flag = resp.agent_capabilities.prompt_capabilities.image;
-                log::info!(
-                    target: "notesage::acp",
-                    "Agent {} supports_images={}",
-                    agent_binary, supports_images_flag,
-                );
-                let capabilities_json = serde_json::to_value(&resp.agent_capabilities).ok();
-                let info = InitInfo {
-                    agent_name: resp.agent_info.as_ref().map(|i| i.name.clone()),
-                    agent_version: resp.agent_info.as_ref().map(|i| i.version.clone()),
-                    auth_methods: auth_methods_info.clone(),
-                    supports_images: supports_images_flag,
-                    capabilities: capabilities_json,
-                };
-                let _ = init_tx.send(Ok(info));
-            }
-            Err(e) => {
-                let _ = init_tx.send(Err(format!("ACP initialize failed: {}", e)));
-                let _ = child.kill().await;
-                return;
-            }
-        }
+                // Store auth methods from init response for later use — variant-aware so the
+                // authenticate command can look up EnvVar vs Agent methods without a second
+                // round-trip to the agent.
+                let auth_methods_info: Vec<AuthMethodInfo>;
 
-        // Command loop — process commands from Tauri
-        while let Some(cmd) = cmd_rx.recv().await {
+                match conn.send_request(init_req).block_task().await {
+                    Ok(resp) => {
+                        log::info!(
+                            target: "notesage::acp",
+                            "ACP initialize succeeded for {}: agent={:?}, auth_methods={:?}",
+                            loop_binary,
+                            resp.agent_info.as_ref().map(|i| format!("{} {}", i.name, i.version)),
+                            resp.auth_methods.iter().map(|m| format!("{}({})", m.id(), m.name())).collect::<Vec<_>>(),
+                        );
+                        auth_methods_info = resp
+                            .auth_methods
+                            .iter()
+                            .map(|m| match m {
+                                AuthMethod::EnvVar(e) => AuthMethodInfo::EnvVar {
+                                    id: e.id.to_string(),
+                                    name: e.name.clone(),
+                                    description: e.description.clone(),
+                                    vars: e
+                                        .vars
+                                        .iter()
+                                        .map(|v| super::acp::AuthEnvVar {
+                                            name: v.name.clone(),
+                                            label: v.label.clone(),
+                                            secret: v.secret,
+                                            optional: v.optional,
+                                        })
+                                        .collect(),
+                                    link: e.link.clone(),
+                                },
+                                AuthMethod::Terminal(_) => {
+                                    // Terminal variant support is Batch F territory — surface it as
+                                    // a plain `Agent`-style info block so the UI still shows the ID/name.
+                                    AuthMethodInfo::Agent {
+                                        id: m.id().to_string(),
+                                        name: m.name().to_string(),
+                                        description: m.description().map(|s| s.to_string()),
+                                    }
+                                }
+                                AuthMethod::Agent(_) => AuthMethodInfo::Agent {
+                                    id: m.id().to_string(),
+                                    name: m.name().to_string(),
+                                    description: m.description().map(|s| s.to_string()),
+                                },
+                                // Non-exhaustive guard: any future ACP variant surfaces as Agent.
+                                _ => AuthMethodInfo::Agent {
+                                    id: m.id().to_string(),
+                                    name: m.name().to_string(),
+                                    description: m.description().map(|s| s.to_string()),
+                                },
+                            })
+                            .collect();
+
+                        let supports_images_flag = resp.agent_capabilities.prompt_capabilities.image;
+                        log::info!(
+                            target: "notesage::acp",
+                            "Agent {} supports_images={}",
+                            loop_binary, supports_images_flag,
+                        );
+                        let capabilities_json = serde_json::to_value(&resp.agent_capabilities).ok();
+                        let info = InitInfo {
+                            agent_name: resp.agent_info.as_ref().map(|i| i.name.clone()),
+                            agent_version: resp.agent_info.as_ref().map(|i| i.version.clone()),
+                            auth_methods: auth_methods_info.clone(),
+                            supports_images: supports_images_flag,
+                            capabilities: capabilities_json,
+                        };
+                        let _ = init_tx.send(Ok(info));
+                    }
+                    Err(e) => {
+                        let _ = init_tx.send(Err(format!("ACP initialize failed: {}", e)));
+                        let _ = child.kill().await;
+                        return Ok(());
+                    }
+                }
+
+                // Bind the moved values so the existing command-loop body compiles
+                // unchanged (it references these names).
+                let agent_binary = loop_binary;
+                let permission_waiters = perm_waiters_loop;
+                let stopped_intentionally = stopped_for_loop;
+                let mut cmd_rx = cmd_rx;
+
+                // Command loop — process commands from Tauri
+                while let Some(cmd) = cmd_rx.recv().await {
             match cmd {
                 AgentCmd::Authenticate { method_id, reply } => {
                     // If agent has no auth methods, it handles auth internally
@@ -656,7 +696,7 @@ fn run_agent_thread(
                     let auth_req = AuthenticateRequest::new(AuthMethodId::new(
                         selected_id.clone(),
                     ));
-                    match conn.authenticate(auth_req).await {
+                    match conn.send_request(auth_req).block_task().await {
                         Ok(resp) => {
                             log::info!(
                                 target: "notesage::acp",
@@ -686,7 +726,7 @@ fn run_agent_thread(
                     reply,
                 } => {
                     let req = NewSessionRequest::new(PathBuf::from(cwd));
-                    match conn.new_session(req).await {
+                    match conn.send_request(req).block_task().await {
                         Ok(resp) => {
                             let mut current_model = None;
                             let mut available_models = Vec::new();
@@ -733,7 +773,7 @@ fn run_agent_thread(
                         SessionId::new(sid.clone()),
                         PathBuf::from(cwd),
                     );
-                    match conn.load_session(req).await {
+                    match conn.send_request(req).block_task().await {
                         Ok(resp) => {
                             let mut current_model = None;
                             let mut available_models = Vec::new();
@@ -778,13 +818,16 @@ fn run_agent_thread(
                     message_id,
                     reply,
                 } => {
-                    // Run prompt in a spawn_local so the command loop remains
-                    // responsive for Cancel and PermissionRespond commands
-                    // while the agent processes the prompt.
-                    let conn = Rc::clone(&conn);
+                    // Run prompt in a background task so the command loop remains
+                    // responsive for Cancel and PermissionRespond commands while the
+                    // agent processes the prompt. `ConnectionTo` is Send + Clone, so a
+                    // plain tokio task suffices; using `tokio::spawn` (rather than
+                    // `conn.spawn`) keeps a prompt error from tearing down the whole
+                    // connection.
+                    let conn = conn.clone();
                     let prompt_binary = agent_binary.clone();
                     let prompt_sid = sid.clone();
-                    tokio::task::spawn_local(async move {
+                    tokio::task::spawn(async move {
                         log::info!(
                             target: "notesage::acp",
                             "[{}] Prompt started (session={}, content_len={}, images={}, has_message_id={})",
@@ -810,7 +853,7 @@ fn run_agent_thread(
                         if let Some(mid) = message_id {
                             req = req.message_id(mid);
                         }
-                        match conn.prompt(req).await {
+                        match conn.send_request(req).block_task().await {
                             Ok(_) => {
                                 log::info!(
                                     target: "notesage::acp",
@@ -836,10 +879,15 @@ fn run_agent_thread(
                     reply,
                 } => {
                     // ACP spec: when sending cancel, the client MUST respond Cancelled
-                    // to all pending session/request_permission requests
-                    permission_waiters.borrow_mut().clear();
+                    // to all pending session/request_permission requests. Dropping the
+                    // waiter senders makes the in-flight permission handler tasks resolve
+                    // to `Cancelled` (their `rx.await` returns `Err`).
+                    if let Ok(mut waiters) = permission_waiters.lock() {
+                        waiters.clear();
+                    }
+                    // Cancel is a notification (fire-and-forget) in ACP.
                     let req = CancelNotification::new(SessionId::new(sid));
-                    match conn.cancel(req).await {
+                    match conn.send_notification(req) {
                         Ok(_) => {
                             let _ = reply.send(Ok(()));
                         }
@@ -853,9 +901,11 @@ fn run_agent_thread(
                     request_id,
                     option_id,
                 } => {
-                    if let Some(tx) =
-                        permission_waiters.borrow_mut().remove(&request_id)
-                    {
+                    let tx = permission_waiters
+                        .lock()
+                        .ok()
+                        .and_then(|mut w| w.remove(&request_id));
+                    if let Some(tx) = tx {
                         let _ = tx.send(PermissionReply { option_id });
                     }
                 }
@@ -868,7 +918,7 @@ fn run_agent_thread(
                         SessionId::new(sid),
                         SessionModeId::new(mode_id),
                     );
-                    match conn.set_session_mode(req).await {
+                    match conn.send_request(req).block_task().await {
                         Ok(_) => { let _ = reply.send(Ok(())); }
                         Err(e) => { let _ = reply.send(Err(format!("set_mode failed: {}", e))); }
                     }
@@ -884,7 +934,7 @@ fn run_agent_thread(
                         SessionConfigId::new(option_id),
                         SessionConfigValueId::new(value_id),
                     );
-                    match conn.set_session_config_option(req).await {
+                    match conn.send_request(req).block_task().await {
                         Ok(_) => { let _ = reply.send(Ok(())); }
                         Err(e) => { let _ = reply.send(Err(format!("set_config_option failed: {}", e))); }
                     }
@@ -898,7 +948,7 @@ fn run_agent_thread(
                         SessionId::new(sid),
                         ModelId::new(model_id),
                     );
-                    match conn.set_session_model(req).await {
+                    match conn.send_request(req).block_task().await {
                         Ok(_) => { let _ = reply.send(Ok(())); }
                         Err(e) => { let _ = reply.send(Err(format!("set_model failed: {}", e))); }
                     }
@@ -908,7 +958,7 @@ fn run_agent_thread(
                     reply,
                 } => {
                     let req = CloseSessionRequest::new(SessionId::new(sid));
-                    match conn.close_session(req).await {
+                    match conn.send_request(req).block_task().await {
                         Ok(_) => { let _ = reply.send(Ok(())); }
                         Err(e) => { let _ = reply.send(Err(format!("close_session failed: {}", e))); }
                     }
@@ -917,7 +967,7 @@ fn run_agent_thread(
                     let mut req = ListSessionsRequest::new();
                     if let Some(c) = cwd { req = req.cwd(Some(PathBuf::from(c))); }
                     if let Some(c) = cursor { req = req.cursor(Some(c)); }
-                    match conn.list_sessions(req).await {
+                    match conn.send_request(req).block_task().await {
                         Ok(resp) => {
                             let sessions: Vec<crate::commands::acp::AcpSessionInfo> =
                                 resp.sessions.iter().map(|s| crate::commands::acp::AcpSessionInfo {
@@ -941,7 +991,7 @@ fn run_agent_thread(
                         SessionId::new(sid.clone()),
                         PathBuf::from(cwd),
                     );
-                    match conn.resume_session(req).await {
+                    match conn.send_request(req).block_task().await {
                         Ok(resp) => {
                             let mut current_model = None;
                             let mut available_models = Vec::new();
@@ -981,7 +1031,7 @@ fn run_agent_thread(
                         SessionId::new(sid),
                         PathBuf::from(cwd),
                     );
-                    match conn.fork_session(req).await {
+                    match conn.send_request(req).block_task().await {
                         Ok(resp) => {
                             let mut current_model = None;
                             let mut available_models = Vec::new();
@@ -1015,25 +1065,41 @@ fn run_agent_thread(
                 AgentCmd::Stop { reply } => {
                     stopped_intentionally.store(true, std::sync::atomic::Ordering::Relaxed);
                     // Clear any pending permission waiters so they cancel
-                    permission_waiters.borrow_mut().clear();
+                    if let Ok(mut waiters) = permission_waiters.lock() {
+                        waiters.clear();
+                    }
                     let _ = child.kill().await;
                     let _ = reply.send(Ok(()));
                     break;
                 }
+                }
             }
-        }
 
-        // Emit exit event if the agent died unexpectedly (not via Stop command)
-        if !stopped_intentionally.load(std::sync::atomic::Ordering::Relaxed) {
-            let exit_code = child.try_wait().ok().flatten().map(|s| s.code()).flatten();
-            let _ = exit_app.emit("acp-agent-exited", AgentExitedPayload {
-                instance_id: exit_instance_id.clone(),
-                exit_code,
-            });
-            log::warn!(
+            // Emit exit event if the agent died unexpectedly (not via Stop command).
+            // `child` and `stopped_intentionally` live in this closure, so the
+            // detection happens here before `connect_with` returns.
+            if !stopped_intentionally.load(std::sync::atomic::Ordering::Relaxed) {
+                let exit_code = child.try_wait().ok().flatten().map(|s| s.code()).flatten();
+                let _ = exit_app.emit("acp-agent-exited", AgentExitedPayload {
+                    instance_id: exit_instance_id.clone(),
+                    exit_code,
+                });
+                log::warn!(
+                    target: "notesage::acp",
+                    "Agent {} exited unexpectedly (code: {:?})",
+                    exit_instance_id, exit_code,
+                );
+            }
+
+            Ok(())
+        })
+        .await;
+
+        if let Err(e) = connect_result {
+            log::error!(
                 target: "notesage::acp",
-                "Agent {} exited unexpectedly (code: {:?})",
-                exit_instance_id, exit_code,
+                "[{}] ACP connection ended with error: {}",
+                agent_binary, e,
             );
         }
     });
@@ -1821,7 +1887,7 @@ pub async fn acp_permission_respond(
 #[cfg(test)]
 mod tests {
     use super::{AuthEnvVar, AuthMethodInfo};
-    use agent_client_protocol::{ContentBlock, PromptRequest, SessionId, TextContent};
+    use agent_client_protocol::schema::{ContentBlock, PromptRequest, SessionId, TextContent};
 
     /// `AuthMethodInfo::EnvVar` must round-trip through serde so the frontend receives
     /// the full `{ vars, link }` payload. Tagged as `{ "type": "env_var", ... }`.

--- a/src-tauri/src/commands/acp.rs
+++ b/src-tauri/src/commands/acp.rs
@@ -467,10 +467,13 @@ fn run_agent_thread(
             }
         }
 
-        // Spawn a task to read and log stderr from the agent process
+        // Spawn a task to read and log stderr from the agent process.
+        // Plain `spawn` (not `spawn_local`): the runtime is a bare
+        // `new_current_thread` with no `LocalSet`, and the captured values
+        // (`String` + `ChildStderr`) are `Send`.
         if let Some(stderr) = child.stderr.take() {
             let stderr_binary = agent_binary.clone();
-            tokio::task::spawn_local(async move {
+            tokio::task::spawn(async move {
                 use tokio::io::{AsyncBufReadExt, BufReader};
                 let mut lines = BufReader::new(stderr).lines();
                 while let Ok(Some(line)) = lines.next_line().await {
@@ -1366,31 +1369,39 @@ pub async fn acp_agent_stop(
     state: State<'_, AcpState>,
     instance_id: String,
 ) -> Result<(), String> {
-    let mut agents = state.agents.lock().await;
-    let mut handle = agents
-        .remove(&instance_id)
-        .ok_or_else(|| format!("No agent found with instance_id: {}", instance_id))?;
+    // Remove the handle and DROP the map lock before any `.await`, so concurrent
+    // ACP commands aren't blocked for the whole stop round-trip (which can be as
+    // long as an in-flight prompt). Holding `agents` across the send/reply/join
+    // below would serialize every other command behind this one.
+    let mut handle = {
+        let mut agents = state.agents.lock().await;
+        agents
+            .remove(&instance_id)
+            .ok_or_else(|| format!("No agent found with instance_id: {}", instance_id))?
+    };
 
+    let thread_handle = handle.thread_handle.take();
+
+    // Best-effort graceful stop. On any failure we still join the OS thread
+    // below so we never leak a zombie (dropping `handle` releases `cmd_tx`, and
+    // `kill_on_drop` tears down the child).
     let (reply_tx, reply_rx) = oneshot::channel();
+    let result = match handle.cmd_tx.send(AgentCmd::Stop { reply: reply_tx }).await {
+        Ok(()) => reply_rx
+            .await
+            .map_err(|_| "Agent thread did not respond to stop".to_string())
+            .and_then(|r| r),
+        Err(_) => Err("Agent thread is no longer running".to_string()),
+    };
 
-    // Send stop command to the agent thread
-    handle
-        .cmd_tx
-        .send(AgentCmd::Stop { reply: reply_tx })
-        .await
-        .map_err(|_| "Agent thread is no longer running".to_string())?;
-
-    // Wait for stop confirmation
-    reply_rx
-        .await
-        .map_err(|_| "Agent thread did not respond to stop".to_string())??;
-
-    // Wait for the OS thread to finish
-    if let Some(th) = handle.thread_handle.take() {
-        let _ = th.join();
+    // Drop the handle (releases cmd_tx → the command loop ends), then join the
+    // OS thread on a blocking-safe task so we don't park the async executor.
+    drop(handle);
+    if let Some(th) = thread_handle {
+        let _ = tokio::task::spawn_blocking(move || th.join()).await;
     }
 
-    Ok(())
+    result
 }
 
 /// Kill a hung agent, respawn with the same config, re-authenticate, and load the session.

--- a/src-tauri/src/commands/acp_client.rs
+++ b/src-tauri/src/commands/acp_client.rs
@@ -1,6 +1,5 @@
-use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
-use std::rc::Rc;
+use std::sync::{Arc, Mutex};
 use tauri::{AppHandle, Emitter};
 use tokio::sync::oneshot;
 
@@ -23,44 +22,78 @@ pub(super) struct PermissionReply {
     pub option_id: Option<String>,
 }
 
-// ---------------------------------------------------------------------------
-// ACP Client implementation with Tauri event forwarding
-// ---------------------------------------------------------------------------
+/// Shared map of pending permission requests, keyed by request id.
+///
+/// The inbound `request_permission` handler inserts a waiter here and forwards
+/// the request to the frontend as an `acp-permission-request` Tauri event; the
+/// command loop's `PermissionRespond` / `Cancel` arms resolve or clear waiters.
+///
+/// Uses `Arc<std::sync::Mutex<…>>` (rather than the old `Rc<RefCell<…>>`) because
+/// the 0.12 `ConnectionTo<Agent>` handle is `Send + Clone` — handlers and the
+/// command loop now run on tokio tasks that may move across threads. The lock is
+/// only ever held for the duration of a `HashMap` insert/remove/clear, so there
+/// is no risk of holding it across an `.await`.
+pub(super) type PermissionWaiters =
+    Arc<Mutex<HashMap<String, oneshot::Sender<PermissionReply>>>>;
 
-/// Notesage's implementation of the ACP Client trait.
-/// Forwards session notifications as `acp-session-update` Tauri events
-/// and handles permission requests by emitting `acp-permission-request`
-/// events and waiting for frontend responses via the command channel.
-pub(super) struct NotesageClient {
+/// Shared client-side context captured by the inbound ACP handlers.
+///
+/// Cloned into both the `on_receive_request` (permission) and
+/// `on_receive_notification` (session update) closures registered on the
+/// connection builder. Everything here is `Send + Sync + Clone` so the handlers
+/// satisfy the 0.12 builder bounds.
+#[derive(Clone)]
+pub(super) struct ClientContext {
     pub app: AppHandle,
     pub instance_id: String,
-    pub permission_waiters: Rc<RefCell<HashMap<String, oneshot::Sender<PermissionReply>>>>,
-    pub next_request_id: Cell<u64>,
+    pub permission_waiters: PermissionWaiters,
+    /// Monotonic counter for generating unique permission request ids.
+    pub next_request_id: Arc<std::sync::atomic::AtomicU64>,
 }
 
-#[async_trait::async_trait(?Send)]
-impl agent_client_protocol::Client for NotesageClient {
-    async fn request_permission(
-        &self,
-        args: agent_client_protocol::RequestPermissionRequest,
-    ) -> agent_client_protocol::Result<agent_client_protocol::RequestPermissionResponse> {
-        use agent_client_protocol::{
-            PermissionOptionId, RequestPermissionOutcome, RequestPermissionResponse,
-            SelectedPermissionOutcome,
-        };
+impl ClientContext {
+    pub fn new(app: AppHandle, instance_id: String, permission_waiters: PermissionWaiters) -> Self {
+        Self {
+            app,
+            instance_id,
+            permission_waiters,
+            next_request_id: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+        }
+    }
 
-        // Generate a unique request ID
-        let id = self.next_request_id.get();
-        self.next_request_id.set(id + 1);
+    /// Forward a `SessionNotification` to the frontend as an `acp-session-update`
+    /// Tauri event. Payload shape is identical to the pre-0.12 client:
+    /// `{ instanceId, sessionId, update }`.
+    pub fn emit_session_update(
+        &self,
+        notification: &agent_client_protocol::schema::SessionNotification,
+    ) {
+        let payload = serde_json::json!({
+            "instanceId": self.instance_id,
+            "sessionId": notification.session_id.to_string(),
+            "update": serde_json::to_value(&notification.update).unwrap_or_default(),
+        });
+        let _ = self.app.emit("acp-session-update", payload);
+    }
+
+    /// Register a permission waiter and emit the `acp-permission-request` event.
+    /// Returns the receiver the handler awaits for the user's decision. Payload
+    /// shape is identical to the pre-0.12 client:
+    /// `{ instanceId, sessionId, requestId, toolCall, options }`.
+    pub fn begin_permission_request(
+        &self,
+        args: &agent_client_protocol::schema::RequestPermissionRequest,
+    ) -> oneshot::Receiver<PermissionReply> {
+        let id = self
+            .next_request_id
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let request_id = format!("perm-{}", id);
 
-        // Create the response channel
         let (tx, rx) = oneshot::channel();
-        self.permission_waiters
-            .borrow_mut()
-            .insert(request_id.clone(), tx);
+        if let Ok(mut waiters) = self.permission_waiters.lock() {
+            waiters.insert(request_id.clone(), tx);
+        }
 
-        // Emit permission request to frontend
         let payload = serde_json::json!({
             "instanceId": self.instance_id,
             "sessionId": args.session_id.to_string(),
@@ -70,40 +103,7 @@ impl agent_client_protocol::Client for NotesageClient {
         });
         let _ = self.app.emit("acp-permission-request", payload);
 
-        // Wait for the frontend to respond
-        match rx.await {
-            Ok(reply) => match reply.option_id {
-                Some(oid) => Ok(RequestPermissionResponse::new(
-                    RequestPermissionOutcome::Selected(SelectedPermissionOutcome::new(
-                        PermissionOptionId::new(oid),
-                    )),
-                )),
-                None => Ok(RequestPermissionResponse::new(
-                    RequestPermissionOutcome::Cancelled,
-                )),
-            },
-            Err(_) => {
-                // Waiter dropped (agent stopped) — cancel
-                Ok(RequestPermissionResponse::new(
-                    RequestPermissionOutcome::Cancelled,
-                ))
-            }
-        }
-    }
-
-    async fn session_notification(
-        &self,
-        args: agent_client_protocol::SessionNotification,
-    ) -> agent_client_protocol::Result<()> {
-        // Serialize the full update and emit as a single event type.
-        // The frontend dispatches based on the `sessionUpdate` tag in the JSON.
-        let payload = serde_json::json!({
-            "instanceId": self.instance_id,
-            "sessionId": args.session_id.to_string(),
-            "update": serde_json::to_value(&args.update).unwrap_or_default(),
-        });
-        let _ = self.app.emit("acp-session-update", payload);
-        Ok(())
+        rx
     }
 }
 

--- a/src-tauri/src/commands/acp_client.rs
+++ b/src-tauri/src/commands/acp_client.rs
@@ -90,9 +90,13 @@ impl ClientContext {
         let request_id = format!("perm-{}", id);
 
         let (tx, rx) = oneshot::channel();
-        if let Ok(mut waiters) = self.permission_waiters.lock() {
-            waiters.insert(request_id.clone(), tx);
-        }
+        // Recover from a poisoned lock (into_inner) rather than silently skipping
+        // the insert — if we dropped `tx` here the handler's `rx` would error and
+        // respond Cancelled for a request the user never saw.
+        self.permission_waiters
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(request_id.clone(), tx);
 
         let payload = serde_json::json!({
             "instanceId": self.instance_id,

--- a/src-tauri/tests/mock_acp_agent.rs
+++ b/src-tauri/tests/mock_acp_agent.rs
@@ -1,16 +1,30 @@
-//! Integration tests for the mock ACP agent.
+//! Integration tests for a mock ACP agent on agent-client-protocol 0.12.1.
 //!
-//! These tests use the ACP crate's own `ClientSideConnection` and a
-//! `MockAgent` (implementing the `Agent` trait) connected via in-memory
-//! `tokio::io::duplex` channels.  No external binary spawn, no `AppHandle`,
-//! and — critically — ACP crate types are used directly throughout.  An ACP
-//! crate version bump that renames or reshapes `InitializeRequest`,
-//! `NewSessionRequest`, `PromptRequest`, etc. will cause compile errors here,
-//! giving immediate protocol-regression feedback.
+//! These tests stand up a **mock agent** (built with `Agent.builder()` and a
+//! request handler per client→agent method) and a **mock client** (built with
+//! `Client.builder()`), wire them together over the crate's own in-memory
+//! [`Channel::duplex`] transport, and drive real ACP round-trips between them.
 //!
-//! Because all `unstable_*` features are unconditionally enabled for this
-//! crate in `Cargo.toml`, there is no feature-gating inside these tests:
-//! all code paths are always compiled and exercised.
+//! Because the ACP crate types (`InitializeRequest`, `NewSessionRequest`,
+//! `PromptRequest`, the capability structs, etc.) are used directly throughout,
+//! an ACP crate version bump that renames or reshapes any of them causes a
+//! compile error here — immediate protocol-regression feedback.
+//!
+//! ## How the harness works
+//!
+//! - `Channel::duplex()` returns a paired pair of in-memory endpoints. One half
+//!   is handed to the agent's `connect_with`, the other to the client's. Both
+//!   `connect_with` futures run concurrently via `tokio::join!`; the messages
+//!   each side emits arrive on the other side's channel.
+//! - The client's driving closure (`main_fn`) performs the requests and the
+//!   assertions, then signals `done` so the agent's driving closure returns and
+//!   its connection shuts down cleanly.
+//! - The mock agent's behaviour (which capabilities it advertises, what session
+//!   IDs it mints) is configured via [`CapabilityProfile`] and shared
+//!   `Arc<Mutex<…>>` state that the handlers read/write.
+//!
+//! All `unstable_*` features are unconditionally enabled for this crate in
+//! `Cargo.toml`, so there is no feature-gating inside these tests.
 //!
 //! ## Running
 //!
@@ -18,31 +32,30 @@
 //! cd src-tauri
 //! cargo test --test mock_acp_agent
 //! ```
-//!
-//! These tests do **not** require `--include-ignored`; they run as part of
-//! the standard `cargo test` suite.
 
 use std::sync::{Arc, Mutex};
 
-use agent_client_protocol::{
-    Agent, AgentCapabilities, AgentSideConnection, AuthenticateRequest, AuthenticateResponse,
-    CancelNotification, Client, ClientSideConnection, CloseSessionRequest, CloseSessionResponse,
-    ForkSessionRequest, ForkSessionResponse, Implementation, InitializeRequest, InitializeResponse,
-    ListSessionsRequest, ListSessionsResponse, LoadSessionRequest, LoadSessionResponse,
-    NewSessionRequest, NewSessionResponse, PromptCapabilities, PromptRequest, PromptResponse,
-    ProtocolVersion, RequestPermissionOutcome, RequestPermissionRequest, RequestPermissionResponse,
+use agent_client_protocol::role::acp::{Agent, Client};
+use agent_client_protocol::schema::{
+    AgentCapabilities, AuthenticateRequest, AuthenticateResponse, CancelNotification,
+    CloseSessionRequest, CloseSessionResponse, ForkSessionRequest, ForkSessionResponse,
+    Implementation, InitializeRequest, InitializeResponse, ListSessionsRequest,
+    ListSessionsResponse, LoadSessionRequest, LoadSessionResponse, NewSessionRequest,
+    NewSessionResponse, PromptCapabilities, PromptRequest, PromptResponse, ProtocolVersion,
+    RequestPermissionOutcome, RequestPermissionRequest, RequestPermissionResponse,
     ResumeSessionRequest, ResumeSessionResponse, SessionCapabilities, SessionCloseCapabilities,
-    SessionForkCapabilities, SessionId, SessionInfo, SessionNotification,
-    SessionResumeCapabilities, SetSessionConfigOptionRequest, SetSessionConfigOptionResponse,
-    SetSessionModeRequest, SetSessionModeResponse, StopReason,
+    SessionForkCapabilities, SessionId, SessionInfo, SessionNotification, SessionResumeCapabilities,
+    SetSessionConfigOptionRequest, SetSessionConfigOptionResponse, SetSessionModeRequest,
+    SetSessionModeResponse, StopReason,
 };
+use agent_client_protocol::{Channel, ConnectionTo, Responder};
 
 // ---------------------------------------------------------------------------
-// MockAgent — configurable ACP agent for in-memory testing
+// MockAgent — configurable ACP agent state for in-memory testing
 // ---------------------------------------------------------------------------
 
 /// Capability profile for the mock agent.
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 enum CapabilityProfile {
     /// Full capabilities: fork, resume, close, images.
     Full,
@@ -50,32 +63,27 @@ enum CapabilityProfile {
     Minimal,
 }
 
-/// Recorded prompt requests for post-test inspection.
-type PromptRecord = (SessionId, Vec<agent_client_protocol::ContentBlock>);
-
+/// Mutable mock-agent state shared across all the request handlers.
+///
+/// `Arc<Mutex<…>>` (rather than the pre-0.12 `&self` trait methods) because the
+/// 0.12 builder handlers are `Send` closures that may run on any task.
 #[derive(Clone)]
-struct MockAgent {
+struct MockAgentState {
     profile: CapabilityProfile,
     sessions: Arc<Mutex<Vec<SessionId>>>,
-    prompts: Arc<Mutex<Vec<PromptRecord>>>,
 }
 
-impl MockAgent {
+impl MockAgentState {
     fn new(profile: CapabilityProfile) -> Self {
         Self {
             profile,
             sessions: Arc::new(Mutex::new(Vec::new())),
-            prompts: Arc::new(Mutex::new(Vec::new())),
         }
     }
-}
 
-#[async_trait::async_trait(?Send)]
-impl Agent for MockAgent {
-    async fn initialize(
-        &self,
-        req: InitializeRequest,
-    ) -> agent_client_protocol::Result<InitializeResponse> {
+    /// Build the `InitializeResponse` for this profile. Mirrors the production
+    /// agent's capability advertisement (read by `acp.rs`).
+    fn initialize_response(&self, protocol_version: ProtocolVersion) -> InitializeResponse {
         let supports_images = matches!(self.profile, CapabilityProfile::Full);
         let prompt_caps = PromptCapabilities::new().image(supports_images);
 
@@ -91,195 +99,264 @@ impl Agent for MockAgent {
             .prompt_capabilities(prompt_caps)
             .session_capabilities(session_caps);
 
-        Ok(InitializeResponse::new(req.protocol_version)
+        InitializeResponse::new(protocol_version)
             .agent_capabilities(caps)
-            .agent_info(Implementation::new("mock-agent", "0.0.0")))
-    }
-
-    async fn authenticate(
-        &self,
-        _req: AuthenticateRequest,
-    ) -> agent_client_protocol::Result<AuthenticateResponse> {
-        Ok(AuthenticateResponse::new())
-    }
-
-    async fn new_session(
-        &self,
-        _req: NewSessionRequest,
-    ) -> agent_client_protocol::Result<NewSessionResponse> {
-        let id = SessionId::new("mock-session-1");
-        self.sessions.lock().unwrap().push(id.clone());
-        Ok(NewSessionResponse::new(id))
-    }
-
-    async fn load_session(
-        &self,
-        _req: LoadSessionRequest,
-    ) -> agent_client_protocol::Result<LoadSessionResponse> {
-        Ok(LoadSessionResponse::new())
-    }
-
-    async fn list_sessions(
-        &self,
-        _req: ListSessionsRequest,
-    ) -> agent_client_protocol::Result<ListSessionsResponse> {
-        let sessions: Vec<SessionInfo> = self
-            .sessions
-            .lock()
-            .unwrap()
-            .iter()
-            .map(|id| SessionInfo::new(id.clone(), "/tmp"))
-            .collect();
-        Ok(ListSessionsResponse::new(sessions))
-    }
-
-    async fn set_session_mode(
-        &self,
-        _req: SetSessionModeRequest,
-    ) -> agent_client_protocol::Result<SetSessionModeResponse> {
-        Ok(SetSessionModeResponse::new())
-    }
-
-    async fn set_session_config_option(
-        &self,
-        _req: SetSessionConfigOptionRequest,
-    ) -> agent_client_protocol::Result<SetSessionConfigOptionResponse> {
-        Ok(SetSessionConfigOptionResponse::new(vec![]))
-    }
-
-    async fn prompt(
-        &self,
-        req: PromptRequest,
-    ) -> agent_client_protocol::Result<PromptResponse> {
-        self.prompts
-            .lock()
-            .unwrap()
-            .push((req.session_id, req.prompt));
-        Ok(PromptResponse::new(StopReason::EndTurn))
-    }
-
-    async fn cancel(
-        &self,
-        _req: CancelNotification,
-    ) -> agent_client_protocol::Result<()> {
-        Ok(())
-    }
-
-    // All unstable_* features are enabled in Cargo.toml — no cfg guards needed.
-
-    async fn fork_session(
-        &self,
-        req: ForkSessionRequest,
-    ) -> agent_client_protocol::Result<ForkSessionResponse> {
-        let new_id = SessionId::new(format!("fork-of-{}", req.session_id.0.as_ref()));
-        self.sessions.lock().unwrap().push(new_id.clone());
-        Ok(ForkSessionResponse::new(new_id))
-    }
-
-    async fn resume_session(
-        &self,
-        req: ResumeSessionRequest,
-    ) -> agent_client_protocol::Result<ResumeSessionResponse> {
-        if !self.sessions.lock().unwrap().contains(&req.session_id) {
-            return Err(agent_client_protocol::Error::invalid_params());
-        }
-        Ok(ResumeSessionResponse::new())
-    }
-
-    async fn close_session(
-        &self,
-        req: CloseSessionRequest,
-    ) -> agent_client_protocol::Result<CloseSessionResponse> {
-        self.sessions
-            .lock()
-            .unwrap()
-            .retain(|id| id != &req.session_id);
-        Ok(CloseSessionResponse::new())
+            .agent_info(Implementation::new("mock-agent", "0.0.0"))
     }
 }
 
-// ---------------------------------------------------------------------------
-// NoopClient — minimal Client impl for the agent side
-// ---------------------------------------------------------------------------
+/// Build a mock-agent connection builder with handlers registered for every
+/// request type the client may send (plus the cancel notification), then run
+/// `driver` as the agent's `main_fn`.
+///
+/// `driver` receives the agent-side [`ConnectionTo<Client>`], which it can use
+/// to push `session/update` notifications. Here the driver simply awaits the
+/// `done` signal so the connection stays alive for the client's whole run.
+async fn run_mock_agent(
+    state: MockAgentState,
+    transport: Channel,
+    done_rx: tokio::sync::oneshot::Receiver<()>,
+) -> Result<(), agent_client_protocol::Error> {
+    // Each handler clones the bits of state it needs.
+    let init_state = state.clone();
+    let new_state = state.clone();
+    let list_state = state.clone();
+    let fork_state = state.clone();
+    let resume_state = state.clone();
+    let close_state = state.clone();
 
-#[derive(Clone)]
-struct NoopClient {
-    notifications: Arc<Mutex<Vec<SessionNotification>>>,
+    Agent
+        .builder()
+        .name("mock-agent")
+        // session/initialize
+        .on_receive_request(
+            move |req: InitializeRequest,
+                  responder: Responder<InitializeResponse>,
+                  _cx: ConnectionTo<Client>| {
+                let state = init_state.clone();
+                async move { responder.respond(state.initialize_response(req.protocol_version)) }
+            },
+            agent_client_protocol::on_receive_request!(),
+        )
+        // session/authenticate
+        .on_receive_request(
+            move |_req: AuthenticateRequest,
+                  responder: Responder<AuthenticateResponse>,
+                  _cx: ConnectionTo<Client>| async move {
+                responder.respond(AuthenticateResponse::new())
+            },
+            agent_client_protocol::on_receive_request!(),
+        )
+        // session/new
+        .on_receive_request(
+            move |_req: NewSessionRequest,
+                  responder: Responder<NewSessionResponse>,
+                  _cx: ConnectionTo<Client>| {
+                let state = new_state.clone();
+                async move {
+                    let id = SessionId::new("mock-session-1");
+                    state.sessions.lock().unwrap().push(id.clone());
+                    responder.respond(NewSessionResponse::new(id))
+                }
+            },
+            agent_client_protocol::on_receive_request!(),
+        )
+        // session/load
+        .on_receive_request(
+            move |_req: LoadSessionRequest,
+                  responder: Responder<LoadSessionResponse>,
+                  _cx: ConnectionTo<Client>| async move {
+                responder.respond(LoadSessionResponse::new())
+            },
+            agent_client_protocol::on_receive_request!(),
+        )
+        // session/list
+        .on_receive_request(
+            move |_req: ListSessionsRequest,
+                  responder: Responder<ListSessionsResponse>,
+                  _cx: ConnectionTo<Client>| {
+                let state = list_state.clone();
+                async move {
+                    let sessions: Vec<SessionInfo> = state
+                        .sessions
+                        .lock()
+                        .unwrap()
+                        .iter()
+                        .map(|id| SessionInfo::new(id.clone(), "/tmp"))
+                        .collect();
+                    responder.respond(ListSessionsResponse::new(sessions))
+                }
+            },
+            agent_client_protocol::on_receive_request!(),
+        )
+        // session/set_mode
+        .on_receive_request(
+            move |_req: SetSessionModeRequest,
+                  responder: Responder<SetSessionModeResponse>,
+                  _cx: ConnectionTo<Client>| async move {
+                responder.respond(SetSessionModeResponse::new())
+            },
+            agent_client_protocol::on_receive_request!(),
+        )
+        // session/set_config_option
+        .on_receive_request(
+            move |_req: SetSessionConfigOptionRequest,
+                  responder: Responder<SetSessionConfigOptionResponse>,
+                  _cx: ConnectionTo<Client>| async move {
+                responder.respond(SetSessionConfigOptionResponse::new(vec![]))
+            },
+            agent_client_protocol::on_receive_request!(),
+        )
+        // session/prompt
+        .on_receive_request(
+            move |_req: PromptRequest,
+                  responder: Responder<PromptResponse>,
+                  _cx: ConnectionTo<Client>| async move {
+                responder.respond(PromptResponse::new(StopReason::EndTurn))
+            },
+            agent_client_protocol::on_receive_request!(),
+        )
+        // session/fork
+        .on_receive_request(
+            move |req: ForkSessionRequest,
+                  responder: Responder<ForkSessionResponse>,
+                  _cx: ConnectionTo<Client>| {
+                let state = fork_state.clone();
+                async move {
+                    let new_id =
+                        SessionId::new(format!("fork-of-{}", req.session_id.0.as_ref()));
+                    state.sessions.lock().unwrap().push(new_id.clone());
+                    responder.respond(ForkSessionResponse::new(new_id))
+                }
+            },
+            agent_client_protocol::on_receive_request!(),
+        )
+        // session/resume
+        .on_receive_request(
+            move |req: ResumeSessionRequest,
+                  responder: Responder<ResumeSessionResponse>,
+                  _cx: ConnectionTo<Client>| {
+                let state = resume_state.clone();
+                async move {
+                    let known = state.sessions.lock().unwrap().contains(&req.session_id);
+                    if known {
+                        responder.respond(ResumeSessionResponse::new())
+                    } else {
+                        responder
+                            .respond_with_error(agent_client_protocol::Error::invalid_params())
+                    }
+                }
+            },
+            agent_client_protocol::on_receive_request!(),
+        )
+        // session/close
+        .on_receive_request(
+            move |req: CloseSessionRequest,
+                  responder: Responder<CloseSessionResponse>,
+                  _cx: ConnectionTo<Client>| {
+                let state = close_state.clone();
+                async move {
+                    state
+                        .sessions
+                        .lock()
+                        .unwrap()
+                        .retain(|id| id != &req.session_id);
+                    responder.respond(CloseSessionResponse::new())
+                }
+            },
+            agent_client_protocol::on_receive_request!(),
+        )
+        // session/cancel (notification — fire-and-forget)
+        .on_receive_notification(
+            move |_n: CancelNotification, _cx: ConnectionTo<Client>| async move { Ok(()) },
+            agent_client_protocol::on_receive_notification!(),
+        )
+        .connect_with(transport, async move |_conn: ConnectionTo<Client>| {
+            // Keep the agent connection alive until the client is done.
+            let _ = done_rx.await;
+            Ok(())
+        })
+        .await
 }
 
-impl NoopClient {
-    fn new() -> Self {
-        Self {
-            notifications: Arc::new(Mutex::new(Vec::new())),
-        }
-    }
-}
-
-#[async_trait::async_trait(?Send)]
-impl Client for NoopClient {
-    async fn request_permission(
-        &self,
-        _req: RequestPermissionRequest,
-    ) -> agent_client_protocol::Result<RequestPermissionResponse> {
-        Ok(RequestPermissionResponse::new(
-            RequestPermissionOutcome::Cancelled,
-        ))
-    }
-
-    async fn session_notification(
-        &self,
-        args: SessionNotification,
-    ) -> agent_client_protocol::Result<()> {
-        self.notifications.lock().unwrap().push(args);
-        Ok(())
-    }
-}
-
 // ---------------------------------------------------------------------------
-// In-memory connection factory
+// NoopClient handlers — minimal Client-side responders
 // ---------------------------------------------------------------------------
 
-/// Creates a paired `ClientSideConnection` (client view) and a future that
-/// drives both IO loops.  Call this inside a `tokio::task::LocalSet`.
-fn make_connection(
-    agent: MockAgent,
-) -> (ClientSideConnection, impl std::future::Future<Output = ()>) {
-    use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
+/// Captured session notifications, for tests that want to inspect them.
+type Notifications = Arc<Mutex<Vec<SessionNotification>>>;
 
-    // Two duplex channels cross-wired:
-    //   client_conn reads from agent_writer, writes to agent_reader
-    //   agent_conn  reads from client_writer, writes to client_reader
-    let (client_reader, agent_writer) = tokio::io::duplex(65536);
-    let (agent_reader, client_writer) = tokio::io::duplex(65536);
+/// Run the mock client: register the permission + session-notification handlers,
+/// then execute `scenario` (the per-test round-trips/assertions) as the client's
+/// `main_fn`. Signals `done` when `scenario` returns so the agent shuts down.
+async fn run_client<F>(
+    transport: Channel,
+    notifications: Notifications,
+    done_tx: tokio::sync::oneshot::Sender<()>,
+    scenario: F,
+) -> Result<(), agent_client_protocol::Error>
+where
+    F: AsyncFnOnce(ConnectionTo<Agent>) -> Result<(), agent_client_protocol::Error>,
+{
+    let notif_for_handler = notifications.clone();
+    let done_cell = Arc::new(Mutex::new(Some(done_tx)));
 
-    let noop_client = NoopClient::new();
+    Client
+        .builder()
+        .name("mock-client")
+        // session/request_permission — mirrors NoopClient (always cancel)
+        .on_receive_request(
+            move |_req: RequestPermissionRequest,
+                  responder: Responder<RequestPermissionResponse>,
+                  _cx: ConnectionTo<Agent>| async move {
+                responder.respond(RequestPermissionResponse::new(
+                    RequestPermissionOutcome::Cancelled,
+                ))
+            },
+            agent_client_protocol::on_receive_request!(),
+        )
+        // session/update — record notifications
+        .on_receive_notification(
+            move |n: SessionNotification, _cx: ConnectionTo<Agent>| {
+                let notifs = notif_for_handler.clone();
+                async move {
+                    notifs.lock().unwrap().push(n);
+                    Ok(())
+                }
+            },
+            agent_client_protocol::on_receive_notification!(),
+        )
+        .connect_with(transport, async move |conn: ConnectionTo<Agent>| {
+            let result = scenario(conn).await;
+            // Tell the agent it can shut down now that the scenario is done.
+            if let Some(tx) = done_cell.lock().unwrap().take() {
+                let _ = tx.send(());
+            }
+            result
+        })
+        .await
+}
 
-    let (client_conn, client_io) = ClientSideConnection::new(
-        noop_client,
-        agent_writer.compat_write(),
-        agent_reader.compat(),
-        |fut| {
-            tokio::task::spawn_local(fut);
-        },
-    );
+/// Spin up a paired mock agent + mock client over an in-memory `Channel::duplex`
+/// transport, run `scenario` against the live `ConnectionTo<Agent>`, and join
+/// both ends. Panics with the scenario's error if it failed.
+async fn with_agent_and_client<F>(profile: CapabilityProfile, scenario: F)
+where
+    F: AsyncFnOnce(ConnectionTo<Agent>) -> Result<(), agent_client_protocol::Error>,
+{
+    let state = MockAgentState::new(profile);
+    let notifications: Notifications = Arc::new(Mutex::new(Vec::new()));
 
-    let (_agent_conn, agent_io) = AgentSideConnection::new(
-        agent,
-        client_writer.compat_write(),
-        client_reader.compat(),
-        |fut| {
-            tokio::task::spawn_local(fut);
-        },
-    );
+    // Paired in-memory endpoints: messages sent on one arrive on the other.
+    let (agent_channel, client_channel) = Channel::duplex();
+    let (done_tx, done_rx) = tokio::sync::oneshot::channel();
 
-    let combined = async move {
-        tokio::join!(
-            async { client_io.await.ok(); },
-            async { agent_io.await.ok(); },
-        );
-    };
+    let agent_fut = run_mock_agent(state, agent_channel, done_rx);
+    let client_fut = run_client(client_channel, notifications, done_tx, scenario);
 
-    (client_conn, combined)
+    let (agent_res, client_res) = tokio::join!(agent_fut, client_fut);
+    agent_res.expect("mock agent connection failed");
+    client_res.expect("mock client scenario failed");
 }
 
 // ---------------------------------------------------------------------------
@@ -290,121 +367,101 @@ fn make_connection(
 /// Verifies the happy-path sequence with strongly-typed ACP crate values.
 #[tokio::test]
 async fn full_lifecycle_initialize_new_prompt_close() {
-    let local = tokio::task::LocalSet::new();
-    local
-        .run_until(async {
-            let agent = MockAgent::new(CapabilityProfile::Full);
-            let (conn, io) = make_connection(agent);
-            tokio::task::spawn_local(io);
+    with_agent_and_client(CapabilityProfile::Full, async |conn: ConnectionTo<Agent>| {
+        // initialize
+        let init_resp = conn
+            .send_request(
+                InitializeRequest::new(ProtocolVersion::V1)
+                    .client_info(Implementation::new("notesage-test", "0.0.0")),
+            )
+            .block_task()
+            .await?;
+        assert_eq!(init_resp.protocol_version, ProtocolVersion::V1);
 
-            // initialize
-            let init_resp = conn
-                .initialize(
-                    InitializeRequest::new(ProtocolVersion::V1)
-                        .client_info(Implementation::new("notesage-test", "0.0.0")),
-                )
-                .await
-                .expect("initialize failed");
-            assert_eq!(init_resp.protocol_version, ProtocolVersion::V1);
+        // session/new
+        let new_resp = conn
+            .send_request(NewSessionRequest::new("/tmp"))
+            .block_task()
+            .await?;
+        assert_eq!(new_resp.session_id, SessionId::new("mock-session-1"));
 
-            // session/new
-            let new_resp = conn
-                .new_session(NewSessionRequest::new("/tmp"))
-                .await
-                .expect("new_session failed");
-            assert_eq!(new_resp.session_id, SessionId::new("mock-session-1"));
+        // session/prompt
+        let prompt_resp = conn
+            .send_request(PromptRequest::new(new_resp.session_id.clone(), vec![]))
+            .block_task()
+            .await?;
+        assert_eq!(prompt_resp.stop_reason, StopReason::EndTurn);
 
-            // session/prompt
-            let prompt_resp = conn
-                .prompt(PromptRequest::new(new_resp.session_id.clone(), vec![]))
-                .await
-                .expect("prompt failed");
-            assert_eq!(prompt_resp.stop_reason, StopReason::EndTurn);
-
-            // session/close
-            let _close_resp = conn
-                .close_session(CloseSessionRequest::new(new_resp.session_id))
-                .await
-                .expect("close_session failed");
-        })
-        .await;
+        // session/close
+        let _close_resp = conn
+            .send_request(CloseSessionRequest::new(new_resp.session_id))
+            .block_task()
+            .await?;
+        Ok(())
+    })
+    .await;
 }
 
 /// Full capability profile: initialize response advertises image support
 /// and all session capabilities (fork, resume, close).
 #[tokio::test]
 async fn full_profile_advertises_all_capabilities() {
-    let local = tokio::task::LocalSet::new();
-    local
-        .run_until(async {
-            let agent = MockAgent::new(CapabilityProfile::Full);
-            let (conn, io) = make_connection(agent);
-            tokio::task::spawn_local(io);
+    with_agent_and_client(CapabilityProfile::Full, async |conn: ConnectionTo<Agent>| {
+        let init_resp = conn
+            .send_request(InitializeRequest::new(ProtocolVersion::V1))
+            .block_task()
+            .await?;
 
-            let init_resp = conn
-                .initialize(InitializeRequest::new(ProtocolVersion::V1))
-                .await
-                .expect("initialize failed");
-
-            // Mirrors `acp.rs`: `resp.agent_capabilities.prompt_capabilities.image`
-            assert!(
-                init_resp.agent_capabilities.prompt_capabilities.image,
-                "Full profile must advertise image support (mirrors acp.rs)"
-            );
-
-            assert!(
-                init_resp
-                    .agent_capabilities
-                    .session_capabilities
-                    .fork
-                    .is_some(),
-                "Full profile must advertise fork capability"
-            );
-
-            assert!(
-                init_resp
-                    .agent_capabilities
-                    .session_capabilities
-                    .resume
-                    .is_some(),
-                "Full profile must advertise resume capability"
-            );
-
-            assert!(
-                init_resp
-                    .agent_capabilities
-                    .session_capabilities
-                    .close
-                    .is_some(),
-                "Full profile must advertise close capability"
-            );
-        })
-        .await;
+        // Mirrors `acp.rs`: `resp.agent_capabilities.prompt_capabilities.image`
+        assert!(
+            init_resp.agent_capabilities.prompt_capabilities.image,
+            "Full profile must advertise image support (mirrors acp.rs)"
+        );
+        assert!(
+            init_resp
+                .agent_capabilities
+                .session_capabilities
+                .fork
+                .is_some(),
+            "Full profile must advertise fork capability"
+        );
+        assert!(
+            init_resp
+                .agent_capabilities
+                .session_capabilities
+                .resume
+                .is_some(),
+            "Full profile must advertise resume capability"
+        );
+        assert!(
+            init_resp
+                .agent_capabilities
+                .session_capabilities
+                .close
+                .is_some(),
+            "Full profile must advertise close capability"
+        );
+        Ok(())
+    })
+    .await;
 }
 
 /// Minimal capability profile: initialize response does NOT advertise image
 /// support or session fork/resume/close.
 #[tokio::test]
 async fn minimal_profile_advertises_no_optional_capabilities() {
-    let local = tokio::task::LocalSet::new();
-    local
-        .run_until(async {
-            let agent = MockAgent::new(CapabilityProfile::Minimal);
-            let (conn, io) = make_connection(agent);
-            tokio::task::spawn_local(io);
-
+    with_agent_and_client(
+        CapabilityProfile::Minimal,
+        async |conn: ConnectionTo<Agent>| {
             let init_resp = conn
-                .initialize(InitializeRequest::new(ProtocolVersion::V1))
-                .await
-                .expect("initialize failed");
+                .send_request(InitializeRequest::new(ProtocolVersion::V1))
+                .block_task()
+                .await?;
 
-            // No images
             assert!(
                 !init_resp.agent_capabilities.prompt_capabilities.image,
                 "Minimal profile must NOT advertise image support"
             );
-
-            // No fork/resume/close
             assert!(
                 init_resp
                     .agent_capabilities
@@ -413,7 +470,6 @@ async fn minimal_profile_advertises_no_optional_capabilities() {
                     .is_none(),
                 "Minimal profile must NOT advertise fork"
             );
-
             assert!(
                 init_resp
                     .agent_capabilities
@@ -422,7 +478,6 @@ async fn minimal_profile_advertises_no_optional_capabilities() {
                     .is_none(),
                 "Minimal profile must NOT advertise resume"
             );
-
             assert!(
                 init_resp
                     .agent_capabilities
@@ -431,146 +486,122 @@ async fn minimal_profile_advertises_no_optional_capabilities() {
                     .is_none(),
                 "Minimal profile must NOT advertise close"
             );
-        })
-        .await;
+            Ok(())
+        },
+    )
+    .await;
 }
 
 /// Session listing via `session/list` returns the newly created session.
 #[tokio::test]
 async fn list_sessions_returns_created_session() {
-    let local = tokio::task::LocalSet::new();
-    local
-        .run_until(async {
-            let agent = MockAgent::new(CapabilityProfile::Minimal);
-            let (conn, io) = make_connection(agent);
-            tokio::task::spawn_local(io);
+    with_agent_and_client(
+        CapabilityProfile::Minimal,
+        async |conn: ConnectionTo<Agent>| {
+            conn.send_request(InitializeRequest::new(ProtocolVersion::V1))
+                .block_task()
+                .await?;
 
-            conn.initialize(InitializeRequest::new(ProtocolVersion::V1))
-                .await
-                .expect("initialize failed");
-
-            conn.new_session(NewSessionRequest::new("/tmp"))
-                .await
-                .expect("new_session failed");
+            conn.send_request(NewSessionRequest::new("/tmp"))
+                .block_task()
+                .await?;
 
             let list_resp = conn
-                .list_sessions(ListSessionsRequest::new())
-                .await
-                .expect("list_sessions failed");
+                .send_request(ListSessionsRequest::new())
+                .block_task()
+                .await?;
 
             assert_eq!(list_resp.sessions.len(), 1);
             assert_eq!(
                 list_resp.sessions[0].session_id,
                 SessionId::new("mock-session-1")
             );
-        })
-        .await;
+            Ok(())
+        },
+    )
+    .await;
 }
 
 /// Fork session (full profile) creates a new session ID derived from the
 /// original session's ID — verifying the fork code path.
 #[tokio::test]
 async fn fork_session_full_profile() {
-    let local = tokio::task::LocalSet::new();
-    local
-        .run_until(async {
-            let agent = MockAgent::new(CapabilityProfile::Full);
-            let (conn, io) = make_connection(agent);
-            tokio::task::spawn_local(io);
+    with_agent_and_client(CapabilityProfile::Full, async |conn: ConnectionTo<Agent>| {
+        conn.send_request(InitializeRequest::new(ProtocolVersion::V1))
+            .block_task()
+            .await?;
 
-            conn.initialize(InitializeRequest::new(ProtocolVersion::V1))
-                .await
-                .expect("initialize failed");
+        let new_resp = conn
+            .send_request(NewSessionRequest::new("/tmp"))
+            .block_task()
+            .await?;
 
-            let new_resp = conn
-                .new_session(NewSessionRequest::new("/tmp"))
-                .await
-                .expect("new_session failed");
+        let fork_resp = conn
+            .send_request(ForkSessionRequest::new(new_resp.session_id.clone(), "/tmp"))
+            .block_task()
+            .await?;
 
-            let fork_resp = conn
-                .fork_session(ForkSessionRequest::new(new_resp.session_id.clone(), "/tmp"))
-                .await
-                .expect("fork_session failed");
-
-            // Fork ID must differ from original
-            assert_ne!(fork_resp.session_id, new_resp.session_id);
-        })
-        .await;
+        // Fork ID must differ from original
+        assert_ne!(fork_resp.session_id, new_resp.session_id);
+        Ok(())
+    })
+    .await;
 }
 
 /// Resume session (full profile) succeeds for an existing session.
 #[tokio::test]
 async fn resume_session_full_profile_existing_session() {
-    let local = tokio::task::LocalSet::new();
-    local
-        .run_until(async {
-            let agent = MockAgent::new(CapabilityProfile::Full);
-            let (conn, io) = make_connection(agent);
-            tokio::task::spawn_local(io);
+    with_agent_and_client(CapabilityProfile::Full, async |conn: ConnectionTo<Agent>| {
+        conn.send_request(InitializeRequest::new(ProtocolVersion::V1))
+            .block_task()
+            .await?;
 
-            conn.initialize(InitializeRequest::new(ProtocolVersion::V1))
-                .await
-                .expect("initialize failed");
+        let new_resp = conn
+            .send_request(NewSessionRequest::new("/tmp"))
+            .block_task()
+            .await?;
 
-            let new_resp = conn
-                .new_session(NewSessionRequest::new("/tmp"))
-                .await
-                .expect("new_session failed");
-
-            // Resume the same session — should succeed
-            conn.resume_session(ResumeSessionRequest::new(new_resp.session_id, "/tmp"))
-                .await
-                .expect("resume_session failed");
-        })
-        .await;
+        // Resume the same session — should succeed
+        conn.send_request(ResumeSessionRequest::new(new_resp.session_id, "/tmp"))
+            .block_task()
+            .await?;
+        Ok(())
+    })
+    .await;
 }
 
-/// `supports_images` extracted from `initialize` response matches the Full
-/// profile.  This is the exact field read by `acp.rs`:
+/// `supports_images` extracted from `initialize` response matches the profile.
+/// This is the exact field read by `acp.rs`:
 /// `resp.agent_capabilities.prompt_capabilities.image`.
 #[tokio::test]
 async fn supports_images_extracted_from_initialize_response() {
     // --- Full profile: supports_images = true ---
-    {
-        let local = tokio::task::LocalSet::new();
-        local
-            .run_until(async {
-                let agent = MockAgent::new(CapabilityProfile::Full);
-                let (conn, io) = make_connection(agent);
-                tokio::task::spawn_local(io);
-
-                let resp = conn
-                    .initialize(InitializeRequest::new(ProtocolVersion::V1))
-                    .await
-                    .expect("initialize failed");
-
-                // This is the exact field read by production acp.rs
-                let supports_images: bool = resp.agent_capabilities.prompt_capabilities.image;
-                assert!(supports_images, "Full profile: supports_images must be true");
-            })
-            .await;
-    }
+    with_agent_and_client(CapabilityProfile::Full, async |conn: ConnectionTo<Agent>| {
+        let resp = conn
+            .send_request(InitializeRequest::new(ProtocolVersion::V1))
+            .block_task()
+            .await?;
+        let supports_images: bool = resp.agent_capabilities.prompt_capabilities.image;
+        assert!(supports_images, "Full profile: supports_images must be true");
+        Ok(())
+    })
+    .await;
 
     // --- Minimal profile: supports_images = false ---
-    {
-        let local = tokio::task::LocalSet::new();
-        local
-            .run_until(async {
-                let agent = MockAgent::new(CapabilityProfile::Minimal);
-                let (conn, io) = make_connection(agent);
-                tokio::task::spawn_local(io);
-
-                let resp = conn
-                    .initialize(InitializeRequest::new(ProtocolVersion::V1))
-                    .await
-                    .expect("initialize failed");
-
-                let supports_images: bool = resp.agent_capabilities.prompt_capabilities.image;
-                assert!(
-                    !supports_images,
-                    "Minimal profile: supports_images must be false"
-                );
-            })
-            .await;
-    }
+    with_agent_and_client(
+        CapabilityProfile::Minimal,
+        async |conn: ConnectionTo<Agent>| {
+            let resp = conn
+                .send_request(InitializeRequest::new(ProtocolVersion::V1))
+                .block_task()
+                .await?;
+            let supports_images: bool = resp.agent_capabilities.prompt_capabilities.image;
+            assert!(
+                !supports_images,
+                "Minimal profile: supports_images must be false"
+            );
+            Ok(())
+        },
+    )
+    .await;
 }

--- a/src-tauri/tests/mock_acp_agent.rs
+++ b/src-tauri/tests/mock_acp_agent.rs
@@ -41,12 +41,14 @@ use agent_client_protocol::schema::{
     CloseSessionRequest, CloseSessionResponse, ForkSessionRequest, ForkSessionResponse,
     Implementation, InitializeRequest, InitializeResponse, ListSessionsRequest,
     ListSessionsResponse, LoadSessionRequest, LoadSessionResponse, NewSessionRequest,
-    NewSessionResponse, PromptCapabilities, PromptRequest, PromptResponse, ProtocolVersion,
-    RequestPermissionOutcome, RequestPermissionRequest, RequestPermissionResponse,
-    ResumeSessionRequest, ResumeSessionResponse, SessionCapabilities, SessionCloseCapabilities,
-    SessionForkCapabilities, SessionId, SessionInfo, SessionNotification, SessionResumeCapabilities,
-    SetSessionConfigOptionRequest, SetSessionConfigOptionResponse, SetSessionModeRequest,
-    SetSessionModeResponse, StopReason,
+    NewSessionResponse, PermissionOption, PermissionOptionId, PermissionOptionKind,
+    PromptCapabilities, PromptRequest, PromptResponse, ProtocolVersion, RequestPermissionOutcome,
+    RequestPermissionRequest, RequestPermissionResponse, ResumeSessionRequest,
+    ResumeSessionResponse, SelectedPermissionOutcome, SessionCapabilities,
+    SessionCloseCapabilities, SessionForkCapabilities, SessionId, SessionInfo, SessionNotification,
+    SessionResumeCapabilities, SetSessionConfigOptionRequest, SetSessionConfigOptionResponse,
+    SetSessionModeRequest, SetSessionModeResponse, SetSessionModelRequest, SetSessionModelResponse,
+    StopReason, ToolCallUpdate, ToolCallUpdateFields,
 };
 use agent_client_protocol::{Channel, ConnectionTo, Responder};
 
@@ -71,6 +73,15 @@ enum CapabilityProfile {
 struct MockAgentState {
     profile: CapabilityProfile,
     sessions: Arc<Mutex<Vec<SessionId>>>,
+    /// When `true`, the `session/prompt` handler first sends an agent-initiated
+    /// `session/request_permission` request to the client and records the
+    /// returned outcome in `permission_outcome`. Default `false` so existing
+    /// prompt-driven tests are unaffected.
+    request_permission_on_prompt: bool,
+    /// Captures the `RequestPermissionOutcome` the client returned to the
+    /// agent's `session/request_permission` request (set by the prompt handler
+    /// when `request_permission_on_prompt` is enabled).
+    permission_outcome: Arc<Mutex<Option<RequestPermissionOutcome>>>,
 }
 
 impl MockAgentState {
@@ -78,6 +89,8 @@ impl MockAgentState {
         Self {
             profile,
             sessions: Arc::new(Mutex::new(Vec::new())),
+            request_permission_on_prompt: false,
+            permission_outcome: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -124,6 +137,7 @@ async fn run_mock_agent(
     let fork_state = state.clone();
     let resume_state = state.clone();
     let close_state = state.clone();
+    let prompt_state = state.clone();
 
     Agent
         .builder()
@@ -207,12 +221,68 @@ async fn run_mock_agent(
             },
             agent_client_protocol::on_receive_request!(),
         )
+        // session/set_model
+        .on_receive_request(
+            move |_req: SetSessionModelRequest,
+                  responder: Responder<SetSessionModelResponse>,
+                  _cx: ConnectionTo<Client>| async move {
+                responder.respond(SetSessionModelResponse::new())
+            },
+            agent_client_protocol::on_receive_request!(),
+        )
         // session/prompt
         .on_receive_request(
-            move |_req: PromptRequest,
+            move |req: PromptRequest,
                   responder: Responder<PromptResponse>,
-                  _cx: ConnectionTo<Client>| async move {
-                responder.respond(PromptResponse::new(StopReason::EndTurn))
+                  cx: ConnectionTo<Client>| {
+                let state = prompt_state.clone();
+                async move {
+                    if !state.request_permission_on_prompt {
+                        return responder.respond(PromptResponse::new(StopReason::EndTurn));
+                    }
+
+                    // Exercise the agent-initiated permission round-trip: send a
+                    // `session/request_permission` request *to the client* and
+                    // record the outcome it returns. This is the inbound-request
+                    // path the production client handles via a waiter + Tauri
+                    // event + async `responder.respond`.
+                    //
+                    // The nested request MUST run on a spawned task, not inline
+                    // in the handler: the event loop cannot process the client's
+                    // response while a handler is awaiting, so blocking here would
+                    // deadlock. `cx.spawn` mirrors production's `cx.spawn` +
+                    // async `responder.respond`. The prompt response is only sent
+                    // once the outcome is captured, so the client's `prompt`
+                    // await resolves *after* `permission_outcome` is populated —
+                    // fully deterministic, no sleeps.
+                    let session_id = req.session_id.clone();
+                    cx.spawn({
+                        let cx = cx.clone();
+                        let state = state.clone();
+                        async move {
+                            let perm_req = RequestPermissionRequest::new(
+                                session_id,
+                                ToolCallUpdate::new("tool-call-1", ToolCallUpdateFields::new()),
+                                vec![
+                                    PermissionOption::new(
+                                        "allow-once",
+                                        "Allow once",
+                                        PermissionOptionKind::AllowOnce,
+                                    ),
+                                    PermissionOption::new(
+                                        "reject-once",
+                                        "Reject once",
+                                        PermissionOptionKind::RejectOnce,
+                                    ),
+                                ],
+                            );
+                            let perm_resp = cx.send_request(perm_req).block_task().await?;
+                            *state.permission_outcome.lock().unwrap() = Some(perm_resp.outcome);
+                            responder.respond(PromptResponse::new(StopReason::EndTurn))
+                        }
+                    })?;
+                    Ok(())
+                }
             },
             agent_client_protocol::on_receive_request!(),
         )
@@ -304,14 +374,22 @@ where
     Client
         .builder()
         .name("mock-client")
-        // session/request_permission — mirrors NoopClient (always cancel)
+        // session/request_permission — the production client registers a waiter,
+        // emits a Tauri event, and responds asynchronously. Here the mock client
+        // selects the first offered option, exercising the inbound-request →
+        // response round-trip end-to-end.
         .on_receive_request(
-            move |_req: RequestPermissionRequest,
+            move |req: RequestPermissionRequest,
                   responder: Responder<RequestPermissionResponse>,
                   _cx: ConnectionTo<Agent>| async move {
-                responder.respond(RequestPermissionResponse::new(
-                    RequestPermissionOutcome::Cancelled,
-                ))
+                // Pick the first offered option if any; otherwise cancel.
+                let outcome = match req.options.first() {
+                    Some(opt) => RequestPermissionOutcome::Selected(
+                        SelectedPermissionOutcome::new(opt.option_id.clone()),
+                    ),
+                    None => RequestPermissionOutcome::Cancelled,
+                };
+                responder.respond(RequestPermissionResponse::new(outcome))
             },
             agent_client_protocol::on_receive_request!(),
         )
@@ -357,6 +435,37 @@ where
     let (agent_res, client_res) = tokio::join!(agent_fut, client_fut);
     agent_res.expect("mock agent connection failed");
     client_res.expect("mock client scenario failed");
+}
+
+/// Like [`with_agent_and_client`] but enables the agent's
+/// `request_permission_on_prompt` behaviour and returns the
+/// `RequestPermissionOutcome` the client returned to the agent's
+/// agent-initiated `session/request_permission` request.
+async fn with_agent_and_client_capturing_permission<F>(
+    profile: CapabilityProfile,
+    scenario: F,
+) -> Option<RequestPermissionOutcome>
+where
+    F: AsyncFnOnce(ConnectionTo<Agent>) -> Result<(), agent_client_protocol::Error>,
+{
+    let mut state = MockAgentState::new(profile);
+    state.request_permission_on_prompt = true;
+    let outcome_cell = state.permission_outcome.clone();
+
+    let notifications: Notifications = Arc::new(Mutex::new(Vec::new()));
+
+    let (agent_channel, client_channel) = Channel::duplex();
+    let (done_tx, done_rx) = tokio::sync::oneshot::channel();
+
+    let agent_fut = run_mock_agent(state, agent_channel, done_rx);
+    let client_fut = run_client(client_channel, notifications, done_tx, scenario);
+
+    let (agent_res, client_res) = tokio::join!(agent_fut, client_fut);
+    agent_res.expect("mock agent connection failed");
+    client_res.expect("mock client scenario failed");
+
+    let outcome = outcome_cell.lock().unwrap().clone();
+    outcome
 }
 
 // ---------------------------------------------------------------------------
@@ -604,4 +713,83 @@ async fn supports_images_extracted_from_initialize_response() {
         },
     )
     .await;
+}
+
+/// `session/set_model` round-trips through the new handler (#5). Covers the
+/// full client→agent operation set previously missing a handler.
+#[tokio::test]
+async fn set_session_model_round_trips() {
+    with_agent_and_client(CapabilityProfile::Full, async |conn: ConnectionTo<Agent>| {
+        conn.send_request(InitializeRequest::new(ProtocolVersion::V1))
+            .block_task()
+            .await?;
+
+        let new_resp = conn
+            .send_request(NewSessionRequest::new("/tmp"))
+            .block_task()
+            .await?;
+
+        // set_model: returns a SetSessionModelResponse without error.
+        let _resp = conn
+            .send_request(SetSessionModelRequest::new(
+                new_resp.session_id,
+                "mock-model-1",
+            ))
+            .block_task()
+            .await?;
+        Ok(())
+    })
+    .await;
+}
+
+/// Agent-initiated permission round-trip (#4): during `session/prompt` the
+/// mock agent sends a `session/request_permission` request *to the client*.
+/// The client's permission handler selects the first offered option; the
+/// agent captures the returned outcome. This exercises the inbound-request →
+/// response path end-to-end across the 0.12 builder/handler model — the same
+/// path the production client handles via a waiter + Tauri event + async
+/// `responder.respond`. Deterministic: relies entirely on request/response
+/// awaiting, no sleeps.
+#[tokio::test]
+async fn agent_initiated_permission_request_round_trips() {
+    let outcome = with_agent_and_client_capturing_permission(
+        CapabilityProfile::Full,
+        async |conn: ConnectionTo<Agent>| {
+            conn.send_request(InitializeRequest::new(ProtocolVersion::V1))
+                .block_task()
+                .await?;
+
+            let new_resp = conn
+                .send_request(NewSessionRequest::new("/tmp"))
+                .block_task()
+                .await?;
+
+            // Sending the prompt triggers the agent to issue a
+            // `session/request_permission` request back to this client; the
+            // client's handler responds before the prompt response returns.
+            let prompt_resp = conn
+                .send_request(PromptRequest::new(new_resp.session_id, vec![]))
+                .block_task()
+                .await?;
+            assert_eq!(prompt_resp.stop_reason, StopReason::EndTurn);
+            Ok(())
+        },
+    )
+    .await;
+
+    // The agent must have received the client's response to its permission
+    // request, and that response must select the first offered option.
+    match outcome {
+        Some(RequestPermissionOutcome::Selected(selected)) => {
+            assert_eq!(
+                selected.option_id,
+                PermissionOptionId::new("allow-once"),
+                "client must have selected the first offered option"
+            );
+        }
+        other => panic!(
+            "expected Selected(allow-once) outcome from the agent-initiated \
+             permission round-trip, got {other:?}"
+        ),
+    }
 }


### PR DESCRIPTION
## Summary

Migrates the ACP integration from `agent-client-protocol` **0.10.4 → 0.12.1** (+ schema **0.11.4 → 0.13.2**; the protocol crate pins schema `=0.13.2`, so they move together). The 0.12.x line is a breaking upstream API redesign, not a version bump:

- **Connection:** `ClientSideConnection::new` → `role::acp::Client.builder()…connect_with(transport, |conn: ConnectionTo<Agent>| …)`. The new handle is `Send + Clone`, so the old `!Send` `LocalSet` / `Rc<RefCell>` dedicated-thread isolation is **removed** — the command loop is now plain async.
- **Inbound:** `impl Client` trait → registered `on_receive_request` / `on_receive_notification` handlers; permission requests round-trip via `cx.spawn` + `responder.respond` so the event loop never blocks.
- **Outbound:** `conn.method(req)` → `conn.send_request(req).block_task().await` (cancel is a `send_notification`). All 13 session operations preserved.
- **Schema types** moved to `agent_client_protocol::schema::*` (all `#[non_exhaustive]`). **No serialized field renames → no frontend changes** (Tauri command signatures + `acp-session-update` / `acp-permission-request` event payloads are byte-identical).
- Dropped the `unstable_session_close` / `unstable_session_resume` features (stabilized upstream).
- Ported the `mock_acp_agent` integration harness to `Agent.builder()` over the crate's `Channel::duplex()` transport.

Design + rationale: `docs/prds/2026-05-31-acp-0.12-migration.md` · task breakdown (incl. spike findings): `docs/tasks/2026-05-31-acp-0.12-migration-tasks.md`.

A code-review pass ran on the branch; all findings fixed in `a5d564ea` — notably two blockers: a `acp_agent_stop` mutex-held-across-await deadlock and a `spawn_local`-without-`LocalSet` panic on agent stderr.

## Test plan

- [x] `cargo build` clean, no warnings in the acp modules
- [x] `cargo test` — 729 lib + 9 `mock_acp_agent`, 0 failures (incl. a new agent→client `request_permission` round-trip test)
- [x] **Live: Claude Code** — connect/auth, prompt + streamed updates, permission cards, mode/model switch, resume/fork/close, cancel — all working
- [ ] **Live: Codex / Copilot / Gemini** — not yet exercised; will be validated via the cut alpha before promotion to stable
- [ ] **Live: kill→reconnect resilience path** — validate via the alpha

🤖 Generated with [Claude Code](https://claude.com/claude-code)