### PR TITLE
test(cmd): fix flaky FileMode Enter-key test

### DIFF
--- a/src/components/cmd/__tests__/FileMode.test.tsx
+++ b/src/components/cmd/__tests__/FileMode.test.tsx
@@ -273,10 +273,18 @@ describe('FileMode — selection (#8)', () => {
     ]);
     renderWithProviders(<FileMode filter="notes" />);
     await screen.findByRole('option', { name: /notes\.md/i });
+    // The Enter handler is a document-level keydown listener that FileMode
+    // rebinds in a useEffect keyed on the async-populated `rows`, and it
+    // early-returns while `rows` is empty. `findByRole` can resolve on the
+    // committed option node *before* that passive effect flushes, leaving the
+    // listener bound to the stale empty-rows closure — pressing Enter then
+    // no-ops and `openedFiles` stays `[]` (the CI flake). Flush pending effects
+    // so the listener is rebound against the populated rows before we press Enter.
+    await act(async () => {});
     act(() => {
       fireEvent.keyDown(document, { key: 'Enter' });
     });
-    expect(openedFiles).toEqual(['/p/alpha/notes.md']);
+    await waitFor(() => expect(openedFiles).toEqual(['/p/alpha/notes.md']));
   });
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`FileMode.test.tsx > "opens the highlighted file on Enter key"` is flaky in CI (`expected [ '/p/alpha/notes.md' ] … got []`). It surfaced as the failing check on dependabot PR #403, but it's unrelated to that PR's `tar` bump — it's a pre-existing test-timing race.

**Cause:** `FileMode` binds its Enter handler as a *document* `keydown` listener inside a `useEffect` keyed on the async-populated `rows`, and the handler early-returns while `rows` is empty. `findByRole('option')` resolves on the committed option node, which can happen *before* that passive effect flushes — so the listener is still bound to the stale empty-`rows` closure, Enter no-ops, and `openedFiles` stays `[]`.

**Fix:** flush pending effects (`await act(async () => {})`) so the listener is rebound against the populated rows before pressing Enter, and assert the outcome via `waitFor`. Test-only timing fix — no product code changes.

Verified locally: 5/5 consecutive runs green (14/14 each).

## Test plan

- [x] `pnpm test src/components/cmd/__tests__/FileMode.test.tsx` — green across 5 repeated runs
- [x] No product/source changes (single test file touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)