### PR TITLE
chore: release v0.46.0-alpha.12

### DIFF
--- a/docs/history/137-release-v0.46.0-alpha.12.md
+++ b/docs/history/137-release-v0.46.0-alpha.12.md
@@ -1,0 +1,24 @@
+# Release v0.46.0-alpha.12
+
+**Date:** 2026-06-01
+**Previous version:** 0.46.0-alpha.11
+**Channel:** Alpha
+
+Auto-cut by `aw-alpha-cut` after Tier-A/B PRs landed. The auto-dump under "Under the hood" lists the merged PRs verbatim.
+
+Before promoting this alpha to stable, edit this file:
+  - Move anything user-visible from "Under the hood" into "## Changes" under `### Features`, `### Improvements`, or `### Fixes` — and rewrite each bullet in user-facing prose (drop PR titles, version triples, internal jargon).
+  - Leave "## Changes" as `_No user-visible changes._` for infra-only releases.
+  - See `feedback_user_facing_release_notes.md` and `scripts/generate-changelog.ts` linter rules.
+
+## Changes
+
+_No user-visible changes._
+
+## Under the hood
+
+Auto-generated dump of merged Tier-A/B PRs. Rewrite as prose grouped by area before stable promotion.
+
+- chore(deps): bump tar from 0.4.45 to 0.4.46 in /src-tauri in the cargo group across 1 directory (#403)
+- refactor(acp): migrate to agent-client-protocol 0.12.1 builder API (#405)
+- test(cmd): fix flaky FileMode Enter-key test (#406)

--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -140,3 +140,4 @@ Chronological log of major implementation milestones and changes.
 | 134 | [Release v0.46.0-alpha.9](134-release-v0.46.0-alpha.9.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
 | 135 | [Release v0.46.0-alpha.10](135-release-v0.46.0-alpha.10.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
 | 136 | [Release v0.46.0-alpha.11](136-release-v0.46.0-alpha.11.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
+| 137 | [Release v0.46.0-alpha.12](137-release-v0.46.0-alpha.12.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "notesage",
   "private": true,
-  "version": "0.46.0-alpha.11",
+  "version": "0.46.0-alpha.12",
   "license": "MIT",
   "author": "Peter Blenessy",
   "type": "module",

--- a/public/changelog-alpha.json
+++ b/public/changelog-alpha.json
@@ -1,6 +1,17 @@
 {
   "releases": [
     {
+      "version": "0.46.0-alpha.12",
+      "date": "2026-06-01",
+      "previousVersion": "0.46.0",
+      "sections": {},
+      "underTheHood": [
+        "chore(deps): bump tar from 0.4.45 to 0.4.46 in /src-tauri in the cargo group across 1 directory (#403)",
+        "refactor(acp): migrate to agent-client-protocol 0.12.1 builder API (#405)",
+        "test(cmd): fix flaky FileMode Enter-key test (#406)"
+      ]
+    },
+    {
       "version": "0.46.0-alpha.11",
       "date": "2026-05-31",
       "previousVersion": "0.46.0",


### PR DESCRIPTION
Auto-cut by `aw-alpha-cut`. The history file at `docs/history/137-release-v0.46.0-alpha.12.md` lists the merged PRs.

## PRs included

- #403
- #405
- #406

Auto-merge enabled. Once the 4 required status checks pass, this merges to main, and the `tag-after-merge` job in `aw-alpha-cut.yml` tags + pushes `v0.46.0-alpha.12`. `release.yml` then builds and publishes.
