### PR TITLE
chore: release v0.46.0-alpha.13

### DIFF
--- a/docs/history/138-release-v0.46.0-alpha.13.md
+++ b/docs/history/138-release-v0.46.0-alpha.13.md
@@ -1,0 +1,22 @@
+# Release v0.46.0-alpha.13
+
+**Date:** 2026-06-03
+**Previous version:** 0.46.0-alpha.12
+**Channel:** Alpha
+
+Auto-cut by `aw-alpha-cut` after Tier-A/B PRs landed. The auto-dump under "Under the hood" lists the merged PRs verbatim.
+
+Before promoting this alpha to stable, edit this file:
+  - Move anything user-visible from "Under the hood" into "## Changes" under `### Features`, `### Improvements`, or `### Fixes` — and rewrite each bullet in user-facing prose (drop PR titles, version triples, internal jargon).
+  - Leave "## Changes" as `_No user-visible changes._` for infra-only releases.
+  - See `feedback_user_facing_release_notes.md` and `scripts/generate-changelog.ts` linter rules.
+
+## Changes
+
+_No user-visible changes._
+
+## Under the hood
+
+Auto-generated dump of merged Tier-A/B PRs. Rewrite as prose grouped by area before stable promotion.
+
+- Hardware-aware local model recommendation (Phase 1 + Phase 2 runtime calibration) (#409)

--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -141,3 +141,4 @@ Chronological log of major implementation milestones and changes.
 | 135 | [Release v0.46.0-alpha.10](135-release-v0.46.0-alpha.10.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
 | 136 | [Release v0.46.0-alpha.11](136-release-v0.46.0-alpha.11.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
 | 137 | [Release v0.46.0-alpha.12](137-release-v0.46.0-alpha.12.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
+| 138 | [Release v0.46.0-alpha.13](138-release-v0.46.0-alpha.13.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "notesage",
   "private": true,
-  "version": "0.46.0-alpha.12",
+  "version": "0.46.0-alpha.13",
   "license": "MIT",
   "author": "Peter Blenessy",
   "type": "module",

--- a/public/changelog-alpha.json
+++ b/public/changelog-alpha.json
@@ -1,6 +1,15 @@
 {
   "releases": [
     {
+      "version": "0.46.0-alpha.13",
+      "date": "2026-06-03",
+      "previousVersion": "0.46.0",
+      "sections": {},
+      "underTheHood": [
+        "Hardware-aware local model recommendation (Phase 1 + Phase 2 runtime calibration) (#409)"
+      ]
+    },
+    {
       "version": "0.46.0-alpha.12",
       "date": "2026-06-01",
       "previousVersion": "0.46.0",


### PR DESCRIPTION
Auto-cut by `aw-alpha-cut`. The history file at `docs/history/138-release-v0.46.0-alpha.13.md` lists the merged PRs.

## PRs included

- #409

Auto-merge enabled. Once the 4 required status checks pass, this merges to main, and the `tag-after-merge` job in `aw-alpha-cut.yml` tags + pushes `v0.46.0-alpha.13`. `release.yml` then builds and publishes.
