### PR TITLE
fix(mcp): close deep-link RCE + OAuth SSRF (security)

### DIFF
--- a/src-tauri/src/commands/mcp_oauth.rs
+++ b/src-tauri/src/commands/mcp_oauth.rs
@@ -19,6 +19,7 @@
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use std::net::{IpAddr, Ipv6Addr};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
@@ -186,6 +187,84 @@ pub fn build_authorize_url(
     Ok(url.to_string())
 }
 
+/// True when an IPv6 address falls in a range we must never reach from an
+/// externally-influenced URL: loopback, unspecified, link-local (`fe80::/10`),
+/// or unique-local (`fc00::/7`). The std lib exposes `is_loopback`/
+/// `is_unspecified` but the latter two ranges have no stable helpers, so we
+/// inspect the leading bits directly.
+fn ipv6_is_dangerous(addr: &Ipv6Addr) -> bool {
+    if addr.is_loopback() || addr.is_unspecified() {
+        return true;
+    }
+    let seg0 = addr.segments()[0];
+    // fe80::/10 — link-local unicast.
+    if seg0 & 0xffc0 == 0xfe80 {
+        return true;
+    }
+    // fc00::/7 — unique-local addresses.
+    if seg0 & 0xfe00 == 0xfc00 {
+        return true;
+    }
+    false
+}
+
+/// SSRF guard for every externally-influenced URL (the MCP `server_url`, the
+/// discovered authorization servers, and the authorization/token endpoints
+/// drawn from attacker-controllable metadata).
+///
+/// Rules:
+/// - must parse as a URL,
+/// - scheme MUST be `https` (rejects `http` and every other scheme),
+/// - if the host is an IP literal, it must NOT be loopback, private,
+///   link-local, unique-local, or unspecified,
+/// - the hostnames `localhost` and `*.localhost` are rejected outright.
+///
+/// Caveat: this does NOT defend against DNS rebinding — a hostname that
+/// resolves to a private IP at request time is not caught here, because we
+/// validate the literal URL, not the resolved address. That requires resolving
+/// and pinning the address at connect time and is out of scope for this fix.
+fn validate_external_url(raw: &str) -> Result<(), String> {
+    let url = url::Url::parse(raw).map_err(|e| format!("Invalid URL {}: {}", raw, e))?;
+
+    if url.scheme() != "https" {
+        return Err(format!(
+            "Refusing to use non-HTTPS URL {} (scheme {:?})",
+            raw,
+            url.scheme()
+        ));
+    }
+
+    let host = url
+        .host_str()
+        .ok_or_else(|| format!("URL {} has no host", raw))?;
+
+    // Reject `localhost` / `*.localhost` by name (it resolves to loopback).
+    let lower = host.to_ascii_lowercase();
+    if lower == "localhost" || lower.ends_with(".localhost") {
+        return Err(format!("Refusing to use loopback hostname {}", raw));
+    }
+
+    // If the host is an IP literal, block dangerous ranges. `host_str()`
+    // keeps the brackets on an IPv6 literal (`[::1]`), so strip them first.
+    let ip_candidate = lower.strip_prefix('[').and_then(|s| s.strip_suffix(']')).unwrap_or(&lower);
+    if let Ok(ip) = ip_candidate.parse::<IpAddr>() {
+        let dangerous = match ip {
+            IpAddr::V4(v4) => {
+                v4.is_loopback()
+                    || v4.is_private()
+                    || v4.is_link_local()
+                    || v4.is_unspecified()
+            }
+            IpAddr::V6(v6) => ipv6_is_dangerous(&v6),
+        };
+        if dangerous {
+            return Err(format!("Refusing to use internal/reserved IP address {}", raw));
+        }
+    }
+
+    Ok(())
+}
+
 /// Build a `<origin>/.well-known/<name>` URL for the origin of `base`.
 /// Falls back to appending if `base` can't be parsed as a URL.
 pub fn well_known(base: &str, name: &str) -> String {
@@ -339,15 +418,37 @@ async fn discover_metadata(
     client: &reqwest::Client,
     server_url: &str,
 ) -> Result<AuthServerMetadata, String> {
+    // The MCP server_url itself is user/attacker-supplied — validate before any fetch.
+    validate_external_url(server_url)?;
+
     let prm_url = well_known(server_url, "oauth-protected-resource");
     if let Ok(prm) = fetch_json::<ProtectedResourceMetadata>(client, &prm_url).await {
         if let Some(issuer) = prm.authorization_servers.into_iter().next() {
+            // `issuer` comes from the (attacker-controlled) protected-resource
+            // metadata — must be validated before we fetch its AS metadata.
+            validate_external_url(&issuer)?;
             let asm_url = well_known(&issuer, "oauth-authorization-server");
-            return fetch_json::<AuthServerMetadata>(client, &asm_url).await;
+            let metadata: AuthServerMetadata = fetch_json(client, &asm_url).await?;
+            validate_endpoints(&metadata)?;
+            return Ok(metadata);
         }
     }
     let asm_url = well_known(server_url, "oauth-authorization-server");
-    fetch_json::<AuthServerMetadata>(client, &asm_url).await
+    let metadata: AuthServerMetadata = fetch_json(client, &asm_url).await?;
+    validate_endpoints(&metadata)?;
+    Ok(metadata)
+}
+
+/// Validate the authorization/token/registration endpoints carried in
+/// attacker-controllable authorization-server metadata before any of them is
+/// opened in a browser or POSTed to.
+fn validate_endpoints(metadata: &AuthServerMetadata) -> Result<(), String> {
+    validate_external_url(&metadata.authorization_endpoint)?;
+    validate_external_url(&metadata.token_endpoint)?;
+    if let Some(reg) = &metadata.registration_endpoint {
+        validate_external_url(reg)?;
+    }
+    Ok(())
 }
 
 async fn register_client(
@@ -355,6 +456,8 @@ async fn register_client(
     registration_endpoint: &str,
     redirect_uri: &str,
 ) -> Result<ClientRegistrationResponse, String> {
+    // The registration endpoint comes from attacker-controllable metadata.
+    validate_external_url(registration_endpoint)?;
     let body = ClientRegistrationRequest {
         client_name: "Notesage",
         redirect_uris: vec![redirect_uri.to_string()],
@@ -423,6 +526,9 @@ async fn exchange_code(
     verifier: &str,
     redirect_uri: &str,
 ) -> Result<TokenResponse, String> {
+    // Defense-in-depth: the token endpoint comes from attacker-controllable
+    // metadata — re-validate immediately before POSTing credentials to it.
+    validate_external_url(token_endpoint)?;
     let mut form = vec![
         ("grant_type", "authorization_code"),
         ("code", code),
@@ -454,6 +560,10 @@ async fn refresh_with(
     tokens: &OAuthTokens,
     refresh_token: &str,
 ) -> Result<OAuthTokens, String> {
+    // The token endpoint was persisted from attacker-controllable metadata —
+    // re-validate before POSTing to it (catches tokens stored before this
+    // guard existed, and is cheap defense-in-depth otherwise).
+    validate_external_url(&tokens.token_endpoint)?;
     let mut form = vec![
         ("grant_type", "refresh_token"),
         ("refresh_token", refresh_token),
@@ -532,6 +642,8 @@ pub async fn mcp_oauth_authorize(
     let (verifier, challenge) = generate_pkce();
     let state = uuid::Uuid::new_v4().to_string();
 
+    // Re-validate the authorization endpoint before handing it to the browser.
+    validate_external_url(&metadata.authorization_endpoint)?;
     let auth_url = build_authorize_url(
         &metadata.authorization_endpoint,
         &reg.client_id,
@@ -722,6 +834,52 @@ mod tests {
     #[test]
     fn oauth_service_id_is_namespaced() {
         assert_eq!(oauth_service("global:github"), "notesage:mcp:global:github:oauth");
+    }
+
+    #[test]
+    fn validate_external_url_accepts_public_https() {
+        assert!(validate_external_url("https://accounts.google.com").is_ok());
+        assert!(validate_external_url("https://api.example.com/.well-known/x").is_ok());
+        // A public IP literal is fine.
+        assert!(validate_external_url("https://8.8.8.8/token").is_ok());
+    }
+
+    #[test]
+    fn validate_external_url_rejects_non_https() {
+        assert!(validate_external_url("http://example.com").is_err());
+        assert!(validate_external_url("ftp://example.com").is_err());
+        assert!(validate_external_url("file:///etc/passwd").is_err());
+    }
+
+    #[test]
+    fn validate_external_url_rejects_cloud_metadata_endpoint() {
+        // AWS/GCP/Azure link-local metadata service.
+        assert!(validate_external_url("https://169.254.169.254/latest/meta-data/").is_err());
+    }
+
+    #[test]
+    fn validate_external_url_rejects_localhost() {
+        assert!(validate_external_url("https://localhost/oauth").is_err());
+        assert!(validate_external_url("https://app.localhost/oauth").is_err());
+        assert!(validate_external_url("https://LOCALHOST:8443/x").is_err());
+    }
+
+    #[test]
+    fn validate_external_url_rejects_private_ipv4() {
+        assert!(validate_external_url("https://10.0.0.1").is_err());
+        assert!(validate_external_url("https://172.16.0.1").is_err());
+        assert!(validate_external_url("https://192.168.1.1").is_err());
+        assert!(validate_external_url("https://127.0.0.1:9000/x").is_err());
+        assert!(validate_external_url("https://0.0.0.0").is_err());
+    }
+
+    #[test]
+    fn validate_external_url_rejects_internal_ipv6() {
+        assert!(validate_external_url("https://[::1]").is_err()); // loopback
+        assert!(validate_external_url("https://[::]").is_err()); // unspecified
+        assert!(validate_external_url("https://[fe80::1]").is_err()); // link-local
+        assert!(validate_external_url("https://[fc00::1]").is_err()); // unique-local
+        assert!(validate_external_url("https://[fd12:3456::1]").is_err()); // unique-local
     }
 
     #[test]

--- a/src/components/settings/McpDeepLinkInstaller.tsx
+++ b/src/components/settings/McpDeepLinkInstaller.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { onOpenUrl, getCurrent } from '@tauri-apps/plugin-deep-link';
+import { toast } from 'sonner';
 import { AddEditServerDialog, type CatalogPrefill } from './McpServersSettings';
 import { parseMcpInstallUrl } from '@/lib/mcp/deeplink';
 
@@ -15,11 +16,16 @@ export function McpDeepLinkInstaller() {
   useEffect(() => {
     const handle = (urls: string[]) => {
       for (const u of urls) {
-        const req = parseMcpInstallUrl(u);
-        if (req) {
-          setPending(req);
+        const res = parseMcpInstallUrl(u);
+        if (!res) continue; // Not an install URL — ignore silently.
+        if (!res.ok) {
+          // Well-formed install URL, but the command isn't allowed. Refuse
+          // loudly and never open the dialog.
+          toast.error(res.reason);
           break;
         }
+        setPending(res.prefill);
+        break;
       }
     };
 

--- a/src/components/settings/McpServersSettings.tsx
+++ b/src/components/settings/McpServersSettings.tsx
@@ -4,7 +4,7 @@ import { toast } from 'sonner';
 import {
   RefreshCw, Plus, MoreHorizontal, Play, Square, RotateCcw,
   ChevronDown, Download, Wrench, Trash2, Boxes,
-  Loader2, CheckCircle2, AlertCircle, Lock, LogOut,
+  Loader2, CheckCircle2, AlertCircle, Lock, LogOut, ShieldAlert,
 } from 'lucide-react';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
@@ -12,6 +12,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { Checkbox } from '@/components/ui/checkbox';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import {
   Dialog,
   DialogContent,
@@ -305,6 +306,13 @@ export interface CatalogPrefill {
   env: EnvRow[];
   transport?: McpTransport;
   url?: string | null;
+  /**
+   * `true` when the prefill came from an attacker-controllable source (a
+   * `notesage://mcp/install` deep link). The Add dialog renders a warning
+   * banner and gates Test/Add behind an explicit acknowledgement when set.
+   * The in-app catalog and manual adds are trusted and leave this unset.
+   */
+  untrusted?: boolean;
 }
 
 /**
@@ -355,6 +363,11 @@ export function AddEditServerDialog({ open, onOpenChange, editServer, prefill }:
   // Validation dry-run state — drives the tool preview / error panel and gates
   // the write (config is only persisted after a successful start → handshake).
   const [validation, setValidation] = useState<ValidationState>({ status: 'idle' });
+  // Untrusted (deep-link-sourced) prefills must be explicitly acknowledged
+  // before Test/Add can spawn the command. Editing or a manual/catalog add is
+  // trusted and never gated.
+  const untrusted = !editServer && !!prefill?.untrusted;
+  const [acknowledged, setAcknowledged] = useState(false);
 
   const { validateServer, oauthAuthorize, oauthStatus } = useMcpOperations();
   const [authorizing, setAuthorizing] = useState(false);
@@ -362,11 +375,16 @@ export function AddEditServerDialog({ open, onOpenChange, editServer, prefill }:
 
   const isRemote = transport === 'http';
   const hasRequiredFields = isRemote ? !!url.trim() : !!command.trim();
+  // Untrusted prefills block Test/Add until the user ticks the acknowledgement.
+  const gateBlocked = untrusted && !acknowledged;
 
   // The "Add" dialog is mounted once and reused, so seed its fields whenever it
   // (re)opens — from the edited server, a catalog prefill, or empty.
   useEffect(() => {
     if (!open) return;
+    // Every (re)open starts unacknowledged — a fresh untrusted prefill must be
+    // reviewed again even if a prior one was acknowledged in this mount.
+    setAcknowledged(false);
     if (editServer) {
       setCommand(editServer.command);
       setArgs(editServer.args.join(' '));
@@ -493,6 +511,10 @@ export function AddEditServerDialog({ open, onOpenChange, editServer, prefill }:
   const requiredFieldError = isRemote ? 'Server URL is required' : 'Command is required';
 
   const handleTest = async () => {
+    if (gateBlocked) {
+      toast.error('Confirm you trust this server before testing it');
+      return;
+    }
     if (!hasRequiredFields) {
       toast.error(requiredFieldError);
       return;
@@ -510,6 +532,10 @@ export function AddEditServerDialog({ open, onOpenChange, editServer, prefill }:
   };
 
   const handleSave = async () => {
+    if (gateBlocked) {
+      toast.error('Confirm you trust this server before adding it');
+      return;
+    }
     if (!hasRequiredFields) {
       toast.error(requiredFieldError);
       return;
@@ -600,6 +626,29 @@ export function AddEditServerDialog({ open, onOpenChange, editServer, prefill }:
         </DialogHeader>
 
         <div className="space-y-4 py-2">
+          {untrusted && (
+            <Alert variant="destructive">
+              <ShieldAlert className="h-4 w-4" strokeWidth={1.5} />
+              <AlertTitle>Requested by an external link</AlertTitle>
+              <AlertDescription className="space-y-2">
+                <p>
+                  This MCP server was requested by an external link. MCP servers
+                  run programs on your computer — review the command and arguments
+                  below before continuing. Only add servers from sources you trust.
+                </p>
+                <label className="flex items-start gap-2 text-foreground">
+                  <Checkbox
+                    checked={acknowledged}
+                    onCheckedChange={(c) => setAcknowledged(c === true)}
+                    className="mt-0.5"
+                  />
+                  <span className="text-xs">
+                    I&apos;ve reviewed this command and trust its source
+                  </span>
+                </label>
+              </AlertDescription>
+            </Alert>
+          )}
           <div className="space-y-1.5">
             <Label className="text-xs text-muted-foreground">Transport</Label>
             <div className="inline-flex rounded-lg border border-border p-0.5">
@@ -818,7 +867,7 @@ export function AddEditServerDialog({ open, onOpenChange, editServer, prefill }:
             variant="ghost"
             size="sm"
             onClick={handleTest}
-            disabled={saving || validation.status === 'testing' || !hasRequiredFields}
+            disabled={saving || validation.status === 'testing' || !hasRequiredFields || gateBlocked}
           >
             {validation.status === 'testing' ? (
               <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" strokeWidth={1.5} />
@@ -831,7 +880,7 @@ export function AddEditServerDialog({ open, onOpenChange, editServer, prefill }:
             <Button variant="outline" onClick={() => onOpenChange(false)}>
               Cancel
             </Button>
-            <Button onClick={handleSave} disabled={saving || !hasRequiredFields}>
+            <Button onClick={handleSave} disabled={saving || !hasRequiredFields || gateBlocked}>
               {saving ? 'Saving...' : editServer ? 'Update' : 'Add Server'}
             </Button>
           </div>

--- a/src/components/settings/__tests__/McpDeepLinkConsentGate.test.tsx
+++ b/src/components/settings/__tests__/McpDeepLinkConsentGate.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+
+import '@/test/tauri-mock';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderWithProviders, screen, fireEvent } from '@/test/component-harness';
+import { clearMockInvokeHandlers, registerDefaultHandlers } from '@/test/tauri-mock';
+import { AddEditServerDialog, type CatalogPrefill } from '@/components/settings/McpServersSettings';
+
+const UNTRUSTED_PREFILL: CatalogPrefill = {
+  name: 'Filesystem',
+  command: 'npx',
+  args: ['-y', '@modelcontextprotocol/server-filesystem'],
+  env: [],
+  transport: 'stdio',
+  url: null,
+  untrusted: true,
+};
+
+const TRUSTED_PREFILL: CatalogPrefill = {
+  ...UNTRUSTED_PREFILL,
+  untrusted: false,
+};
+
+beforeEach(() => {
+  clearMockInvokeHandlers();
+  registerDefaultHandlers();
+});
+
+describe('AddEditServerDialog deep-link consent gate', () => {
+  it('shows a warning and disables Test/Add until the source is acknowledged', () => {
+    renderWithProviders(
+      <AddEditServerDialog open onOpenChange={() => {}} prefill={UNTRUSTED_PREFILL} />
+    );
+
+    expect(screen.getByText('Requested by an external link')).toBeTruthy();
+
+    const testBtn = screen.getByRole('button', { name: /test/i }) as HTMLButtonElement;
+    const addBtn = screen.getByRole('button', { name: /add server/i }) as HTMLButtonElement;
+    expect(testBtn.disabled).toBe(true);
+    expect(addBtn.disabled).toBe(true);
+
+    // Tick the acknowledgement checkbox.
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    expect((screen.getByRole('button', { name: /test/i }) as HTMLButtonElement).disabled).toBe(false);
+    expect((screen.getByRole('button', { name: /add server/i }) as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it('does not gate a trusted (catalog/manual) prefill', () => {
+    renderWithProviders(
+      <AddEditServerDialog open onOpenChange={() => {}} prefill={TRUSTED_PREFILL} />
+    );
+
+    expect(screen.queryByText('Requested by an external link')).toBeNull();
+    expect((screen.getByRole('button', { name: /test/i }) as HTMLButtonElement).disabled).toBe(false);
+    expect((screen.getByRole('button', { name: /add server/i }) as HTMLButtonElement).disabled).toBe(false);
+  });
+});

--- a/src/hooks/__tests__/useMcpOperations.test.ts
+++ b/src/hooks/__tests__/useMcpOperations.test.ts
@@ -1,13 +1,15 @@
 // @vitest-environment jsdom
 
 import { describe, it, expect, beforeEach } from 'vitest';
-import { renderHook } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
 import {
   setMockInvokeHandler,
   clearMockInvokeHandlers,
   registerDefaultHandlers,
 } from '@/test/tauri-mock';
-import { useMcpOperations, type McpValidationResult } from '../useMcpOperations';
+import { useMcpOperations, useMcpDiscovery, type McpValidationResult } from '../useMcpOperations';
+import { useSettingsStore } from '@/stores/settings-store';
+import { useWorkspaceStore } from '@/stores/workspace-store';
 
 // The hook is mocked at the @tauri-apps boundary by src/test/tauri-mock.ts
 // (wired globally in vitest setup). We register per-test invoke handlers.
@@ -154,6 +156,31 @@ describe('useMcpOperations.validateServer', () => {
     expect(loggedOut).toMatchObject({ serverId: 'global:r' });
   });
 
+  it('startServer forwards transport + url so http servers launch over HTTP', async () => {
+    const captured: { config?: Record<string, unknown> } = {};
+    setMockInvokeHandler('mcp_start_server', (args) => {
+      captured.config = (args as { config: Record<string, unknown> }).config;
+      return { id: 'global:r', name: 'r', command: '', args: [], env: {}, source: 'notesage_global', enabled: true, status: 'running', error: null, tools: [], transport: 'http', url: 'https://x/mcp' };
+    });
+
+    const { result } = renderHook(() => useMcpOperations());
+    await result.current.startServer({
+      id: 'global:r',
+      name: 'r',
+      command: '',
+      args: [],
+      env: {},
+      source: 'notesage-global',
+      enabled: true,
+      status: 'stopped',
+      tools: [],
+      transport: 'http',
+      url: 'https://x/mcp',
+    });
+
+    expect(captured.config).toMatchObject({ transport: 'http', url: 'https://x/mcp' });
+  });
+
   it('propagates a failed validation result (mapped error) to the caller', async () => {
     const failResult: McpValidationResult = {
       ok: false,
@@ -171,5 +198,52 @@ describe('useMcpOperations.validateServer', () => {
     expect(res.ok).toBe(false);
     expect(res.error_kind).toBe('binary_not_found');
     expect(res.error).toContain('PATH');
+  });
+});
+
+describe('useMcpDiscovery auto-start', () => {
+  beforeEach(() => {
+    clearMockInvokeHandlers();
+    registerDefaultHandlers();
+    useWorkspaceStore.setState({ projects: [] });
+    useSettingsStore.setState({ startupReady: false });
+  });
+
+  it('includes transport + url in the launch-time auto-start payload', async () => {
+    const httpServer = {
+      id: 'global:Remote',
+      name: 'Remote',
+      command: '',
+      args: [],
+      env: {},
+      source: 'notesage_global',
+      enabled: true,
+      transport: 'http',
+      url: 'https://mcp.example.com/mcp',
+    };
+
+    setMockInvokeHandler('mcp_discover_configs', () => [httpServer]);
+
+    const captured: { config?: Record<string, unknown> } = {};
+    setMockInvokeHandler('mcp_start_server', (args) => {
+      captured.config = (args as { config: Record<string, unknown> }).config;
+      return {
+        id: 'global:Remote', name: 'Remote', command: '', args: [], env: {},
+        source: 'notesage_global', enabled: true, status: 'running', error: null,
+        tools: [], transport: 'http', url: 'https://mcp.example.com/mcp',
+      };
+    });
+
+    renderHook(() => useMcpDiscovery());
+    // Discovery is gated on startupReady — flip it to trigger the effect.
+    useSettingsStore.setState({ startupReady: true });
+
+    await waitFor(() => {
+      expect(captured.config).toBeDefined();
+    });
+    expect(captured.config).toMatchObject({
+      transport: 'http',
+      url: 'https://mcp.example.com/mcp',
+    });
   });
 });

--- a/src/hooks/useMcpOperations.ts
+++ b/src/hooks/useMcpOperations.ts
@@ -180,6 +180,10 @@ export function useMcpDiscovery() {
                   env: entry.env,
                   source: sourceToRust(entry.source),
                   enabled: entry.enabled,
+                  // Carry transport + url so http servers launch over HTTP, not
+                  // silently as stdio (they have no command/args).
+                  transport: entry.transport ?? 'stdio',
+                  url: entry.url ?? null,
                 },
               });
               if (cancelled) return;

--- a/src/lib/mcp/__tests__/deeplink.test.ts
+++ b/src/lib/mcp/__tests__/deeplink.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseMcpInstallUrl } from '../deeplink';
+import { parseMcpInstallUrl, isAllowedMcpCommand, MCP_ALLOWED_COMMANDS } from '../deeplink';
 
 describe('parseMcpInstallUrl', () => {
   it('parses a stdio install link with args', () => {
@@ -7,28 +7,36 @@ describe('parseMcpInstallUrl', () => {
       'notesage://mcp/install?name=Filesystem&command=npx&args=-y%20@modelcontextprotocol/server-filesystem'
     );
     expect(r).toEqual({
-      name: 'Filesystem',
-      command: 'npx',
-      args: ['-y', '@modelcontextprotocol/server-filesystem'],
-      env: [],
-      transport: 'stdio',
-      url: null,
+      ok: true,
+      prefill: {
+        name: 'Filesystem',
+        command: 'npx',
+        args: ['-y', '@modelcontextprotocol/server-filesystem'],
+        env: [],
+        transport: 'stdio',
+        url: null,
+        untrusted: true,
+      },
     });
   });
 
   it('parses a remote (http) install link', () => {
     const r = parseMcpInstallUrl('notesage://mcp/install?name=Sentry&transport=http&url=https://mcp.sentry.dev/mcp');
-    expect(r).toMatchObject({ name: 'Sentry', transport: 'http', url: 'https://mcp.sentry.dev/mcp', command: '', args: [] });
+    expect(r).toMatchObject({
+      ok: true,
+      prefill: { name: 'Sentry', transport: 'http', url: 'https://mcp.sentry.dev/mcp', command: '', args: [], untrusted: true },
+    });
   });
 
   it('derives a name from the command when none is given', () => {
     const r = parseMcpInstallUrl('notesage://mcp/install?command=uvx&args=mcp-server-git');
-    expect(r?.name).toBe('uvx');
+    expect(r).toMatchObject({ ok: true, prefill: { name: 'uvx' } });
   });
 
   it('collects env keys with secret flags but no values', () => {
     const r = parseMcpInstallUrl('notesage://mcp/install?command=node&env=PORT&env=TOKEN:secret');
-    expect(r?.env).toEqual([
+    expect(r?.ok).toBe(true);
+    expect(r?.ok && r.prefill.env).toEqual([
       { key: 'PORT', value: '', secret: false },
       { key: 'TOKEN', value: '', secret: true },
     ]);
@@ -52,5 +60,57 @@ describe('parseMcpInstallUrl', () => {
 
   it('rejects malformed urls', () => {
     expect(parseMcpInstallUrl('not a url')).toBeNull();
+  });
+
+  // --- Command allowlist (RCE defense) ---
+
+  it('accepts each allowlisted command', () => {
+    for (const cmd of MCP_ALLOWED_COMMANDS) {
+      const r = parseMcpInstallUrl(`notesage://mcp/install?command=${cmd}&args=foo`);
+      expect(r?.ok).toBe(true);
+    }
+  });
+
+  it('rejects a bare disallowed command (bash) without opening', () => {
+    const r = parseMcpInstallUrl('notesage://mcp/install?command=bash&args=-c%20whoami');
+    expect(r).toMatchObject({ ok: false });
+    expect(r?.ok === false && r.reason).toContain('bash');
+  });
+
+  it('rejects an absolute-path command (/bin/bash)', () => {
+    const r = parseMcpInstallUrl('notesage://mcp/install?command=/bin/bash');
+    expect(r).toMatchObject({ ok: false });
+  });
+
+  it('rejects /usr/bin/env', () => {
+    const r = parseMcpInstallUrl('notesage://mcp/install?command=/usr/bin/env&args=npx');
+    expect(r).toMatchObject({ ok: false });
+  });
+
+  it('rejects sh (with -c args)', () => {
+    const r = parseMcpInstallUrl('notesage://mcp/install?command=sh&args=-c%20rm%20-rf');
+    expect(r).toMatchObject({ ok: false });
+  });
+
+  it('rejects a relative path command (./evil)', () => {
+    const r = parseMcpInstallUrl('notesage://mcp/install?command=./evil');
+    expect(r).toMatchObject({ ok: false });
+  });
+});
+
+describe('isAllowedMcpCommand', () => {
+  it('returns true only for exact allowlist matches', () => {
+    expect(isAllowedMcpCommand('npx')).toBe(true);
+    expect(isAllowedMcpCommand('  npx  ')).toBe(true);
+    expect(isAllowedMcpCommand('python3')).toBe(true);
+  });
+
+  it('rejects path separators and off-list values', () => {
+    expect(isAllowedMcpCommand('/bin/bash')).toBe(false);
+    expect(isAllowedMcpCommand('./npx')).toBe(false);
+    expect(isAllowedMcpCommand('C:\\Windows\\system32\\cmd.exe')).toBe(false);
+    expect(isAllowedMcpCommand('bash')).toBe(false);
+    expect(isAllowedMcpCommand('env')).toBe(false);
+    expect(isAllowedMcpCommand('')).toBe(false);
   });
 });

--- a/src/lib/mcp/deeplink.ts
+++ b/src/lib/mcp/deeplink.ts
@@ -6,6 +6,16 @@
  * provides; nothing is installed until the user reviews and confirms in the
  * validate-first Add dialog (the dialog IS the confirmation step).
  *
+ * SECURITY: a deep link is attacker-controllable — any webpage, email, or chat
+ * message can hand the OS a `notesage://mcp/install?command=...` URL. The Add
+ * dialog spawns `command` as a subprocess on "Test"/"Add", so an unconstrained
+ * command turns one benign-looking click into arbitrary code execution. Two
+ * defenses live here and in the dialog:
+ *   1. (this file) a hard allowlist on the stdio command — only known package
+ *      runners pass; anything with a path separator or off-list is rejected.
+ *   2. (the dialog) deep-link-sourced prefills are flagged untrusted and gated
+ *      behind an explicit "I trust this source" acknowledgement.
+ *
  * Examples:
  *   notesage://mcp/install?name=Filesystem&command=npx&args=-y%20@modelcontextprotocol/server-filesystem
  *   notesage://mcp/install?name=Sentry&transport=http&url=https://mcp.sentry.dev/mcp
@@ -17,15 +27,61 @@ import type { CatalogPrefill } from '@/components/settings/McpServersSettings';
 export type McpInstallRequest = CatalogPrefill;
 
 /**
+ * Result of parsing an install URL:
+ *   - `{ ok: true, prefill }`  — a well-formed, allowed install request.
+ *   - `{ ok: false, reason }`  — a well-formed install URL whose command is
+ *     NOT on the allowlist (the caller should surface `reason` and refuse).
+ *   - `null`                   — not an install URL at all (wrong protocol/path
+ *     or missing required fields); the caller should ignore it silently.
+ */
+export type McpInstallParseResult =
+  | { ok: true; prefill: McpInstallRequest }
+  | { ok: false; reason: string };
+
+/**
+ * Commands a deep link is allowed to pre-fill for a stdio MCP server.
+ *
+ * These are the standard package runners / interpreters MCP servers ship with.
+ * The list is intentionally small and exact-match only — no shells, no env
+ * wrappers, no absolute paths. Even these still permit running an arbitrary
+ * package (e.g. `npx -y <anything>`), which is why the dialog adds a human
+ * consent gate on top of this allowlist.
+ */
+export const MCP_ALLOWED_COMMANDS = [
+  'npx',
+  'uvx',
+  'uv',
+  'node',
+  'python',
+  'python3',
+  'deno',
+  'bun',
+  'bunx',
+] as const;
+
+/**
+ * True only if `cmd` is EXACTLY one of the allowlisted runners. Any path
+ * separator (`/` or `\`) or off-list value is rejected — this blocks
+ * `/bin/bash`, `./evil`, `/usr/bin/env`, `sh`, etc.
+ */
+export function isAllowedMcpCommand(cmd: string): boolean {
+  const trimmed = cmd.trim();
+  if (!trimmed) return false;
+  if (trimmed.includes('/') || trimmed.includes('\\')) return false;
+  return (MCP_ALLOWED_COMMANDS as readonly string[]).includes(trimmed);
+}
+
+/**
  * Parse a `notesage://mcp/install?...` URL into an Add-dialog prefill.
- * Returns `null` for any URL that isn't a well-formed install link.
  *
  * - `args` is space-separated (each token may be percent-encoded).
  * - `transport` defaults to `stdio`; `http` requires a `url`.
  * - `env` keys come from repeatable `env` params (`env=KEY` or `env=KEY:secret`)
  *   — values are always left blank (secrets are entered by the user).
+ * - stdio commands are checked against {@link MCP_ALLOWED_COMMANDS}; a
+ *   disallowed command returns `{ ok: false }` rather than a prefill.
  */
-export function parseMcpInstallUrl(raw: string): McpInstallRequest | null {
+export function parseMcpInstallUrl(raw: string): McpInstallParseResult | null {
   let url: URL;
   try {
     url = new URL(raw);
@@ -50,6 +106,16 @@ export function parseMcpInstallUrl(raw: string): McpInstallRequest | null {
     return null;
   }
 
+  // Hard allowlist gate for stdio commands. A disallowed command is a
+  // well-formed install URL, so we surface it as `{ ok: false }` (not null) so
+  // the caller can tell the user exactly what was rejected.
+  if (transport === 'stdio' && !isAllowedMcpCommand(command)) {
+    return {
+      ok: false,
+      reason: `"${command}" is not an allowed MCP command. Allowed commands: ${MCP_ALLOWED_COMMANDS.join(', ')}.`,
+    };
+  }
+
   const argsRaw = (q.get('args') ?? '').trim();
   const args = argsRaw ? argsRaw.split(/\s+/) : [];
 
@@ -63,11 +129,17 @@ export function parseMcpInstallUrl(raw: string): McpInstallRequest | null {
     || 'server';
 
   return {
-    name,
-    command: transport === 'http' ? '' : command,
-    args: transport === 'http' ? [] : args,
-    env,
-    transport,
-    url: transport === 'http' ? serverUrl : null,
+    ok: true,
+    prefill: {
+      name,
+      command: transport === 'http' ? '' : command,
+      args: transport === 'http' ? [] : args,
+      env,
+      transport,
+      url: transport === 'http' ? serverUrl : null,
+      // Deep-link-sourced prefills are untrusted by construction — the dialog
+      // gates Test/Add behind an explicit acknowledgement.
+      untrusted: true,
+    },
   };
 }


### PR DESCRIPTION
Security + correctness fixes for the MCP registration UX (#410), found in a deep review before cutting an alpha. **Recommend landing before the next alpha** so testers never run the vulnerable build.

## 🔴 Critical — RCE via `notesage://mcp/install` deep links
An attacker-controllable link (any webpage/email) pre-filled the Add dialog with an arbitrary `command`; clicking the benign-looking **"Test"** (or "Add", which validates inline) invoked `mcp_validate_server`, which **spawns the command** — one-click arbitrary code execution. Closed two ways:
- **Allowlist** (`deeplink.ts`): `parseMcpInstallUrl` now returns `{ok:true|false}`; a deep-link stdio `command` must be exactly one of `npx/uvx/uv/node/python/python3/deno/bun/bunx` (no path separators). Disallowed → toast, dialog never opens, spawn unreachable.
- **Consent gate** (`McpServersSettings.tsx`): deep-link-sourced prefills render a destructive warning + an "I've reviewed this and trust the source" checkbox; **Test/Add are disabled until ticked** (plus early-return defense-in-depth). Neutralizes allowlisted-but-malicious `npx -y <pkg>`. Catalog/manual adds unchanged.

## 🟠 High — SSRF in OAuth discovery
`authorization_servers` / `token_endpoint` / etc. taken from attacker-controlled `.well-known` metadata were fetched unvalidated (e.g. `http://169.254.169.254/...` cloud metadata). Added `validate_external_url` (https-only; rejects loopback/private/link-local/ULA IP literals + `localhost`/`*.localhost`), applied at **all 8** externally-influenced fetch sites in `mcp_oauth.rs`.

## 🔴 Functional — auto-start transport bug
`useMcpOperations` launch-time auto-start omitted `transport`/`url`, so HTTP MCP servers silently launched as stdio. Now sends the full payload.

## Known residuals (out of scope, documented)
- SSRF guard validates the literal URL, not DNS-rebinding (would need connect-time address pinning).
- The consent gate is informed-consent, not a hard block, for allowlisted `npx`-style packages — by design.

## Test plan
- [x] `pnpm typecheck` clean
- [x] Full unit suite — **5305 passed** (deep-link allowlist + return shape, consent-gate disable logic, auto-start payload)
- [x] Full Rust suite — **791 + 9 passed** (6 `validate_external_url` cases: cloud-metadata, localhost, private IPv4, internal IPv6, non-https all rejected)
- [x] Re-traced the kill chain: `notesage://mcp/install?command=/bin/bash…` → `{ok:false}` → toast, no dialog, no spawn

🤖 Generated with [Claude Code](https://claude.com/claude-code)