### PR TITLE
chore: release v0.46.0-alpha.16

### DIFF
--- a/docs/history/141-release-v0.46.0-alpha.16.md
+++ b/docs/history/141-release-v0.46.0-alpha.16.md
@@ -1,0 +1,23 @@
+# Release v0.46.0-alpha.16
+
+**Date:** 2026-06-07
+**Previous version:** 0.46.0-alpha.15
+**Channel:** Alpha
+
+Auto-cut by `aw-alpha-cut` after Tier-A/B PRs landed. The auto-dump under "Under the hood" lists the merged PRs verbatim.
+
+Before promoting this alpha to stable, edit this file:
+  - Move anything user-visible from "Under the hood" into "## Changes" under `### Features`, `### Improvements`, or `### Fixes` — and rewrite each bullet in user-facing prose (drop PR titles, version triples, internal jargon).
+  - Leave "## Changes" as `_No user-visible changes._` for infra-only releases.
+  - See `feedback_user_facing_release_notes.md` and `scripts/generate-changelog.ts` linter rules.
+
+## Changes
+
+_No user-visible changes._
+
+## Under the hood
+
+Auto-generated dump of merged Tier-A/B PRs. Rewrite as prose grouped by area before stable promotion.
+
+- feat(telemetry): usage analytics (Aptabase) + crash reporting (Sentry), channel-based opt-out (#423)
+- chore(mcp): remove unused WWW-Authenticate parsing helpers (#425)

--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -144,3 +144,4 @@ Chronological log of major implementation milestones and changes.
 | 138 | [Release v0.46.0-alpha.13](138-release-v0.46.0-alpha.13.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
 | 139 | [Release v0.46.0-alpha.14](139-release-v0.46.0-alpha.14.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
 | 140 | [Release v0.46.0-alpha.15](140-release-v0.46.0-alpha.15.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
+| 141 | [Release v0.46.0-alpha.16](141-release-v0.46.0-alpha.16.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "notesage",
   "private": true,
-  "version": "0.46.0-alpha.15",
+  "version": "0.46.0-alpha.16",
   "license": "MIT",
   "author": "Peter Blenessy",
   "type": "module",

--- a/public/changelog-alpha.json
+++ b/public/changelog-alpha.json
@@ -1,6 +1,16 @@
 {
   "releases": [
     {
+      "version": "0.46.0-alpha.16",
+      "date": "2026-06-07",
+      "previousVersion": "0.46.0",
+      "sections": {},
+      "underTheHood": [
+        "feat(telemetry): usage analytics (Aptabase) + crash reporting (Sentry), channel-based opt-out (#423)",
+        "chore(mcp): remove unused WWW-Authenticate parsing helpers (#425)"
+      ]
+    },
+    {
       "version": "0.46.0-alpha.15",
       "date": "2026-06-07",
       "previousVersion": "0.46.0",


### PR DESCRIPTION
Auto-cut by `aw-alpha-cut`. The history file at `docs/history/141-release-v0.46.0-alpha.16.md` lists the merged PRs.

## PRs included

- #423
- #425

Auto-merge enabled. Once the 4 required status checks pass, this merges to main, and the `tag-after-merge` job in `aw-alpha-cut.yml` tags + pushes `v0.46.0-alpha.16`. `release.yml` then builds and publishes.
