### PR TITLE
fix(quiet): stop StatusTray mic tooltip auto-opening; fully hide sidebar in focus mode

### DIFF
--- a/src/components/editor/StatusTray.tsx
+++ b/src/components/editor/StatusTray.tsx
@@ -766,17 +766,17 @@ export function StatusTray({
   );
 
   // `onOpenAutoFocus` runs after Radix has mounted the popover content.
-  // When a dot has pre-selected a group, intercept the default autofocus
-  // (which would land on the first focusable descendant — typically the
-  // Completions "Off" radio) and steer focus + scroll to the requested
-  // group root instead. Without this, Radix would win the focus race and
-  // any scrollIntoView we did in a later tick would be overridden.
+  // ALWAYS prevent Radix's default autofocus: it lands on the first focusable
+  // descendant — the recording `MicButton` — whose focus-triggered Radix
+  // tooltip then auto-opens on every popover open (the tooltip looks "stuck").
+  // Focus stays on the trigger; Tab still reaches the controls. When a dot has
+  // pre-selected a group, steer focus + scroll to that group root instead.
   const handleOpenAutoFocus = React.useCallback(
     (e: Event) => {
+      e.preventDefault();
       if (!initialExpandedGroup) return;
       const target = resolveGroup(initialExpandedGroup);
       if (!target) return;
-      e.preventDefault();
       target.scrollIntoView({ block: "nearest" });
       target.focus({ preventScroll: true });
     },

--- a/src/components/editor/__tests__/StatusTray.test.tsx
+++ b/src/components/editor/__tests__/StatusTray.test.tsx
@@ -724,6 +724,37 @@ describe('StatusTray — task #53', () => {
     expect(spy).not.toHaveBeenCalled();
   });
 
+  it('does not autofocus a control on open (mic tooltip would auto-show) (#bug)', async () => {
+    const editor = createMockEditor() as unknown as Editor;
+    function Harness() {
+      const [open, setOpen] = React.useState(false);
+      return (
+        <div>
+          <button data-testid="opener" onClick={() => setOpen(true)}>
+            open
+          </button>
+          <TrayHost open={open} onOpenChange={setOpen} editor={editor} />
+        </div>
+      );
+    }
+
+    renderWithProviders(<Harness />);
+    const opener = document.querySelector('[data-testid="opener"]') as HTMLElement;
+    await act(async () => {
+      fireEvent.click(opener);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    });
+
+    // Radix's default autofocus is prevented, so focus must NOT land on the
+    // recording MicButton (whose focus-triggered tooltip would otherwise stick
+    // open on every popover open).
+    const micButton = document
+      .querySelector('[aria-label="Editor tools"]')
+      ?.querySelector('button');
+    expect(micButton).toBeTruthy();
+    expect(document.activeElement).not.toBe(micButton);
+  });
+
   // -------------------------------------------------------------------------
   // Editor tools (#110) — MicButton + source-mode toggle
   // -------------------------------------------------------------------------

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -887,12 +887,19 @@ body {
  * ========================================================================= */
 /* Sidebar lives at the layout-root level (sibling of the title-bar +
    doc-area column) since live-test 2026-04-25 — the selector no
-   longer descends through `[data-quiet-layout-document-area]`. */
+   longer descends through `[data-quiet-layout-document-area]`.
+
+   Focus mode fully HIDES the sidebar (Quiet Composer is the only shell):
+   a negative left margin equal to its own width collapses the reserved
+   252 px track so the document column reclaims the space, while the nav
+   slides off the left edge (clipped by the layout root's `overflow-hidden`)
+   and fades out. `var(--quiet-sidebar-width)` is published by QuietLayout
+   (252 px when pinned), so the collapse always matches the actual width. */
 .app.focus-mode nav[aria-label="Workspace sidebar"] {
   opacity: 0;
-  transform: translateX(-12px);
+  margin-left: calc(-1 * var(--quiet-sidebar-width, 252px));
   pointer-events: none;
-  transition: opacity 220ms ease-out, transform 220ms ease-out;
+  transition: opacity 220ms ease-out, margin-left 220ms ease-out;
 }
 .app.focus-mode [data-quiet-toolbar],
 .app.focus-mode [data-quiet-status] {


### PR DESCRIPTION
## Summary

Two UI bugs in the Quiet Composer shell (the only shell now that Classic Layout is removed):

1. **StatusTray mic tooltip stays open** — opening the status-bar popover let Radix's default autofocus land on the first control (the recording `MicButton`), and its focus-triggered Radix tooltip then auto-opened on every popover open (looked stuck). `onOpenAutoFocus` now **always** prevents the default focus — keeping focus on the trigger, so Tab still reaches the controls — and only steers focus when a group was pre-selected via `initialExpandedGroup`.

2. **Focus mode (⌘.) didn't hide the sidebar** — it only faded the sidebar and nudged it 12px left while keeping its full 252px column, so a blank gap remained. It now **fully collapses**: a negative left margin equal to its width (`var(--quiet-sidebar-width)`) reclaims the track while the nav slides off the left edge (clipped by the layout root's `overflow-hidden`) and fades out. The document column reclaims the space.

## Test plan
- `pnpm typecheck` — clean
- `pnpm test` (StatusTray / QuietLayout / reduced-motion-sweep / useFocusMode) — passing, incl. a new regression that the tray does not autofocus the mic button on open
- Reduced-motion guard for the focus-mode sidebar transition still asserted by `reduced-motion-sweep.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
