### PR TITLE
chore: release v0.46.0-alpha.17

### DIFF
--- a/docs/history/142-release-v0.46.0-alpha.17.md
+++ b/docs/history/142-release-v0.46.0-alpha.17.md
@@ -1,0 +1,23 @@
+# Release v0.46.0-alpha.17
+
+**Date:** 2026-06-08
+**Previous version:** 0.46.0-alpha.16
+**Channel:** Alpha
+
+Auto-cut by `aw-alpha-cut` after Tier-A/B PRs landed. The auto-dump under "Under the hood" lists the merged PRs verbatim.
+
+Before promoting this alpha to stable, edit this file:
+  - Move anything user-visible from "Under the hood" into "## Changes" under `### Features`, `### Improvements`, or `### Fixes` — and rewrite each bullet in user-facing prose (drop PR titles, version triples, internal jargon).
+  - Leave "## Changes" as `_No user-visible changes._` for infra-only releases.
+  - See `feedback_user_facing_release_notes.md` and `scripts/generate-changelog.ts` linter rules.
+
+## Changes
+
+_No user-visible changes._
+
+## Under the hood
+
+Auto-generated dump of merged Tier-A/B PRs. Rewrite as prose grouped by area before stable promotion.
+
+- feat(recording): orb panel controls, pause/resume, and richer transcript items (#427)
+- fix(quiet): stop StatusTray mic tooltip auto-opening; fully hide sidebar in focus mode (#428)

--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -145,3 +145,4 @@ Chronological log of major implementation milestones and changes.
 | 139 | [Release v0.46.0-alpha.14](139-release-v0.46.0-alpha.14.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
 | 140 | [Release v0.46.0-alpha.15](140-release-v0.46.0-alpha.15.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
 | 141 | [Release v0.46.0-alpha.16](141-release-v0.46.0-alpha.16.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
+| 142 | [Release v0.46.0-alpha.17](142-release-v0.46.0-alpha.17.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "notesage",
   "private": true,
-  "version": "0.46.0-alpha.16",
+  "version": "0.46.0-alpha.17",
   "license": "MIT",
   "author": "Peter Blenessy",
   "type": "module",

--- a/public/changelog-alpha.json
+++ b/public/changelog-alpha.json
@@ -1,6 +1,16 @@
 {
   "releases": [
     {
+      "version": "0.46.0-alpha.17",
+      "date": "2026-06-08",
+      "previousVersion": "0.46.0",
+      "sections": {},
+      "underTheHood": [
+        "feat(recording): orb panel controls, pause/resume, and richer transcript items (#427)",
+        "fix(quiet): stop StatusTray mic tooltip auto-opening; fully hide sidebar in focus mode (#428)"
+      ]
+    },
+    {
       "version": "0.46.0-alpha.16",
       "date": "2026-06-07",
       "previousVersion": "0.46.0",


### PR DESCRIPTION
Auto-cut by `aw-alpha-cut`. The history file at `docs/history/142-release-v0.46.0-alpha.17.md` lists the merged PRs.

## PRs included

- #427
- #428

Auto-merge enabled. Once the 4 required status checks pass, this merges to main, and the `tag-after-merge` job in `aw-alpha-cut.yml` tags + pushes `v0.46.0-alpha.17`. `release.yml` then builds and publishes.
