### PR TITLE
fix(startup): enter a Tokio runtime before the Tauri builder (alpha.17/18 launch crash)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -204,6 +204,41 @@ jobs:
         working-directory: src-tauri
         run: cargo test
 
+      # Regression guard for the v0.46.0-alpha.17/18 startup crash: with
+      # NOTESAGE_APTABASE_KEY set, the Aptabase plugin registers and its setup
+      # hook calls tokio::spawn — which panics ("there is no reactor running")
+      # unless run() enters a Tokio runtime first. Keyless test/dev builds never
+      # register the plugin, so ONLY a key'd launch reproduces it. We build with
+      # a dummy key and launch briefly, asserting the app gets past plugin setup
+      # (reaches the "starting up" hook) without the reactor panic.
+      - name: Smoke-launch with telemetry key (aptabase startup-panic regression)
+        working-directory: src-tauri
+        env:
+          NOTESAGE_APTABASE_KEY: "A-DEV-0000000000"
+        run: |
+          cargo build --bin notesage
+          BIN=target/debug/notesage
+          echo "Launching $BIN for 20s to verify it survives plugin setup…"
+          # The webview may fail to load in headless CI (no dev server) AFTER
+          # plugin setup — that's fine; we only assert plugin init succeeds.
+          "$BIN" > smoke.log 2>&1 &
+          PID=$!
+          sleep 20
+          kill "$PID" 2>/dev/null || true
+          wait "$PID" 2>/dev/null || true
+          echo "----- smoke.log (tail) -----"
+          tail -40 smoke.log || true
+          echo "----------------------------"
+          if grep -qi "there is no reactor running" smoke.log; then
+            echo "::error::Startup panic from the telemetry plugin reproduced — run() must enter a Tokio runtime before the Tauri builder. See src-tauri/src/lib.rs build_app_runtime()."
+            exit 1
+          fi
+          if ! grep -q "Notesage starting up" smoke.log; then
+            echo "::error::App did not reach the 'starting up' setup hook within 20s with the telemetry plugin registered — startup is broken."
+            exit 1
+          fi
+          echo "OK: app reached startup with the telemetry plugin registered; no reactor panic."
+
   real-e2e-tests:
     name: Real Tauri E2E Tests
     # Pinned to `macos-26` (not `macos-latest`) to escape the Safari 26.5

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -46,8 +46,36 @@ fn set_log_level(level: String) {
 const SENTRY_DSN: Option<&str> = option_env!("NOTESAGE_SENTRY_DSN");
 const APTABASE_KEY: Option<&str> = option_env!("NOTESAGE_APTABASE_KEY");
 
+/// Build the process-wide multi-threaded Tokio runtime that `run()` enters
+/// before the Tauri builder starts. Entering this runtime on the main thread is
+/// what gives plugin `setup` hooks a reactor for `tokio::spawn`
+/// (tauri-plugin-aptabase's `start_polling`); without it the app panics at
+/// startup with "there is no reactor running" — see `run()` and the regression
+/// test below.
+fn build_app_runtime() -> tokio::runtime::Runtime {
+    tokio::runtime::Runtime::new().expect("failed to build Tokio runtime")
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // Establish and ENTER a Tokio runtime for the whole process BEFORE the
+    // Tauri builder runs. Some plugins call the global `tokio::spawn` from their
+    // `setup` hook (notably `tauri-plugin-aptabase`'s `start_polling`), which
+    // panics with "there is no reactor running, must be called from the context
+    // of a Tokio 1.x runtime" unless a runtime is entered on the main thread at
+    // plugin-setup time. Tauri's default runtime is not entered there, so we
+    // create one, hand it to Tauri (`async_runtime::set`) so everything shares a
+    // single runtime, and keep the enter-guard alive for the app's lifetime.
+    //
+    // This only manifested once `NOTESAGE_APTABASE_KEY` was wired into release
+    // builds (v0.46.0-alpha.17+): without the key the Aptabase plugin is never
+    // registered, so the panic never fired — which is why dev/local builds and
+    // earlier alphas were unaffected. `runtime` + `_runtime_guard` are held as
+    // locals through the blocking `builder.run(...)` call below.
+    let runtime = build_app_runtime();
+    tauri::async_runtime::set(runtime.handle().clone());
+    let _runtime_guard = runtime.enter();
+
     // Build the Sentry client ONCE up front so the panic hook installs exactly
     // once. The returned guard is `mem::forget`-ed (we keep the client alive for
     // the whole process via `telemetry::set_sentry_client`); dropping it would
@@ -469,4 +497,44 @@ pub fn run() {
                 _ => {}
             }
         });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression for the v0.46.0-alpha.17/18 startup crash: tauri-plugin-aptabase
+    /// calls `tokio::spawn` from its plugin `setup` hook, which panics with
+    /// "there is no reactor running, must be called from the context of a Tokio
+    /// 1.x runtime" unless a runtime is ENTERED on the main thread before the
+    /// Tauri builder runs. This proves `build_app_runtime()` + `enter()` is the
+    /// mechanism that prevents it.
+    ///
+    /// This test only exercises the runtime mechanism. The end-to-end guard —
+    /// actually launching a build with `NOTESAGE_APTABASE_KEY` set so the plugin
+    /// registers — lives in CI (`.github/workflows/test.yml`), because the plugin
+    /// is never registered in a keyless test/dev build.
+    #[test]
+    fn entered_app_runtime_provides_a_reactor_for_plugin_setup() {
+        // Failure precondition: with no runtime entered on this thread, there is
+        // no reactor — exactly the state that made aptabase's `tokio::spawn` panic.
+        assert!(
+            tokio::runtime::Handle::try_current().is_err(),
+            "test thread must start with no entered runtime",
+        );
+
+        let rt = build_app_runtime();
+        {
+            let _guard = rt.enter();
+            // A reactor is now available on this thread …
+            assert!(
+                tokio::runtime::Handle::try_current().is_ok(),
+                "entering the app runtime must provide a reactor",
+            );
+            // … so the spawn that aptabase's `start_polling` performs no longer
+            // panics. `spawn` returning a handle (rather than unwinding) is the
+            // assertion; the task itself is a no-op.
+            let _join = tokio::spawn(async {});
+        }
+    }
 }


### PR DESCRIPTION
## Critical: all v0.46.0-alpha.17/18 users can't launch the app

```
thread 'main' panicked at tauri-plugin-aptabase-1.0.0/src/client.rs:78:
there is no reactor running, must be called from the context of a Tokio 1.x runtime
```

### Root cause
`tauri-plugin-aptabase`'s plugin `setup` hook calls the global `tokio::spawn` (`start_polling`), which panics unless a Tokio runtime is **entered on the main thread** before the Tauri builder runs. Tauri's default runtime isn't entered at plugin-setup time.

The plugin only registers when `NOTESAGE_APTABASE_KEY` is set at build time. That secret was wired into release builds starting with **alpha.17**, so 17/18 are the first builds where the plugin loads — bricking every launch. Keyless dev/local/test builds never register it, which is exactly why every test passed.

### Fix
`run()` builds a Tokio runtime, hands it to Tauri (`async_runtime::set`), and **enters** it for the process lifetime (`build_app_runtime()`), so plugin-setup `tokio::spawn` has a reactor.

### Regression guards
- **Rust unit test** — proves the runtime-enter mechanism gives `tokio::spawn` a reactor.
- **CI smoke step** (Rust job) — builds with a dummy `NOTESAGE_APTABASE_KEY` and launches the binary, failing if the reactor panic reappears or the app never reaches the `starting up` hook. This is the only way to catch the class of bug, since keyless builds don't register the plugin.

### Verified locally
- key + **no fix** → panics at `client.rs:78`, app exits.
- key + **fix** → reaches `Notesage starting up`, no panic, stays running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
