### PR TITLE
chore: release v0.46.0-alpha.19

### DIFF
--- a/docs/history/144-release-v0.46.0-alpha.19.md
+++ b/docs/history/144-release-v0.46.0-alpha.19.md
@@ -1,0 +1,22 @@
+# Release v0.46.0-alpha.19
+
+**Date:** 2026-06-08
+**Previous version:** 0.46.0-alpha.18
+**Channel:** Alpha
+
+Auto-cut by `aw-alpha-cut` after Tier-A/B PRs landed. The auto-dump under "Under the hood" lists the merged PRs verbatim.
+
+Before promoting this alpha to stable, edit this file:
+  - Move anything user-visible from "Under the hood" into "## Changes" under `### Features`, `### Improvements`, or `### Fixes` — and rewrite each bullet in user-facing prose (drop PR titles, version triples, internal jargon).
+  - Leave "## Changes" as `_No user-visible changes._` for infra-only releases.
+  - See `feedback_user_facing_release_notes.md` and `scripts/generate-changelog.ts` linter rules.
+
+## Changes
+
+_No user-visible changes._
+
+## Under the hood
+
+Auto-generated dump of merged Tier-A/B PRs. Rewrite as prose grouped by area before stable promotion.
+
+- fix(startup): enter a Tokio runtime before the Tauri builder (alpha.17/18 launch crash) (#432)

--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -147,3 +147,4 @@ Chronological log of major implementation milestones and changes.
 | 141 | [Release v0.46.0-alpha.16](141-release-v0.46.0-alpha.16.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
 | 142 | [Release v0.46.0-alpha.17](142-release-v0.46.0-alpha.17.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
 | 143 | [Release v0.46.0-alpha.18](143-release-v0.46.0-alpha.18.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
+| 144 | [Release v0.46.0-alpha.19](144-release-v0.46.0-alpha.19.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "notesage",
   "private": true,
-  "version": "0.46.0-alpha.18",
+  "version": "0.46.0-alpha.19",
   "license": "MIT",
   "author": "Peter Blenessy",
   "type": "module",

--- a/public/changelog-alpha.json
+++ b/public/changelog-alpha.json
@@ -1,6 +1,15 @@
 {
   "releases": [
     {
+      "version": "0.46.0-alpha.19",
+      "date": "2026-06-08",
+      "previousVersion": "0.46.0",
+      "sections": {},
+      "underTheHood": [
+        "fix(startup): enter a Tokio runtime before the Tauri builder (alpha.17/18 launch crash) (#432)"
+      ]
+    },
+    {
       "version": "0.46.0-alpha.18",
       "date": "2026-06-08",
       "previousVersion": "0.46.0",


### PR DESCRIPTION
Auto-cut by `aw-alpha-cut`. The history file at `docs/history/144-release-v0.46.0-alpha.19.md` lists the merged PRs.

## PRs included

- #432

Auto-merge enabled. Once the 4 required status checks pass, this merges to main, and the `tag-after-merge` job in `aw-alpha-cut.yml` tags + pushes `v0.46.0-alpha.19`. `release.yml` then builds and publishes.
