### PR TITLE
docs(changelog): backfill real alpha.14–19 notes + fix the generator

### DIFF
--- a/.github/workflows/aw-alpha-cut.yml
+++ b/.github/workflows/aw-alpha-cut.yml
@@ -239,7 +239,6 @@ jobs:
       - name: Generate history file from merged PRs
         env:
           GH_TOKEN: ${{ secrets.WORKFLOW_PAT }}
-          PR_NUMBERS: ${{ needs.preflight.outputs.pr_numbers }}
           PREVIOUS_TAG: ${{ needs.preflight.outputs.previous_tag }}
           NEXT_VERSION: ${{ needs.preflight.outputs.next_version }}
           NEXT_NUMBER: ${{ needs.preflight.outputs.next_history_number }}
@@ -249,6 +248,33 @@ jobs:
           DATE=$(date -u +%Y-%m-%d)
           FILE="docs/history/${NEXT_NUMBER}-release-v${NEXT_VERSION}.md"
 
+          # Enumerate EVERY PR merged since the previous tag — squash commits
+          # ("title (#N)") and merge commits ("Merge pull request #N") alike.
+          # The old approach used a tier-label-filtered `gh pr list`, which
+          # silently dropped untiered PRs (alpha.14 lost the whole MCP overhaul).
+          # Sourcing from the git range guarantees nothing is missed.
+          mapfile -t ALL_PRS < <(
+            git log "${PREVIOUS_TAG}..HEAD" --format='%s %b' \
+              | grep -oE '#[0-9]+' | tr -d '#' | sort -un
+          )
+
+          feat=(); fix=(); imp=(); hood=()
+          for pr in "${ALL_PRS[@]}"; do
+            title=$(gh pr view "$pr" --json title --jq .title 2>/dev/null) || continue
+            [ -z "$title" ] && continue
+            # Skip the release PR itself.
+            case "$title" in chore*release*|*auto-cut*) continue;; esac
+            line="- ${title} (#${pr})"
+            # Classify by conventional-commit type so user-facing work lands in
+            # the right section instead of all being dumped "under the hood".
+            case "$title" in
+              feat*)            feat+=("$line");;
+              fix*)             fix+=("$line");;
+              perf*|refactor*)  imp+=("$line");;
+              *)                hood+=("$line");;
+            esac
+          done
+
           {
             echo "# Release v${NEXT_VERSION}"
             echo ""
@@ -256,26 +282,29 @@ jobs:
             echo "**Previous version:** ${PREVIOUS_TAG#v}"
             echo "**Channel:** Alpha"
             echo ""
-            echo "Auto-cut by \`aw-alpha-cut\` after Tier-A/B PRs landed. The auto-dump under \"Under the hood\" lists the merged PRs verbatim."
-            echo ""
-            echo "Before promoting this alpha to stable, edit this file:"
-            echo "  - Move anything user-visible from \"Under the hood\" into \"## Changes\" under \`### Features\`, \`### Improvements\`, or \`### Fixes\` — and rewrite each bullet in user-facing prose (drop PR titles, version triples, internal jargon)."
-            echo "  - Leave \"## Changes\" as \`_No user-visible changes._\` for infra-only releases."
-            echo "  - See \`feedback_user_facing_release_notes.md\` and \`scripts/generate-changelog.ts\` linter rules."
+            echo "Auto-cut by \`aw-alpha-cut\`. Sections below are auto-classified from merged PRs; refine the prose before promoting to stable."
             echo ""
             echo "## Changes"
             echo ""
-            echo "_No user-visible changes._"
-            echo ""
+            if [ ${#feat[@]} -eq 0 ] && [ ${#fix[@]} -eq 0 ] && [ ${#imp[@]} -eq 0 ]; then
+              echo "_No user-visible changes._"
+              echo ""
+            else
+              if [ ${#feat[@]} -gt 0 ]; then echo "### Features"; printf '%s\n' "${feat[@]}"; echo ""; fi
+              if [ ${#fix[@]}  -gt 0 ]; then echo "### Fixes";    printf '%s\n' "${fix[@]}";  echo ""; fi
+              if [ ${#imp[@]}  -gt 0 ]; then echo "### Improvements"; printf '%s\n' "${imp[@]}"; echo ""; fi
+            fi
             echo "## Under the hood"
             echo ""
-            echo "Auto-generated dump of merged Tier-A/B PRs. Rewrite as prose grouped by area before stable promotion."
+            echo "Auto-generated from merged PRs + commits since \`${PREVIOUS_TAG}\`. Alpha builds list commit-level detail for technical users."
             echo ""
-            IFS=',' read -ra PRS <<< "$PR_NUMBERS"
-            for pr in "${PRS[@]}"; do
-              title=$(gh pr view "$pr" --json title --jq .title)
-              echo "- ${title} (#${pr})"
-            done
+            if [ ${#hood[@]} -gt 0 ]; then printf '%s\n' "${hood[@]}"; fi
+            # Commit-level detail (alpha channel targets technical users). These
+            # `- ` lines are also surfaced in the in-app changelog's "Under the
+            # hood" list by scripts/generate-changelog.ts.
+            git log "${PREVIOUS_TAG}..HEAD" --no-merges --format='- %s' \
+              | grep -viE 'chore: release|auto-cut|Generate history|Regenerate changelog|Update history README' \
+              || true
           } > "$FILE"
 
           cat "$FILE"

--- a/docs/history/139-release-v0.46.0-alpha.14.md
+++ b/docs/history/139-release-v0.46.0-alpha.14.md
@@ -4,19 +4,34 @@
 **Previous version:** 0.46.0-alpha.13
 **Channel:** Alpha
 
-Auto-cut by `aw-alpha-cut` after Tier-A/B PRs landed. The auto-dump under "Under the hood" lists the merged PRs verbatim.
-
-Before promoting this alpha to stable, edit this file:
-  - Move anything user-visible from "Under the hood" into "## Changes" under `### Features`, `### Improvements`, or `### Fixes` — and rewrite each bullet in user-facing prose (drop PR titles, version triples, internal jargon).
-  - Leave "## Changes" as `_No user-visible changes._` for infra-only releases.
-  - See `feedback_user_facing_release_notes.md` and `scripts/generate-changelog.ts` linter rules.
+Major MCP (Model Context Protocol) registration overhaul: remote HTTP servers, OAuth 2.1, a curated catalog, keychain-stored secrets, and one-click deep-link install — plus a security hardening pass on the MCP surface.
 
 ## Changes
 
-_No user-visible changes._
+### Features
+- Connect to **remote (Streamable HTTP) MCP servers**, not just local stdio ones — added end to end (backend transport + settings UI) (#410).
+- **OAuth 2.1 for protected MCP servers**: authorization-code + PKCE, RFC 9728/8414 discovery, dynamic client registration, a loopback callback, and token refresh — tokens stored in the OS keychain with an in-app "Re-authenticate" / "Sign out" flow (#410).
+- **Curated MCP server catalog**: a "Browse catalog" picker seeded with the official reference servers (Filesystem, Fetch, Memory, Git, Sequential Thinking, Time, Everything), each badged "Official" with provenance links (#410).
+- **Validate-on-add**: adding a server runs a dry-run handshake (connect → initialize → list tools) and previews its tools before anything is written to `mcp.json` (#410).
+- **Env secrets in the keychain**: MCP server environment values flagged secret are stored in the OS keychain and resolved only at spawn — `mcp.json` keeps just a reference, never the value (#410).
+- **One-click install** via `notesage://mcp/install?…` deep-links that open the validate-first Add dialog pre-filled (#410).
+
+### Fixes
+- **Security**: closed a deep-link RCE and an OAuth SSRF on the MCP surface, and fixed an MCP server auto-start transport bug (#419).
 
 ## Under the hood
-
-Auto-generated dump of merged Tier-A/B PRs. Rewrite as prose grouped by area before stable promotion.
-
-- fix(mcp): close deep-link RCE + OAuth SSRF (security) (#419)
+- Add remote (Streamable HTTP) MCP transport — backend (#410)
+- Wire remote (HTTP) MCP servers into the UI (#410)
+- Validate MCP servers before writing them (validate-on-add) (#410)
+- Add MCP catalog scaffolding (empty manifest), then seed it with official reference servers + provenance badges (#410)
+- Add OAuth 2.1 core for remote MCP servers (PKCE, token storage) — part 1 (#410)
+- Wire the OAuth authorization-code + PKCE flow — part 2 (#410)
+- Add OAuth authorize / re-auth UI for remote MCP servers — part 3 (#410)
+- Use the `oauth2` crate for MCP OAuth instead of hand-rolling (#410)
+- Resolve MCP env secrets from the keychain at spawn — backend (#410)
+- Store MCP env secrets in the keychain from the UI — frontend (#410)
+- Add `notesage://mcp/install` deep-link for one-click MCP add (#410)
+- Polish MCP catalog card + fix pre-existing design-system violations in MCP settings (#410)
+- Document the MCP registration UX overhaul (PRD + task breakdown) (#410)
+- Refactor: extract `ProjectRow`, `ChildRow` + inline-edit/drag hooks from `ProjectsSection` (#416)
+- Reconcile `Cargo.lock` after dropping the unused `tauri-plugin-fs` during merge (#419)

--- a/docs/history/140-release-v0.46.0-alpha.15.md
+++ b/docs/history/140-release-v0.46.0-alpha.15.md
@@ -4,19 +4,12 @@
 **Previous version:** 0.46.0-alpha.14
 **Channel:** Alpha
 
-Auto-cut by `aw-alpha-cut` after Tier-A/B PRs landed. The auto-dump under "Under the hood" lists the merged PRs verbatim.
-
-Before promoting this alpha to stable, edit this file:
-  - Move anything user-visible from "Under the hood" into "## Changes" under `### Features`, `### Improvements`, or `### Fixes` — and rewrite each bullet in user-facing prose (drop PR titles, version triples, internal jargon).
-  - Leave "## Changes" as `_No user-visible changes._` for infra-only releases.
-  - See `feedback_user_facing_release_notes.md` and `scripts/generate-changelog.ts` linter rules.
+A small AI-settings clarity improvement.
 
 ## Changes
 
-_No user-visible changes._
+### Improvements
+- AI settings: the access / isolation controls are now grouped under a clearer **"Permission scopes"** heading (#422).
 
 ## Under the hood
-
-Auto-generated dump of merged Tier-A/B PRs. Rewrite as prose grouped by area before stable promotion.
-
-- feat: rename access/isolation grouping to "Permission scopes" in AI settings (#422)
+- Rename the access/isolation grouping to "Permission scopes" in AI settings (#422)

--- a/docs/history/141-release-v0.46.0-alpha.16.md
+++ b/docs/history/141-release-v0.46.0-alpha.16.md
@@ -4,20 +4,23 @@
 **Previous version:** 0.46.0-alpha.15
 **Channel:** Alpha
 
-Auto-cut by `aw-alpha-cut` after Tier-A/B PRs landed. The auto-dump under "Under the hood" lists the merged PRs verbatim.
+> ⚠️ **Broken build — does not launch.** This release crashes on startup (telemetry plugin Tokio-runtime panic). Fixed in alpha.19; the auto-updater no longer serves it. See #432.
 
-Before promoting this alpha to stable, edit this file:
-  - Move anything user-visible from "Under the hood" into "## Changes" under `### Features`, `### Improvements`, or `### Fixes` — and rewrite each bullet in user-facing prose (drop PR titles, version triples, internal jargon).
-  - Leave "## Changes" as `_No user-visible changes._` for infra-only releases.
-  - See `feedback_user_facing_release_notes.md` and `scripts/generate-changelog.ts` linter rules.
+Opt-in telemetry: privacy-first usage analytics and crash reporting, gated behind a consent toggle.
 
 ## Changes
 
-_No user-visible changes._
+### Features
+- **Opt-in telemetry** (#423):
+  - Usage analytics via **Aptabase** (privacy-first, EU/US regions).
+  - Crash reporting via **Sentry** (with a PII scrubber on the way out).
+  - Channel-based consent — nothing is sent until you opt in, and it can be toggled live in Settings.
 
 ## Under the hood
+- Usage analytics (Aptabase) + crash reporting (Sentry) with channel-based opt-out (#423)
+- Sentry client initialised once up front; crash egress gated at runtime by binding/unbinding the Hub client (#423)
+- `before_send` PII scrubber + breadcrumb capture disabled to avoid leaking file paths (#423)
+- Remove unused `WWW-Authenticate` parsing helpers from MCP OAuth (dead code) (#425)
 
-Auto-generated dump of merged Tier-A/B PRs. Rewrite as prose grouped by area before stable promotion.
-
-- feat(telemetry): usage analytics (Aptabase) + crash reporting (Sentry), channel-based opt-out (#423)
-- chore(mcp): remove unused WWW-Authenticate parsing helpers (#425)
+## Known issues
+- **Crashes on launch.** `tauri-plugin-aptabase`'s `start_polling` calls `tokio::spawn` during plugin setup with no Tokio runtime entered → panic. This is the first release built with the Aptabase key, so it's the first to hit it. Fixed in alpha.19 (#432).

--- a/docs/history/142-release-v0.46.0-alpha.17.md
+++ b/docs/history/142-release-v0.46.0-alpha.17.md
@@ -4,20 +4,29 @@
 **Previous version:** 0.46.0-alpha.16
 **Channel:** Alpha
 
-Auto-cut by `aw-alpha-cut` after Tier-A/B PRs landed. The auto-dump under "Under the hood" lists the merged PRs verbatim.
+> ⚠️ **Broken build — does not launch.** Inherits the alpha.16 startup crash. Fixed in alpha.19; the auto-updater no longer serves it. See #432.
 
-Before promoting this alpha to stable, edit this file:
-  - Move anything user-visible from "Under the hood" into "## Changes" under `### Features`, `### Improvements`, or `### Fixes` — and rewrite each bullet in user-facing prose (drop PR titles, version triples, internal jargon).
-  - Leave "## Changes" as `_No user-visible changes._` for infra-only releases.
-  - See `feedback_user_facing_release_notes.md` and `scripts/generate-changelog.ts` linter rules.
+Meeting recordings are now fully driven from the agent orb, plus focus-mode and tooltip fixes.
 
 ## Changes
 
-_No user-visible changes._
+### Features
+- **Recording controls in the agent orb** (#427): stop, pause, and resume a meeting recording inline, with a pause-aware timer and a clock-style seconds animation distinct from the agent-activity pulse.
+- **Richer transcript items** (#427): click a finished transcript to open it, reveal it in Finder, or move it to a project; each shows **start – stop · length**.
+
+### Fixes
+- Stop the StatusTray mic tooltip from auto-opening when the popover opens (#428).
+- Focus mode (⌘.) now **fully hides the sidebar** instead of just dimming it (#428).
+- Fix transcript frontmatter rendering `[object Object]` for the `segments` array (#427).
 
 ## Under the hood
+- AgentOrb recording panel: stop/pause/resume controls + pause-aware duration from written samples (#427)
+- Seconds-ray ring animation that builds up one ray per second (#427)
+- Transcript card: open / Reveal in Finder / Move to project actions + start–stop · length info row (#427)
+- Rename recording bundles from "Meeting <timestamp>" to "Recording <timestamp>" (#427)
+- `pause_recording` / `resume_recording` Tauri commands; capture pause discards samples without tearing down the cpal stream (#427)
+- StatusTray popover: prevent default autofocus so the mic tooltip doesn't fire on open (#428)
+- Focus-mode CSS: collapse the sidebar's grid track so the document reclaims the space (#428)
 
-Auto-generated dump of merged Tier-A/B PRs. Rewrite as prose grouped by area before stable promotion.
-
-- feat(recording): orb panel controls, pause/resume, and richer transcript items (#427)
-- fix(quiet): stop StatusTray mic tooltip auto-opening; fully hide sidebar in focus mode (#428)
+## Known issues
+- **Crashes on launch** — inherits the alpha.16 telemetry-plugin runtime panic. Fixed in alpha.19 (#432).

--- a/docs/history/143-release-v0.46.0-alpha.18.md
+++ b/docs/history/143-release-v0.46.0-alpha.18.md
@@ -4,19 +4,19 @@
 **Previous version:** 0.46.0-alpha.17
 **Channel:** Alpha
 
-Auto-cut by `aw-alpha-cut` after Tier-A/B PRs landed. The auto-dump under "Under the hood" lists the merged PRs verbatim.
+> ⚠️ **Broken build — does not launch.** Inherits the alpha.16 startup crash. Fixed in alpha.19; the auto-updater no longer serves it. See #432.
 
-Before promoting this alpha to stable, edit this file:
-  - Move anything user-visible from "Under the hood" into "## Changes" under `### Features`, `### Improvements`, or `### Fixes` — and rewrite each bullet in user-facing prose (drop PR titles, version triples, internal jargon).
-  - Leave "## Changes" as `_No user-visible changes._` for infra-only releases.
-  - See `feedback_user_facing_release_notes.md` and `scripts/generate-changelog.ts` linter rules.
+Primary button labels are now legible on the accent fill.
 
 ## Changes
 
-_No user-visible changes._
+### Fixes
+- Primary and destructive buttons now keep a legible **white label + icon on the accent fill** in both light and dark mode (matching macOS System Settings), including a readable disabled state (#430).
 
 ## Under the hood
+- New `--color-on-accent` token: white on a chromatic accent in both themes, falling back to `--color-primary-foreground` on the neutral no-accent button (#430)
+- Default `Button` label uses `--color-on-accent` instead of `--color-primary-foreground` (which was dark-on-accent in dark mode) (#430)
+- Disabled buttons keep their label and dim via `opacity-70` instead of the unreadable grey `disabled:text-muted-foreground` (#430)
 
-Auto-generated dump of merged Tier-A/B PRs. Rewrite as prose grouped by area before stable promotion.
-
-- fix(ui): white label on primary buttons over the accent fill (macOS style) (#430)
+## Known issues
+- **Crashes on launch** — inherits the alpha.16 telemetry-plugin runtime panic. Fixed in alpha.19 (#432).

--- a/docs/history/144-release-v0.46.0-alpha.19.md
+++ b/docs/history/144-release-v0.46.0-alpha.19.md
@@ -4,19 +4,17 @@
 **Previous version:** 0.46.0-alpha.18
 **Channel:** Alpha
 
-Auto-cut by `aw-alpha-cut` after Tier-A/B PRs landed. The auto-dump under "Under the hood" lists the merged PRs verbatim.
-
-Before promoting this alpha to stable, edit this file:
-  - Move anything user-visible from "Under the hood" into "## Changes" under `### Features`, `### Improvements`, or `### Fixes` — and rewrite each bullet in user-facing prose (drop PR titles, version triples, internal jargon).
-  - Leave "## Changes" as `_No user-visible changes._` for infra-only releases.
-  - See `feedback_user_facing_release_notes.md` and `scripts/generate-changelog.ts` linter rules.
+Fixes the startup crash that bricked alpha.16–18.
 
 ## Changes
 
-_No user-visible changes._
+### Fixes
+- **Fixed the launch crash** affecting alpha.16, .17, and .18 (#432). The telemetry plugin ran `tokio::spawn` during startup with no Tokio runtime entered, panicking immediately; the app now enters a runtime before the Tauri builder so it launches cleanly.
 
 ## Under the hood
+- `run()` builds a Tokio runtime, hands it to Tauri (`async_runtime::set`), and enters it for the process lifetime before the builder runs (#432)
+- Rust unit test proving the entered runtime gives plugin-setup `tokio::spawn` a reactor (#432)
+- CI smoke-launch step builds with the telemetry key and actually starts the app, failing if the reactor panic returns or startup is never reached (#432)
 
-Auto-generated dump of merged Tier-A/B PRs. Rewrite as prose grouped by area before stable promotion.
-
-- fix(startup): enter a Tokio runtime before the Tauri builder (alpha.17/18 launch crash) (#432)
+## Upgrade note
+If you're stuck on a broken build (alpha.16–18), the app can't auto-update — download and install alpha.19 manually once, and auto-updates resume.

--- a/public/changelog-alpha.json
+++ b/public/changelog-alpha.json
@@ -3,63 +3,126 @@
     {
       "version": "0.46.0-alpha.19",
       "date": "2026-06-08",
-      "previousVersion": "0.46.0",
-      "sections": {},
+      "previousVersion": "0.46.0-alpha.18",
+      "sections": {
+        "fixes": [
+          "**Fixed the launch crash** affecting alpha.16, .17, and .18 (#432). The telemetry plugin ran `tokio::spawn` during startup with no Tokio runtime entered, panicking immediately; the app now enters a runtime before the Tauri builder so it launches cleanly."
+        ]
+      },
       "underTheHood": [
-        "fix(startup): enter a Tokio runtime before the Tauri builder (alpha.17/18 launch crash) (#432)"
+        "`run()` builds a Tokio runtime, hands it to Tauri (`async_runtime::set`), and enters it for the process lifetime before the builder runs (#432)",
+        "Rust unit test proving the entered runtime gives plugin-setup `tokio::spawn` a reactor (#432)",
+        "CI smoke-launch step builds with the telemetry key and actually starts the app, failing if the reactor panic returns or startup is never reached (#432)"
       ]
     },
     {
       "version": "0.46.0-alpha.18",
       "date": "2026-06-08",
-      "previousVersion": "0.46.0",
-      "sections": {},
+      "previousVersion": "0.46.0-alpha.17",
+      "sections": {
+        "fixes": [
+          "Primary and destructive buttons now keep a legible **white label + icon on the accent fill** in both light and dark mode (matching macOS System Settings), including a readable disabled state (#430)."
+        ]
+      },
       "underTheHood": [
-        "fix(ui): white label on primary buttons over the accent fill (macOS style) (#430)"
+        "New `--color-on-accent` token: white on a chromatic accent in both themes, falling back to `--color-primary-foreground` on the neutral no-accent button (#430)",
+        "Default `Button` label uses `--color-on-accent` instead of `--color-primary-foreground` (which was dark-on-accent in dark mode) (#430)",
+        "Disabled buttons keep their label and dim via `opacity-70` instead of the unreadable grey `disabled:text-muted-foreground` (#430)"
       ]
     },
     {
       "version": "0.46.0-alpha.17",
       "date": "2026-06-08",
-      "previousVersion": "0.46.0",
-      "sections": {},
+      "previousVersion": "0.46.0-alpha.16",
+      "sections": {
+        "features": [
+          "**Recording controls in the agent orb** (#427): stop, pause, and resume a meeting recording inline, with a pause-aware timer and a clock-style seconds animation distinct from the agent-activity pulse.",
+          "**Richer transcript items** (#427): click a finished transcript to open it, reveal it in Finder, or move it to a project; each shows **start – stop · length**."
+        ],
+        "fixes": [
+          "Stop the StatusTray mic tooltip from auto-opening when the popover opens (#428).",
+          "Focus mode (⌘.) now **fully hides the sidebar** instead of just dimming it (#428).",
+          "Fix transcript frontmatter rendering `[object Object]` for the `segments` array (#427)."
+        ]
+      },
       "underTheHood": [
-        "feat(recording): orb panel controls, pause/resume, and richer transcript items (#427)",
-        "fix(quiet): stop StatusTray mic tooltip auto-opening; fully hide sidebar in focus mode (#428)"
+        "AgentOrb recording panel: stop/pause/resume controls + pause-aware duration from written samples (#427)",
+        "Seconds-ray ring animation that builds up one ray per second (#427)",
+        "Transcript card: open / Reveal in Finder / Move to project actions + start–stop · length info row (#427)",
+        "Rename recording bundles from \"Meeting <timestamp>\" to \"Recording <timestamp>\" (#427)",
+        "`pause_recording` / `resume_recording` Tauri commands; capture pause discards samples without tearing down the cpal stream (#427)",
+        "StatusTray popover: prevent default autofocus so the mic tooltip doesn't fire on open (#428)",
+        "Focus-mode CSS: collapse the sidebar's grid track so the document reclaims the space (#428)"
       ]
     },
     {
       "version": "0.46.0-alpha.16",
       "date": "2026-06-07",
-      "previousVersion": "0.46.0",
-      "sections": {},
+      "previousVersion": "0.46.0-alpha.15",
+      "sections": {
+        "features": [
+          "**Opt-in telemetry** (#423):"
+        ]
+      },
       "underTheHood": [
-        "feat(telemetry): usage analytics (Aptabase) + crash reporting (Sentry), channel-based opt-out (#423)",
-        "chore(mcp): remove unused WWW-Authenticate parsing helpers (#425)"
+        "Usage analytics (Aptabase) + crash reporting (Sentry) with channel-based opt-out (#423)",
+        "Sentry client initialised once up front; crash egress gated at runtime by binding/unbinding the Hub client (#423)",
+        "`before_send` PII scrubber + breadcrumb capture disabled to avoid leaking file paths (#423)",
+        "Remove unused `WWW-Authenticate` parsing helpers from MCP OAuth (dead code) (#425)"
       ]
     },
     {
       "version": "0.46.0-alpha.15",
       "date": "2026-06-07",
-      "previousVersion": "0.46.0",
-      "sections": {},
+      "previousVersion": "0.46.0-alpha.14",
+      "sections": {
+        "improvements": [
+          "AI settings: the access / isolation controls are now grouped under a clearer **\"Permission scopes\"** heading (#422)."
+        ]
+      },
       "underTheHood": [
-        "feat: rename access/isolation grouping to \"Permission scopes\" in AI settings (#422)"
+        "Rename the access/isolation grouping to \"Permission scopes\" in AI settings (#422)"
       ]
     },
     {
       "version": "0.46.0-alpha.14",
       "date": "2026-06-04",
-      "previousVersion": "0.46.0",
-      "sections": {},
+      "previousVersion": "0.46.0-alpha.13",
+      "sections": {
+        "features": [
+          "Connect to **remote (Streamable HTTP) MCP servers**, not just local stdio ones — added end to end (backend transport + settings UI) (#410).",
+          "**OAuth 2.1 for protected MCP servers**: authorization-code + PKCE, RFC 9728/8414 discovery, dynamic client registration, a loopback callback, and token refresh — tokens stored in the OS keychain with an in-app \"Re-authenticate\" / \"Sign out\" flow (#410).",
+          "**Curated MCP server catalog**: a \"Browse catalog\" picker seeded with the official reference servers (Filesystem, Fetch, Memory, Git, Sequential Thinking, Time, Everything), each badged \"Official\" with provenance links (#410).",
+          "**Validate-on-add**: adding a server runs a dry-run handshake (connect → initialize → list tools) and previews its tools before anything is written to `mcp.json` (#410).",
+          "**Env secrets in the keychain**: MCP server environment values flagged secret are stored in the OS keychain and resolved only at spawn — `mcp.json` keeps just a reference, never the value (#410).",
+          "**One-click install** via `notesage://mcp/install?…` deep-links that open the validate-first Add dialog pre-filled (#410)."
+        ],
+        "fixes": [
+          "**Security**: closed a deep-link RCE and an OAuth SSRF on the MCP surface, and fixed an MCP server auto-start transport bug (#419)."
+        ]
+      },
       "underTheHood": [
-        "fix(mcp): close deep-link RCE + OAuth SSRF (security) (#419)"
+        "Add remote (Streamable HTTP) MCP transport — backend (#410)",
+        "Wire remote (HTTP) MCP servers into the UI (#410)",
+        "Validate MCP servers before writing them (validate-on-add) (#410)",
+        "Add MCP catalog scaffolding (empty manifest), then seed it with official reference servers + provenance badges (#410)",
+        "Add OAuth 2.1 core for remote MCP servers (PKCE, token storage) — part 1 (#410)",
+        "Wire the OAuth authorization-code + PKCE flow — part 2 (#410)",
+        "Add OAuth authorize / re-auth UI for remote MCP servers — part 3 (#410)",
+        "Use the `oauth2` crate for MCP OAuth instead of hand-rolling (#410)",
+        "Resolve MCP env secrets from the keychain at spawn — backend (#410)",
+        "Store MCP env secrets in the keychain from the UI — frontend (#410)",
+        "Add `notesage://mcp/install` deep-link for one-click MCP add (#410)",
+        "Polish MCP catalog card + fix pre-existing design-system violations in MCP settings (#410)",
+        "Document the MCP registration UX overhaul (PRD + task breakdown) (#410)",
+        "Refactor: extract `ProjectRow`, `ChildRow` + inline-edit/drag hooks from `ProjectsSection` (#416)",
+        "Reconcile `Cargo.lock` after dropping the unused `tauri-plugin-fs` during merge (#419)"
       ]
     },
     {
       "version": "0.46.0-alpha.13",
       "date": "2026-06-03",
-      "previousVersion": "0.46.0",
+      "previousVersion": "0.46.0-alpha.12",
       "sections": {},
       "underTheHood": [
         "Hardware-aware local model recommendation (Phase 1 + Phase 2 runtime calibration) (#409)"
@@ -68,7 +131,7 @@
     {
       "version": "0.46.0-alpha.12",
       "date": "2026-06-01",
-      "previousVersion": "0.46.0",
+      "previousVersion": "0.46.0-alpha.11",
       "sections": {},
       "underTheHood": [
         "chore(deps): bump tar from 0.4.45 to 0.4.46 in /src-tauri in the cargo group across 1 directory (#403)",
@@ -79,7 +142,7 @@
     {
       "version": "0.46.0-alpha.11",
       "date": "2026-05-31",
-      "previousVersion": "0.46.0",
+      "previousVersion": "0.46.0-alpha.10",
       "sections": {},
       "underTheHood": [
         "feat(transcription): meeting recording with background transcription (#398)",
@@ -92,7 +155,7 @@
     {
       "version": "0.46.0-alpha.10",
       "date": "2026-05-30",
-      "previousVersion": "0.46.0",
+      "previousVersion": "0.46.0-alpha.9",
       "sections": {},
       "underTheHood": [
         "ci(e2e-real): contain the WebDriver session-timeout cascade (#396)"
@@ -101,7 +164,7 @@
     {
       "version": "0.46.0-alpha.9",
       "date": "2026-05-30",
-      "previousVersion": "0.46.0",
+      "previousVersion": "0.46.0-alpha.8",
       "sections": {},
       "underTheHood": [
         "fix(sidebar): prune Recent and Pinned on external file delete (#392)"
@@ -110,7 +173,7 @@
     {
       "version": "0.46.0-alpha.8",
       "date": "2026-05-29",
-      "previousVersion": "0.46.0",
+      "previousVersion": "0.46.0-alpha.7",
       "sections": {},
       "underTheHood": [
         "fix(ci): fold auto-labelled PRs into alpha-cut ship list to dodge search lag (#387)"
@@ -119,7 +182,7 @@
     {
       "version": "0.46.0-alpha.7",
       "date": "2026-05-29",
-      "previousVersion": "0.46.0",
+      "previousVersion": "0.46.0-alpha.6",
       "sections": {},
       "underTheHood": [
         "feat(release): surface merged-PR dump in alpha release notes (#385)"
@@ -128,7 +191,7 @@
     {
       "version": "0.46.0-alpha.6",
       "date": "2026-05-29",
-      "previousVersion": "0.46.0",
+      "previousVersion": "0.46.0-alpha.5",
       "sections": {},
       "underTheHood": [
         "feat(ai): plumb response_format for schema-constrained local LLM output (#383)"
@@ -137,7 +200,7 @@
     {
       "version": "0.46.0-alpha.5",
       "date": "2026-05-28",
-      "previousVersion": "0.46.0",
+      "previousVersion": "0.46.0-alpha.4",
       "sections": {},
       "underTheHood": [
         "feat(quiet-chrome): extend Aggressive preset with title bar + cmd bar fade and mouse-only unfade (#381)"
@@ -146,7 +209,7 @@
     {
       "version": "0.46.0-alpha.4",
       "date": "2026-05-27",
-      "previousVersion": "0.46.0",
+      "previousVersion": "0.46.0-alpha.3",
       "sections": {},
       "underTheHood": [
         "fix(ci): exclude release PRs from alpha cut to prevent infinite loop (#374)"
@@ -155,7 +218,7 @@
     {
       "version": "0.46.0-alpha.3",
       "date": "2026-05-27",
-      "previousVersion": "0.46.0",
+      "previousVersion": "0.46.0-alpha.2",
       "sections": {},
       "underTheHood": [
         "fix(html-viewer): fix 10 bugs from v0.46.0 code review (#375) (#377)"
@@ -164,7 +227,7 @@
     {
       "version": "0.46.0-alpha.2",
       "date": "2026-05-26",
-      "previousVersion": "0.46.0",
+      "previousVersion": "0.46.0-alpha.1",
       "sections": {},
       "underTheHood": [
         "chore: release v0.46.0-alpha.1 (#372)"
@@ -173,7 +236,7 @@
     {
       "version": "0.46.0-alpha.1",
       "date": "2026-05-26",
-      "previousVersion": "0.45.0",
+      "previousVersion": "0.45.0-alpha.5",
       "sections": {},
       "underTheHood": [
         "fix(ci): bump minor (not patch) when starting new alpha series (#367)",
@@ -206,7 +269,7 @@
     {
       "version": "0.45.0-alpha.6",
       "date": "2026-05-26",
-      "previousVersion": "0.45.0",
+      "previousVersion": "0.45.0-alpha.5",
       "sections": {},
       "underTheHood": [
         "fix(viewer): replace HtmlViewer static toolbar with floating pill (#363)",
@@ -216,7 +279,7 @@
     {
       "version": "0.45.0-alpha.5",
       "date": "2026-05-24",
-      "previousVersion": "0.45.0",
+      "previousVersion": "0.45.0-alpha.4",
       "sections": {
         "improvements": [
           "**Quiet Composer is now the only editor shell.** The earlier multi-column workspace with tab strips, the activity panel rail, the chat panel, and the command palette modal has been removed. Everything you used to do there now lives in one of the surfaces you already know: the floating command bar (⌘K) for prompts, palettes, and quick switches; the flat sidebar for Pinned / Projects / Recent / Tags / Mentions; and the document switcher (⌃Tab / ⌃⇧Tab) for cycling recent files. One coherent interface instead of two parallel ones.",
@@ -230,7 +293,7 @@
     {
       "version": "0.45.0-alpha.4",
       "date": "2026-05-22",
-      "previousVersion": "0.45.0",
+      "previousVersion": "0.45.0-alpha.3",
       "sections": {},
       "underTheHood": [
         "fix(release): generator writes honest placeholder; fix alpha-3 notes (#323)",
@@ -240,7 +303,7 @@
     {
       "version": "0.45.0-alpha.3",
       "date": "2026-05-22",
-      "previousVersion": "0.45.0",
+      "previousVersion": "0.45.0-alpha.2",
       "sections": {},
       "underTheHood": [
         "Corrected the alpha.2 release notes to remove placeholder text and add honest user-facing prose. (#320)",
@@ -251,7 +314,7 @@
     {
       "version": "0.45.0-alpha.2",
       "date": "2026-05-21",
-      "previousVersion": "0.45.0",
+      "previousVersion": "0.45.0-alpha.1",
       "sections": {
         "improvements": [
           "**Infrastructure-only release.** No user-visible changes vs. alpha.1 — same features, same behaviour. This alpha ships the CI plumbing that makes future auto-cuts actually work, plus two routine dependency patches."
@@ -265,7 +328,7 @@
     {
       "version": "0.45.0-alpha.1",
       "date": "2026-05-21",
-      "previousVersion": "0.45.0",
+      "previousVersion": "0.45.0-alpha.0",
       "sections": {
         "improvements": [
           "**Agent mode picker reappears for existing AI connections.** If your Claude Code / Codex / Copilot / Gemini connection was set up before the recent capability-probe change, the mode picker (Shield icon) in the chat footer had silently disappeared. Opening the chat now restores it automatically — no need to re-add the connection or visit the connection config dialog.",
@@ -370,7 +433,7 @@
     {
       "version": "0.44.0-alpha.2",
       "date": "2026-05-11",
-      "previousVersion": "0.44.0",
+      "previousVersion": "0.44.0-alpha.1",
       "sections": {
         "features": [
           "**Block external resources in the HTML viewer.** Settings → System → HTML viewer → \"Block external resources\" — toggle ON to strip `https://...` URLs from `<img src>`, `<link href>`, `<source srcset>`, and similar attributes before render. Local relative paths and same-directory files still load. Default OFF.",
@@ -405,7 +468,7 @@
     {
       "version": "0.44.0-alpha.1",
       "date": "2026-05-10",
-      "previousVersion": "0.44.0",
+      "previousVersion": "0.44.0-alpha.0",
       "sections": {
         "fixes": [
           "**Release pipeline unblocked.** Removed the obsolete"

--- a/scripts/generate-changelog.ts
+++ b/scripts/generate-changelog.ts
@@ -71,8 +71,9 @@ export function parseReleaseFile(filepath: string): ReleaseEntry | null {
   const dateMatch = content.match(/\*\*Date:\*\*\s*([\d-]+)/);
   const date = dateMatch ? dateMatch[1] : '';
 
-  // Extract previous version
-  const prevMatch = content.match(/\*\*Previous version:\*\*\s*([\d.]+)/);
+  // Extract previous version — include any `-alpha.N` prerelease suffix (the
+  // old `[\d.]+` stopped at the `-`, so every alpha reported `0.46.0`).
+  const prevMatch = content.match(/\*\*Previous version:\*\*\s*([\d.]+(?:-[\w.]+)?)/);
   const previousVersion = prevMatch ? prevMatch[1] : '';
 
   // Parse sections


### PR DESCRIPTION
## Summary
Alpha release notes (GitHub pages + in-app "View Changelog") didn't reflect what shipped. Root causes:
1. The cut sourced PRs from a **tier-label-filtered** `gh pr list` → untiered PRs were silently dropped. **alpha.14** listed only #419 but actually shipped the whole **MCP registration overhaul (#410, ~15 commits)** + a **sidebar refactor (#416)**.
2. Every entry hard-coded *"No user-visible changes"* and dumped all PRs under "Under the hood" — even `feat`/`fix`.
3. `changelog-alpha.json` reported `previousVersion: 0.46.0` for every alpha (parser truncated the `-alpha.N` suffix).

## Changes
- **Backfill** `docs/history/139–144` (alpha.14–19) with real **Features / Fixes / Improvements** + **commit-level "Under the hood"**, and broken-build warnings on 16/17/18.
- **Fix** the `previousVersion` regex in `generate-changelog.ts`; regenerate `public/changelog-alpha.json`.
- **Fix the generator** (`aw-alpha-cut`): enumerate **every** PR in the git range (squash + merge), classify by conventional-commit type, and append commit-level detail — so future cuts are complete and grouped.

## Notes
- The in-app dialog already renders Features/Fixes/Improvements/Under-the-hood as lists — no UI change needed.
- The matching **GitHub release bodies** and the live **`changelog-alpha.json`** asset on the `latest-alpha` release are being updated out-of-band so users see the corrected notes immediately (independent of this merge).

## Test plan
- `pnpm typecheck` ✓, `pnpm generate-changelog` ✓ (alpha.14 → 6 features/1 fix/15 under-the-hood, previousVersion correct), changelog + linter tests ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)