### PR TITLE
chore: release v0.46.0-alpha.20

### DIFF
--- a/docs/history/145-release-v0.46.0-alpha.20.md
+++ b/docs/history/145-release-v0.46.0-alpha.20.md
@@ -1,0 +1,28 @@
+# Release v0.46.0-alpha.20
+
+**Date:** 2026-06-08
+**Previous version:** 0.46.0-alpha.19
+**Channel:** Alpha
+
+Auto-cut by `aw-alpha-cut`. Sections below are auto-classified from merged PRs; refine the prose before promoting to stable.
+
+## Changes
+
+### Fixes
+- fix(mcp): close deep-link RCE + OAuth SSRF (security) (#419)
+
+### Improvements
+- refactor(sidebar): extract ProjectRow, ChildRow + inline-edit/drag hooks from ProjectsSection (#416)
+
+## Under the hood
+
+Auto-generated from merged PRs + commits since `v0.46.0-alpha.19`. Alpha builds list commit-level detail for technical users.
+
+- Fix ArrowUp re-render race in ProjectsSection focusRow (#350)
+- MCP server registration UX overhaul (#410)
+- chore(skills): suite-wide review fixes + Autonomy policy (#411)
+- docs(changelog): backfill real alpha.14–19 notes + fix the generator (#434)
+- test(e2e-real): sidebar keyboard-nav regression lock (#349) that actually loads (#435)
+- chore(skills): suite-wide review fixes + Autonomy policy (#411)
+- test(e2e-real): sidebar keyboard-nav regression lock (#349) that actually loads (#435)
+- docs(changelog): backfill real alpha.14–19 notes + fix the generator (#434)

--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -148,3 +148,4 @@ Chronological log of major implementation milestones and changes.
 | 142 | [Release v0.46.0-alpha.17](142-release-v0.46.0-alpha.17.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
 | 143 | [Release v0.46.0-alpha.18](143-release-v0.46.0-alpha.18.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
 | 144 | [Release v0.46.0-alpha.19](144-release-v0.46.0-alpha.19.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
+| 145 | [Release v0.46.0-alpha.20](145-release-v0.46.0-alpha.20.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "notesage",
   "private": true,
-  "version": "0.46.0-alpha.19",
+  "version": "0.46.0-alpha.20",
   "license": "MIT",
   "author": "Peter Blenessy",
   "type": "module",

--- a/public/changelog-alpha.json
+++ b/public/changelog-alpha.json
@@ -1,6 +1,29 @@
 {
   "releases": [
     {
+      "version": "0.46.0-alpha.20",
+      "date": "2026-06-08",
+      "previousVersion": "0.46.0-alpha.19",
+      "sections": {
+        "fixes": [
+          "fix(mcp): close deep-link RCE + OAuth SSRF (security) (#419)"
+        ],
+        "improvements": [
+          "refactor(sidebar): extract ProjectRow, ChildRow + inline-edit/drag hooks from ProjectsSection (#416)"
+        ]
+      },
+      "underTheHood": [
+        "Fix ArrowUp re-render race in ProjectsSection focusRow (#350)",
+        "MCP server registration UX overhaul (#410)",
+        "chore(skills): suite-wide review fixes + Autonomy policy (#411)",
+        "docs(changelog): backfill real alpha.14–19 notes + fix the generator (#434)",
+        "test(e2e-real): sidebar keyboard-nav regression lock (#349) that actually loads (#435)",
+        "chore(skills): suite-wide review fixes + Autonomy policy (#411)",
+        "test(e2e-real): sidebar keyboard-nav regression lock (#349) that actually loads (#435)",
+        "docs(changelog): backfill real alpha.14–19 notes + fix the generator (#434)"
+      ]
+    },
+    {
       "version": "0.46.0-alpha.19",
       "date": "2026-06-08",
       "previousVersion": "0.46.0-alpha.18",


### PR DESCRIPTION
Auto-cut by `aw-alpha-cut`. The history file at `docs/history/145-release-v0.46.0-alpha.20.md` lists the merged PRs.

## PRs included

- #411
- #434
- #435

Auto-merge enabled. Once the 4 required status checks pass, this merges to main, and the `tag-after-merge` job in `aw-alpha-cut.yml` tags + pushes `v0.46.0-alpha.20`. `release.yml` then builds and publishes.
