### PR TITLE
fix(transcription): auto-detect spoken language instead of forcing English

### DIFF
--- a/src-tauri/src/commands/transcription.rs
+++ b/src-tauri/src/commands/transcription.rs
@@ -970,7 +970,7 @@ pub async fn transcribe_file(
     // Model load + whole-file transcription on a blocking thread so it never
     // contends with a live capture (which lives on its own dedicated thread).
     let result = tokio::task::spawn_blocking(
-        move || -> Result<(Vec<TranscriptSegment>, f64), String> {
+        move || -> Result<(Vec<TranscriptSegment>, f64, Option<String>), String> {
             // Load (or reuse cached) whisper context.
             {
                 let mut ctx_lock = whisper_ctx.lock();
@@ -1013,6 +1013,16 @@ pub async fn transcribe_file(
                 .full(params, &audio_data)
                 .map_err(|e| format!("Transcription failed: {}", e))?;
 
+            // When auto-detecting, surface the language Whisper actually picked
+            // (e.g. "sv") so the transcript note records it instead of "auto".
+            // A pinned language is reported back verbatim.
+            let detected_lang = if lang == "auto" {
+                let id = whisper_state.full_lang_id_from_state();
+                whisper_rs::get_lang_str(id).map(|s| s.to_string())
+            } else {
+                Some(lang.clone())
+            };
+
             let num_segments = whisper_state.full_n_segments();
             let mut segments = Vec::new();
             for i in 0..num_segments {
@@ -1043,13 +1053,13 @@ pub async fn transcribe_file(
             }
 
             let duration_secs = audio_data.len() as f64 / sample_rate as f64;
-            Ok((segments, duration_secs))
+            Ok((segments, duration_secs, detected_lang))
         },
     )
     .await
     .map_err(|e| format!("Transcription task panicked: {}", e))??;
 
-    let (segments, duration_secs) = result;
+    let (segments, duration_secs, detected_lang) = result;
     log::info!(target: "notesage::transcription", "transcribe_file complete (job={}): {} segments, {:.1}s", job_id, segments.len(), duration_secs);
 
     let _ = app_final.emit(
@@ -1060,7 +1070,9 @@ pub async fn transcribe_file(
     Ok(TranscriptionResult {
         segments,
         duration_secs,
-        language: lang_result,
+        // Prefer the detected language; fall back to the requested value
+        // (e.g. "auto") only if Whisper couldn't map the detected id.
+        language: detected_lang.unwrap_or(lang_result),
     })
 }
 

--- a/src-tauri/src/commands/transcription.rs
+++ b/src-tauri/src/commands/transcription.rs
@@ -954,7 +954,14 @@ pub async fn transcribe_file(
     );
 
     let whisper_ctx = state.whisper_ctx.clone();
-    let lang = language.unwrap_or_else(|| "en".to_string());
+    // An empty / missing language means auto-detect. whisper.cpp treats the
+    // sentinel "auto" as "detect the spoken language for this file". Previously
+    // we coerced the unset case to "en", which forced English decoding and
+    // produced "[speaking in foreign language]" garbage for every other tongue.
+    let lang = match language {
+        Some(l) if !l.trim().is_empty() => l,
+        _ => "auto".to_string(),
+    };
     let lang_result = lang.clone();
     let job_id_task = job_id.clone();
     let model_task = model.clone();

--- a/src/components/settings/TranscriptionSettings.tsx
+++ b/src/components/settings/TranscriptionSettings.tsx
@@ -26,20 +26,35 @@ import { useModelMetadata } from '@/hooks/useModelMetadata';
 import { ModelMetadataTooltip } from './ModelMetadataTooltip';
 import { TooltipProvider } from '@/components/ui/tooltip';
 
+// Whisper supports 99 languages; "Auto-detect" covers them all (it sets the
+// language to "auto", which makes Whisper detect the language per recording).
+// The explicit entries below are common picks for users who want to pin a
+// language and skip per-file detection. Keep "Auto-detect" first.
 const LANGUAGES = [
+  { value: 'auto', label: 'Auto-detect' },
   { value: 'ar', label: 'Arabic' },
   { value: 'zh', label: 'Chinese' },
+  { value: 'cs', label: 'Czech' },
+  { value: 'da', label: 'Danish' },
   { value: 'nl', label: 'Dutch' },
   { value: 'en', label: 'English' },
+  { value: 'fi', label: 'Finnish' },
   { value: 'fr', label: 'French' },
   { value: 'de', label: 'German' },
+  { value: 'el', label: 'Greek' },
+  { value: 'hi', label: 'Hindi' },
   { value: 'it', label: 'Italian' },
   { value: 'ja', label: 'Japanese' },
   { value: 'ko', label: 'Korean' },
+  { value: 'no', label: 'Norwegian' },
+  { value: 'pl', label: 'Polish' },
   { value: 'pt', label: 'Portuguese' },
   { value: 'ru', label: 'Russian' },
   { value: 'es', label: 'Spanish' },
   { value: 'sv', label: 'Swedish' },
+  { value: 'tr', label: 'Turkish' },
+  { value: 'uk', label: 'Ukrainian' },
+  { value: 'vi', label: 'Vietnamese' },
 ];
 
 function modelDisplayName(name: string): string {

--- a/src/hooks/__tests__/useTranscriptionJob.test.ts
+++ b/src/hooks/__tests__/useTranscriptionJob.test.ts
@@ -99,6 +99,22 @@ describe('useTranscriptionJob', () => {
     expect(jobTask().progress).toBe(100);
   });
 
+  it('passes the "auto" language through to the backend (no English coercion)', async () => {
+    // Regression lock: the store default is 'auto', which must reach the
+    // backend verbatim so Whisper auto-detects the language. A truthy 'auto'
+    // must not be dropped to undefined nor silently turned into 'en'.
+    useRecordingStore.setState({ defaultModel: 'small', speechLanguage: 'auto' });
+    const d = deferred<TranscriptionResult>();
+    transcribeFile.mockReturnValue(d.promise);
+
+    renderHook(() => useTranscriptionJob());
+    act(() => startTranscription({ audioPath: AUDIO }));
+    const jobId = jobTask().id;
+
+    await waitFor(() => expect(transcribeFile).toHaveBeenCalled());
+    expect(transcribeFile).toHaveBeenCalledWith(jobId, AUDIO, 'small', 'auto');
+  });
+
   it('routes transcription-progress only for the matching jobId', async () => {
     const d = deferred<TranscriptionResult>();
     transcribeFile.mockReturnValue(d.promise); // keep job in-flight

--- a/src/stores/recording-store.ts
+++ b/src/stores/recording-store.ts
@@ -108,7 +108,9 @@ export const useRecordingStore = create<RecordingStore>()(
 
         // Persisted state
         defaultModel: 'base',
-        speechLanguage: 'en',
+        // 'auto' lets Whisper detect the spoken language (all 99 it supports)
+        // instead of forcing English and mistranscribing other languages.
+        speechLanguage: 'auto',
         lastUsedSource: 'microphone',
 
         // Actions


### PR DESCRIPTION
## Problem

Meeting recordings in any non-English language were transcribed as gibberish or literal `[speaking in foreign language]` output. The cause was that the spoken language was pinned to **English** end-to-end, so Whisper's built-in language auto-detection (which covers all **99** languages the bundled models support) was never reachable:

- `recording-store` defaulted `speechLanguage` to `'en'`.
- The Settings → Voice language picker offered **no auto-detect option** — even though the help text right next to it says *"leave on auto-detect if unsure."* It also only listed 13 languages.
- `transcribe_file` coerced a missing/`None` language to `"en"` (`language.unwrap_or_else(|| "en")`) and then `set_language(Some("en"))`, forcing English decoding of non-English audio — the classic Whisper "wrong forced language" artifact.

## Fix

- **Add an "Auto-detect" option** (first in the list) and widen the curated language list in `TranscriptionSettings` (`src/components/settings/TranscriptionSettings.tsx`).
- **Default `speechLanguage` to `'auto'`** (`src/stores/recording-store.ts`). Existing users keep whatever they had persisted; they can switch to Auto-detect or pick their language.
- **Pass `"auto"` through to whisper.cpp** instead of defaulting to English when the language is unset/empty (`src-tauri/src/commands/transcription.rs`). `"auto"` is whisper.cpp's sentinel for per-file language detection.
- **Report the detected language** in `TranscriptionResult` — reads Whisper's detected language id via `WhisperState::full_lang_id_from_state()` + `get_lang_str()`, so the transcript note records the real language (e.g. `sv`) instead of `auto`. A pinned language is reported back verbatim; falls back to the requested value if the id can't be mapped.
- **Regression test** locking the `'auto'` passthrough to the backend (`src/hooks/__tests__/useTranscriptionJob.test.ts`).

## Workaround for users on the current build

Settings → Voice → **Recording language** → pick the actual language (or this PR's new **Auto-detect**), and use the **Small** model or larger — `tiny`/`base` hallucinate on non-English.

## Testing

- `pnpm typecheck` — clean
- `pnpm test` — 311 files / 5393 tests pass (incl. the new regression test)
- `cargo check` and `cargo check --tests` — clean (via the project's pkg-config stubs; only pre-existing dead-code warnings)

## Context

This came out of a question about whether Microsoft's VibeVoice models would help Notesage transcription. Short version: the **TTS** models don't apply (wrong direction), and VibeVoice **ASR**'s "50+ languages" is not actually an edge over us — we already ship 99-language Whisper. The non-English failures were purely this forced-English bug.

https://claude.ai/code/session_01RTqfP8hch83RedbPVfcN1t