### PR TITLE
chore(editor): split StatusTray.tsx into one-component-per-file

### DIFF
--- a/src/components/editor/ActionsGroup.tsx
+++ b/src/components/editor/ActionsGroup.tsx
@@ -1,0 +1,47 @@
+import { CheckSquare } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useActionStore } from "@/stores/action-store";
+
+export function ActionsGroup({ onOpenActions }: { onOpenActions?: () => void }) {
+  const openCount = useActionStore((s) => s.getOpenCount());
+
+  return (
+    <section className="space-y-2" aria-label="Actions">
+      <div className="flex items-center gap-2">
+        <CheckSquare className="h-3.5 w-3.5 shrink-0" strokeWidth={1.5} />
+        <span className="text-xs font-medium">Actions</span>
+      </div>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={onOpenActions}
+            disabled={!onOpenActions}
+            className={cn(
+              "w-full flex items-center gap-2 text-xs text-muted-foreground hover:text-foreground transition-colors",
+              "rounded-sm px-2 py-1 hover:bg-muted/50",
+              "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+              "disabled:cursor-not-allowed disabled:opacity-60",
+            )}
+          >
+            <CheckSquare className="h-3 w-3 shrink-0" strokeWidth={1.5} />
+            <span className="flex-1 text-left">
+              {openCount === 0
+                ? "No open actions"
+                : `${openCount} open ${openCount === 1 ? "action" : "actions"}`}
+            </span>
+            <span className="text-[10px] text-muted-foreground/60 tabular-nums">{"⌘!"}</span>
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="text-xs max-w-[220px]">
+          Open the actions dashboard
+        </TooltipContent>
+      </Tooltip>
+    </section>
+  );
+}

--- a/src/components/editor/CommentsGroup.tsx
+++ b/src/components/editor/CommentsGroup.tsx
@@ -1,0 +1,105 @@
+import * as React from "react";
+import { MessageSquare } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import type { Comment } from "@/stores/comment-store";
+import { CommentList } from "./CommentListPopover";
+
+export function CommentsGroup({
+  comments,
+  onSelectComment,
+  onDelegateComment,
+  onDelegateAll,
+  canDelegate,
+  onCloseTray,
+}: {
+  comments: Comment[];
+  onSelectComment?: (c: Comment) => void;
+  onDelegateComment?: (c: Comment) => void;
+  onDelegateAll?: () => void;
+  canDelegate: boolean;
+  /** Closes the parent StatusTray so focus returns to the editor after selecting a comment. */
+  onCloseTray: () => void;
+}) {
+  // A comment is "open" unless explicitly resolved — `status === undefined`
+  // on freshly created comments, so a strict `=== "open"` would miss them.
+  const openCount = comments.filter(
+    (c) => c.status !== "resolved" && c.status !== "done",
+  ).length;
+  const hasOpen = openCount > 0;
+  const totalVisible = comments.filter((c) => c.status !== "resolved").length;
+
+  const [listOpen, setListOpen] = React.useState(false);
+
+  const handleOpenChange = React.useCallback(
+    (next: boolean) => {
+      setListOpen(next);
+      if (next) {
+        const detail = { comments, onSelectComment, onDelegateComment, onDelegateAll, canDelegate };
+        window.dispatchEvent(new CustomEvent("notesage:open-comment-list", { detail }));
+      }
+    },
+    [comments, onSelectComment, onDelegateComment, onDelegateAll, canDelegate],
+  );
+
+  return (
+    <section className="space-y-2" aria-label="Comments">
+      <div className="flex items-center gap-2">
+        <MessageSquare className="h-3.5 w-3.5 shrink-0" strokeWidth={1.5} />
+        <span className="text-xs font-medium">Comments</span>
+        <span className="ml-auto text-[10px] tabular-nums text-muted-foreground/60">
+          {hasOpen ? `${openCount} open` : totalVisible > 0 ? "none open" : "none"}
+        </span>
+      </div>
+      {hasOpen ? (
+        <Popover open={listOpen} onOpenChange={handleOpenChange}>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              className={cn(
+                "w-full text-left text-xs text-muted-foreground hover:text-foreground transition-colors",
+                "rounded-sm px-2 py-1 hover:bg-muted/50",
+                "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+              )}
+            >
+              View open comments
+            </button>
+          </PopoverTrigger>
+          <PopoverContent
+            side="left"
+            align="start"
+            sideOffset={8}
+            // z-[60] sits above the parent StatusTray popover (z-50) so we
+            // don't get clipped by it. Width + max-height match
+            // CommentListPopover's content for visual parity.
+            className="w-72 p-0 max-h-80 overflow-y-auto z-[60]"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <CommentList
+              comments={comments}
+              onSelectComment={(c) => {
+                onSelectComment?.(c);
+                setListOpen(false);
+                onCloseTray();
+              }}
+              onDelegateComment={onDelegateComment}
+              onDelegateAll={onDelegateAll}
+              canDelegate={canDelegate}
+              onDismiss={() => setListOpen(false)}
+            />
+          </PopoverContent>
+        </Popover>
+      ) : (
+        <p className="text-[10px] text-muted-foreground/60 leading-tight px-2">
+          {totalVisible > 0
+            ? "All comments handled."
+            : "No comments on this document yet."}
+        </p>
+      )}
+    </section>
+  );
+}

--- a/src/components/editor/CompletionsGroup.tsx
+++ b/src/components/editor/CompletionsGroup.tsx
@@ -1,0 +1,112 @@
+import { useMemo } from "react";
+import { cn } from "@/lib/utils";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useSettingsStore } from "@/stores/settings-store";
+import { useRoutingStore } from "@/stores/routing-store";
+import { useConnectionsStore } from "@/stores/connections-store";
+
+/** Italic T with sparkle trail — mirrors the icon in StatusBar.tsx. */
+function InlineCompletionIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" className={className}>
+      <line x1="2" y1="3" x2="8.5" y2="3" strokeWidth="1.5" strokeLinecap="round" />
+      <line x1="6.5" y1="3" x2="3.5" y2="13" strokeWidth="1.5" strokeLinecap="round" />
+      <path d="M9 9 L9.7 11.8 L12 13 L9.7 14.2 L9 17 L8.3 14.2 L6 13 L8.3 11.8 Z" fill="currentColor" stroke="none" />
+      <path d="M13.5 2 L14.55 6.2 L18 8 L14.55 9.8 L13.5 14 L12.45 9.8 L9 8 L12.45 6.2 Z" fill="currentColor" stroke="none" />
+    </svg>
+  );
+}
+
+export function CompletionsGroup() {
+  const inlineCompletionsDisabled = useSettingsStore((s) => s.inlineCompletionsDisabled);
+  const setInlineCompletionsDisabled = useSettingsStore(
+    (s) => s.setInlineCompletionsDisabled,
+  );
+  const routing = useRoutingStore((s) => s.routing);
+  const setRouting = useRoutingStore((s) => s.setRouting);
+  const connections = useConnectionsStore((s) => s.connections);
+
+  const compatibleConnections = useMemo(
+    () => connections.filter((c) => c.capabilities.includes("inline_completion")),
+    [connections],
+  );
+
+  const currentConnectionId = routing.inline_completion?.connectionId ?? null;
+
+  const isOff =
+    inlineCompletionsDisabled ||
+    !currentConnectionId ||
+    !compatibleConnections.some((c) => c.id === currentConnectionId);
+
+  // Sentinel value meaning "no provider / disabled" — matches the NONE
+  // constant in UseCaseRoutingSettings so the two surfaces share vocabulary.
+  const OFF = "__off__";
+  const selectValue = isOff ? OFF : (currentConnectionId ?? OFF);
+
+  return (
+    <section className="space-y-2" aria-label="Completions">
+      <div className="flex items-center gap-2">
+        <InlineCompletionIcon className="h-3.5 w-3.5 shrink-0" />
+        <span className="text-xs font-medium">Completions</span>
+      </div>
+
+      <Select
+        value={selectValue}
+        onValueChange={(val) => {
+          if (val === OFF) setInlineCompletionsDisabled(true);
+          else {
+            setInlineCompletionsDisabled(false);
+            setRouting("inline_completion", val);
+          }
+        }}
+      >
+        <SelectTrigger aria-label="Completion provider" className="w-full h-8 text-xs">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={OFF}>
+            <span className="text-muted-foreground">Off</span>
+          </SelectItem>
+          {compatibleConnections.map((conn) => (
+            <SelectItem key={conn.id} value={conn.id}>
+              <span className="flex items-center gap-1.5">
+                <span
+                  className={cn(
+                    "h-1.5 w-1.5 rounded-full shrink-0",
+                    conn.status === "connected"
+                      ? "bg-foreground/60"
+                      : conn.status === "error"
+                        ? "bg-destructive"
+                        : "bg-foreground/40",
+                  )}
+                />
+                {conn.label}
+              </span>
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      {compatibleConnections.length === 0 && (
+        <p className="text-[10px] text-muted-foreground/60 leading-tight px-2">
+          No inline completion provider configured.{" "}
+          <button
+            type="button"
+            onClick={() =>
+              window.dispatchEvent(new CustomEvent("notesage:open-settings"))
+            }
+            className="underline hover:text-foreground transition-colors"
+          >
+            Configure in Settings…
+          </button>
+        </p>
+      )}
+    </section>
+  );
+}

--- a/src/components/editor/EditorToolsGroup.tsx
+++ b/src/components/editor/EditorToolsGroup.tsx
@@ -1,0 +1,68 @@
+import { FileCode, FileText } from "lucide-react";
+import type { Editor } from "@tiptap/react";
+import { cn } from "@/lib/utils";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import type { ViewMode } from "@/lib/file-utils";
+import { MicButton } from "./toolbar/MicButton";
+
+export function EditorToolsGroup({
+  editor,
+  viewMode,
+  onToggleViewMode,
+}: {
+  editor: Editor | null;
+  viewMode?: ViewMode;
+  onToggleViewMode?: () => void;
+}) {
+  const showSourceToggle = Boolean(onToggleViewMode);
+  const showMic = Boolean(editor);
+  if (!showMic && !showSourceToggle) return null;
+
+  const isSource = viewMode === "source";
+
+  return (
+    <section className="flex items-center gap-2" aria-label="Editor tools">
+      {showMic && <MicButton editor={editor ?? null} />}
+      {showSourceToggle && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={isSource}
+              aria-label={
+                isSource ? "Switch to Rich text" : "Switch to Markdown source"
+              }
+              onClick={onToggleViewMode}
+              className={cn(
+                "ml-auto inline-flex items-center gap-1.5 h-7 px-2 rounded-sm border border-border",
+                "text-[11px] text-muted-foreground hover:text-foreground hover:bg-muted/50",
+                "transition-colors",
+                "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+              )}
+            >
+              {isSource ? (
+                <>
+                  <FileText className="h-3.5 w-3.5 shrink-0" strokeWidth={1.5} />
+                  <span>Source</span>
+                </>
+              ) : (
+                <>
+                  <FileCode className="h-3.5 w-3.5 shrink-0" strokeWidth={1.5} />
+                  <span>WYSIWYG</span>
+                </>
+              )}
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="top" className="text-xs max-w-[220px]">
+            {isSource ? "Rich text" : "Markdown source"}
+          </TooltipContent>
+        </Tooltip>
+      )}
+    </section>
+  );
+}

--- a/src/components/editor/HelpGroup.tsx
+++ b/src/components/editor/HelpGroup.tsx
@@ -1,0 +1,42 @@
+import { HelpCircle, Command as CommandIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+export function HelpGroup({ onShortcutsOpen }: { onShortcutsOpen?: () => void }) {
+  return (
+    <section className="space-y-2" aria-label="Help">
+      <div className="flex items-center gap-2">
+        <HelpCircle className="h-3.5 w-3.5 shrink-0" strokeWidth={1.5} />
+        <span className="text-xs font-medium">Help</span>
+      </div>
+      {onShortcutsOpen && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={onShortcutsOpen}
+              className={cn(
+                "w-full flex items-center gap-2 text-xs text-muted-foreground hover:text-foreground transition-colors",
+                "rounded-sm px-2 py-1 hover:bg-muted/50",
+                "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+              )}
+            >
+              <CommandIcon className="h-3 w-3 shrink-0" strokeWidth={1.5} />
+              <span className="flex-1 text-left">Keyboard shortcuts</span>
+              <span className="text-[10px] text-muted-foreground/60 tabular-nums">
+                {"⌘7"}
+              </span>
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="top" className="text-xs max-w-[220px]">
+            Show all keyboard shortcuts
+          </TooltipContent>
+        </Tooltip>
+      )}
+    </section>
+  );
+}

--- a/src/components/editor/SessionGroup.tsx
+++ b/src/components/editor/SessionGroup.tsx
@@ -1,0 +1,101 @@
+import { Cpu } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useLocalAIStore } from "@/stores/local-ai-store";
+import { useConnectionsStore } from "@/stores/connections-store";
+import { useReducedMotion } from "@/hooks/useReducedMotion";
+import { localAiDotClass, localAiStatusLabel } from "./local-ai-dot";
+
+// `SessionGroup` is kept as the export name to avoid touching the
+// `StatusTrayGroup = "session"` deep-link key in StatusBar.
+export function SessionGroup() {
+  const serverStatus = useLocalAIStore((s) => s.serverStatus);
+  const activeModelId = useLocalAIStore((s) => s.activeModelId);
+  const setActiveModel = useLocalAIStore((s) => s.setActiveModel);
+  const models = useLocalAIStore((s) => s.models);
+  const connections = useConnectionsStore((s) => s.connections);
+  const reducedMotion = useReducedMotion();
+
+  const hasConnection = connections.some(
+    (c) => c.provider === "local_ai" && c.authMethod === "local_bundled",
+  );
+  if (!hasConnection) return null;
+
+  // Shared helper keeps this dot and the quiet status strip's dot in sync.
+  const dot = localAiDotClass(serverStatus, reducedMotion);
+  const statusLabel = localAiStatusLabel(serverStatus);
+
+  const downloadedModels = models.filter((m) => m.downloaded);
+
+  return (
+    <section className="space-y-2" aria-label="Local AI">
+      <div className="flex items-center gap-2">
+        <Cpu className="h-3.5 w-3.5 shrink-0" strokeWidth={1.5} />
+        <span className="text-xs font-medium">Local AI</span>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span
+              className={cn("ml-auto h-1.5 w-1.5 rounded-full shrink-0", dot)}
+              data-testid="local-ai-status-dot"
+              data-server-status={serverStatus}
+              role="status"
+              aria-label={`Local AI ${statusLabel}`}
+            />
+          </TooltipTrigger>
+          <TooltipContent side="top" className="text-xs max-w-[220px]">
+            {statusLabel}
+          </TooltipContent>
+        </Tooltip>
+      </div>
+
+      <div className="flex items-center justify-between gap-2 px-2 min-h-0">
+        <label
+          htmlFor="status-tray-local-ai-model"
+          className="text-xs text-muted-foreground"
+        >
+          Model
+        </label>
+        <Select
+          value={activeModelId ?? undefined}
+          onValueChange={setActiveModel}
+          disabled={downloadedModels.length === 0}
+        >
+          <SelectTrigger
+            id="status-tray-local-ai-model"
+            className={cn(
+              "h-5 w-[160px] max-w-[160px] text-[11px] leading-none",
+              "px-1.5 py-0 gap-1 border-0 bg-muted/40 hover:bg-muted/70",
+              "[&>svg]:size-2.5",
+              "[&_[data-slot=select-value]]:truncate [&_[data-slot=select-value]]:min-w-0",
+            )}
+            aria-label="Active local AI model"
+          >
+            <SelectValue
+              placeholder={
+                downloadedModels.length === 0 ? "No models downloaded" : "Pick a model"
+              }
+            />
+          </SelectTrigger>
+          <SelectContent>
+            {downloadedModels.map((m) => (
+              <SelectItem key={m.id} value={m.id} className="text-xs">
+                {m.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </section>
+  );
+}

--- a/src/components/editor/StatusTray.tsx
+++ b/src/components/editor/StatusTray.tsx
@@ -1,76 +1,24 @@
 import * as React from "react";
-import { useMemo } from "react";
-import {
-  Cpu,
-  MessageSquare,
-  HelpCircle,
-  Command as CommandIcon,
-  FileCode,
-  FileText,
-  CheckSquare,
-} from "lucide-react";
 import type { Editor } from "@tiptap/react";
-import { cn } from "@/lib/utils";
 import {
   Popover,
   PopoverAnchor,
   PopoverContent,
-  PopoverTrigger,
 } from "@/components/ui/popover";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
-import { useSettingsStore } from "@/stores/settings-store";
-import { useRoutingStore } from "@/stores/routing-store";
-import { useConnectionsStore } from "@/stores/connections-store";
-import { useLocalAIStore } from "@/stores/local-ai-store";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import type { Comment } from "@/stores/comment-store";
-import { useActionStore } from "@/stores/action-store";
 import type { ViewMode } from "@/lib/file-utils";
-import { useReducedMotion } from "@/hooks/useReducedMotion";
-import { MicButton } from "./toolbar/MicButton";
-import { CommentList } from "./CommentListPopover";
-import { localAiDotClass, localAiStatusLabel } from "./local-ai-dot";
+import { EditorToolsGroup } from "./EditorToolsGroup";
+import { CompletionsGroup } from "./CompletionsGroup";
+import { CommentsGroup } from "./CommentsGroup";
+import { ActionsGroup } from "./ActionsGroup";
+import { SessionGroup } from "./SessionGroup";
+import { HelpGroup } from "./HelpGroup";
 
 /**
- * Inline completion icon — italic T with sparkle trail. Mirrors the
- * SVG in `StatusBar.tsx` so the tray and the bar stay visually
- * consistent.
- */
-function InlineCompletionIcon({ className }: { className?: string }) {
-  return (
-    <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" className={className}>
-      <line x1="2" y1="3" x2="8.5" y2="3" strokeWidth="1.5" strokeLinecap="round" />
-      <line x1="6.5" y1="3" x2="3.5" y2="13" strokeWidth="1.5" strokeLinecap="round" />
-      <path d="M9 9 L9.7 11.8 L12 13 L9.7 14.2 L9 17 L8.3 14.2 L6 13 L8.3 11.8 Z" fill="currentColor" stroke="none" />
-      <path d="M13.5 2 L14.55 6.2 L18 8 L14.55 9.8 L13.5 14 L12.45 9.8 L9 8 L12.45 6.2 Z" fill="currentColor" stroke="none" />
-    </svg>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Completion provider picker
-// ---------------------------------------------------------------------------
-
-// ---------------------------------------------------------------------------
-// Props
-// ---------------------------------------------------------------------------
-
-/**
- * Group identifiers used by the task #54 ambient dots to request that a
- * specific section of the tray be scrolled into view + focused when the
- * popover opens. These strings are stable contract between the dots in
- * `QuietStatusBar` and the tray layout below.
+ * Section identifiers for deep-linking into a group on open (task #54 dots).
+ * `"actions"` is in the type but has no ref — deep-linking to it silently
+ * no-ops (no current call site passes it as `initialExpandedGroup`).
  */
 export type StatusTrayGroup =
   | "completions"
@@ -80,617 +28,27 @@ export type StatusTrayGroup =
   | "help";
 
 export interface StatusTrayProps {
-  /** Controlled open state. */
   open: boolean;
-  /** Notified on any open/close transition, including Escape and outside clicks. */
   onOpenChange: (open: boolean) => void;
-  /**
-   * Anchor — used to position the popover. Required because the tray is
-   * mounted as a sibling, not a descendant of a trigger button.
-   *
-   * Accepts either a ref to a real DOM element (Radix calls
-   * `getBoundingClientRect()` on it directly), or a "virtual" ref holding
-   * an object that exposes `getBoundingClientRect()` — used by
-   * `QuietStatusBar` to anchor the popover to the click coordinates rather
-   * than the whole status strip.
-   */
+  /** Virtual ref accepted — `QuietStatusBar` passes click coordinates. */
   anchor: React.RefObject<
     HTMLElement | { getBoundingClientRect(): DOMRect } | null
   >;
-
-  /** Comments on the active document. Count + list affordance live in Comments group. */
   comments?: Comment[];
   onSelectComment?: (c: Comment) => void;
   onDelegateComment?: (c: Comment) => void;
   onDelegateAll?: () => void;
   canDelegate?: boolean;
-
-  /** Opens the ⌘7 keyboard-shortcuts dialog from the Help group. */
   onShortcutsOpen?: () => void;
-
-  /**
-   * Opens the Actions dashboard from the Actions group (bugs #3-#5).
-   * Mirrors the `ActionsIndicator` button in `StatusBar`'s full
-   * variant — the QuietStatusBar variant gets the same affordance via
-   * this group inside the popover.
-   */
   onOpenActions?: () => void;
-
-  /**
-   * When provided on open, scroll the named group into view and give it
-   * programmatic focus so screen readers announce the section. Used by
-   * the task #54 ambient dots to deep-link into their owning group
-   * (e.g. clicking the red recording dot jumps to Session).
-   *
-   * Only read when `open` transitions from false → true. Subsequent
-   * changes while the tray is already open are ignored so user scrolling
-   * inside the tray is never yanked back.
-   */
+  /** Scroll + focus this group when the tray opens. Ignored on subsequent re-renders. */
   initialExpandedGroup?: StatusTrayGroup;
-
-  /**
-   * Active editor instance. When provided, the tray hosts the meeting-
-   * recording `MicButton` (⌘⇧R, moved off the pill toolbar in #110). Pass
-   * `null` (or omit) when there is no editor — the row hides itself.
-   */
+  /** Pass `null` to hide the EditorToolsGroup row. */
   editor?: Editor | null;
-
-  /** Active document's viewMode. Drives the source-mode switch label/state. */
-  viewMode?: ViewMode;
-
-  /**
-   * Source-mode toggle callback. When provided alongside `viewMode`, the
-   * tray shows a WYSIWYG ↔ Source switcher above the Completions group.
-   * Mirrors `Toolbar`'s `onToggleViewMode` prop.
-   */
-  onToggleViewMode?: () => void;
-}
-
-// ---------------------------------------------------------------------------
-// Editor tools group — hosts MicButton + view-mode toggle (#110).
-// These previously lived on the inline Toolbar; the pill variant omits them
-// because the pill is intentionally tiny. The keyboard shortcuts (⌘⇧R for
-// meeting recording, no chord for view-mode) continue to work app-wide
-// regardless of where the affordance lives.
-// ---------------------------------------------------------------------------
-
-function EditorToolsGroup({
-  editor,
-  viewMode,
-  onToggleViewMode,
-}: {
-  editor: Editor | null;
   viewMode?: ViewMode;
   onToggleViewMode?: () => void;
-}) {
-  const showSourceToggle = Boolean(onToggleViewMode);
-  const showMic = Boolean(editor);
-  if (!showMic && !showSourceToggle) return null;
-
-  const isSource = viewMode === "source";
-
-  return (
-    <section className="flex items-center gap-2" aria-label="Editor tools">
-      {showMic && (
-        // Re-enable the MicButton's built-in Tooltip so it matches the
-        // rest of the tray's chrome (consistent with source toggle,
-        // completion picker, actions, shortcuts). Earlier `showTooltip={false}`
-        // suppressed it to avoid the focus-on-popover-open auto-show, but
-        // the user explicitly wants tooltip parity here.
-        <MicButton editor={editor ?? null} />
-      )}
-      {showSourceToggle && (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              role="switch"
-              aria-checked={isSource}
-              aria-label={
-                isSource ? "Switch to Rich text" : "Switch to Markdown source"
-              }
-              onClick={onToggleViewMode}
-              className={cn(
-                "ml-auto inline-flex items-center gap-1.5 h-7 px-2 rounded-sm border border-border",
-                "text-[11px] text-muted-foreground hover:text-foreground hover:bg-muted/50",
-                "transition-colors",
-                "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
-              )}
-            >
-              {isSource ? (
-                <>
-                  <FileText className="h-3.5 w-3.5 shrink-0" strokeWidth={1.5} />
-                  <span>Source</span>
-                </>
-              ) : (
-                <>
-                  <FileCode className="h-3.5 w-3.5 shrink-0" strokeWidth={1.5} />
-                  <span>WYSIWYG</span>
-                </>
-              )}
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="top" className="text-xs max-w-[220px]">
-            {isSource ? "Rich text" : "Markdown source"}
-          </TooltipContent>
-        </Tooltip>
-      )}
-    </section>
-  );
 }
 
-// ---------------------------------------------------------------------------
-// Completion picker
-// ---------------------------------------------------------------------------
-
-function CompletionsGroup() {
-  const inlineCompletionsDisabled = useSettingsStore((s) => s.inlineCompletionsDisabled);
-  const setInlineCompletionsDisabled = useSettingsStore(
-    (s) => s.setInlineCompletionsDisabled,
-  );
-  const routing = useRoutingStore((s) => s.routing);
-  const setRouting = useRoutingStore((s) => s.setRouting);
-  const connections = useConnectionsStore((s) => s.connections);
-
-  // Only show connections that advertise the inline_completion capability —
-  // mirrors the filter in UseCaseRoutingSettings so the two surfaces stay consistent.
-  const compatibleConnections = useMemo(
-    () => connections.filter((c) => c.capabilities.includes("inline_completion")),
-    [connections],
-  );
-
-  const currentConnectionId = routing.inline_completion?.connectionId ?? null;
-
-  const isOff =
-    inlineCompletionsDisabled ||
-    !currentConnectionId ||
-    !compatibleConnections.some((c) => c.id === currentConnectionId);
-
-  const handleSelectOff = () => {
-    setInlineCompletionsDisabled(true);
-  };
-
-  const handleSelectConnection = (connId: string) => {
-    setInlineCompletionsDisabled(false);
-    setRouting("inline_completion", connId);
-  };
-
-  // Sentinel value used by the Select to mean "no provider / disabled".
-  // Mirrors the `NONE` constant in `UseCaseRoutingSettings` so the two
-  // surfaces speak the same vocabulary.
-  const OFF = "__off__";
-  const selectValue = isOff ? OFF : (currentConnectionId ?? OFF);
-
-  return (
-    <section className="space-y-2" aria-label="Completions">
-      <div className="flex items-center gap-2">
-        <InlineCompletionIcon className="h-3.5 w-3.5 shrink-0" />
-        <span className="text-xs font-medium">Completions</span>
-      </div>
-
-      {/* Dropdown picker (replaces the segmented Off/Provider/Provider toggle).
-          Matches the Settings > Inline Completion picker so users see one UI. */}
-      <Select
-        value={selectValue}
-        onValueChange={(val) => {
-          if (val === OFF) handleSelectOff();
-          else handleSelectConnection(val);
-        }}
-      >
-        <SelectTrigger
-          aria-label="Completion provider"
-          className="w-full h-8 text-xs"
-        >
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value={OFF}>
-            <span className="text-muted-foreground">Off</span>
-          </SelectItem>
-          {compatibleConnections.map((conn) => (
-            <SelectItem key={conn.id} value={conn.id}>
-              <span className="flex items-center gap-1.5">
-                <span
-                  className={cn(
-                    "h-1.5 w-1.5 rounded-full shrink-0",
-                    conn.status === "connected"
-                      ? "bg-foreground/60"
-                      : conn.status === "error"
-                        ? "bg-destructive"
-                        : "bg-foreground/40",
-                  )}
-                />
-                {conn.label}
-              </span>
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-
-      {/* Empty state: no compatible connections configured */}
-      {compatibleConnections.length === 0 && (
-        <p className="text-[10px] text-muted-foreground/60 leading-tight px-2">
-          No inline completion provider configured.{" "}
-          <button
-            type="button"
-            onClick={() =>
-              window.dispatchEvent(new CustomEvent("notesage:open-settings"))
-            }
-            className="underline hover:text-foreground transition-colors"
-          >
-            Configure in Settings…
-          </button>
-        </p>
-      )}
-    </section>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Comments group
-// ---------------------------------------------------------------------------
-
-function CommentsGroup({
-  comments,
-  onSelectComment,
-  onDelegateComment,
-  onDelegateAll,
-  canDelegate,
-  onCloseTray,
-}: {
-  comments: Comment[];
-  onSelectComment?: (c: Comment) => void;
-  onDelegateComment?: (c: Comment) => void;
-  onDelegateAll?: () => void;
-  canDelegate: boolean;
-  /**
-   * Closes the parent StatusTray popover. Called after the user picks a
-   * comment so the user lands back on the editor with focus on the
-   * jumped-to anchor — same UX as the standalone `CommentListPopover`
-   * (which dismisses itself on row click).
-   */
-  onCloseTray: () => void;
-}) {
-  // Match `CommentListPopover`'s "visible" semantics: a comment is open
-  // unless it has been explicitly resolved. Newly created comments have
-  // `status === undefined` (the `addComment` action never assigns one),
-  // so a strict `=== "open"` check would miss every freshly authored
-  // comment and surface "0 / none open" for documents that obviously
-  // have comments.
-  const openCount = comments.filter((c) => c.status !== "resolved" && c.status !== "done").length;
-  const hasOpen = openCount > 0;
-  const totalVisible = comments.filter((c) => c.status !== "resolved").length;
-
-  // Local open state for the inner Comments popover. Anchored to the
-  // "View open comments" button via PopoverTrigger asChild — Radix
-  // handles outside-click and Escape automatically. We dispatch the
-  // `notesage:open-comment-list` CustomEvent on open so existing
-  // listeners (and the perf/regression tests that watch for it) keep
-  // firing exactly once per click.
-  const [listOpen, setListOpen] = React.useState(false);
-
-  const handleOpenChange = React.useCallback(
-    (next: boolean) => {
-      setListOpen(next);
-      if (next) {
-        const detail = {
-          comments,
-          onSelectComment,
-          onDelegateComment,
-          onDelegateAll,
-          canDelegate,
-        };
-        window.dispatchEvent(
-          new CustomEvent("notesage:open-comment-list", { detail }),
-        );
-      }
-    },
-    [
-      comments,
-      onSelectComment,
-      onDelegateComment,
-      onDelegateAll,
-      canDelegate,
-    ],
-  );
-
-  return (
-    <section className="space-y-2" aria-label="Comments">
-      <div className="flex items-center gap-2">
-        <MessageSquare className="h-3.5 w-3.5 shrink-0" strokeWidth={1.5} />
-        <span className="text-xs font-medium">Comments</span>
-        <span className="ml-auto text-[10px] tabular-nums text-muted-foreground/60">
-          {hasOpen
-            ? `${openCount} open`
-            : totalVisible > 0
-            ? "none open"
-            : "none"}
-        </span>
-      </div>
-      {hasOpen ? (
-        <Popover open={listOpen} onOpenChange={handleOpenChange}>
-          <PopoverTrigger asChild>
-            <button
-              type="button"
-              className={cn(
-                "w-full text-left text-xs text-muted-foreground hover:text-foreground transition-colors",
-                "rounded-sm px-2 py-1 hover:bg-muted/50",
-                "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
-              )}
-            >
-              View open comments
-            </button>
-          </PopoverTrigger>
-          <PopoverContent
-            side="left"
-            align="start"
-            sideOffset={8}
-            // Sit ABOVE the parent StatusTray popover (z-50) so we don't
-            // get clipped by it. Same width + max-height as
-            // `CommentListPopover`'s content for visual parity.
-            className="w-72 p-0 max-h-80 overflow-y-auto z-[60]"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <CommentList
-              comments={comments}
-              onSelectComment={(c) => {
-                onSelectComment?.(c);
-                // Close the inner list AND the outer tray so the user
-                // lands back on the editor focused on the anchor.
-                setListOpen(false);
-                onCloseTray();
-              }}
-              onDelegateComment={onDelegateComment}
-              onDelegateAll={onDelegateAll}
-              canDelegate={canDelegate}
-              onDismiss={() => setListOpen(false)}
-            />
-          </PopoverContent>
-        </Popover>
-      ) : (
-        <p className="text-[10px] text-muted-foreground/60 leading-tight px-2">
-          {totalVisible > 0
-            ? "All comments handled."
-            : "No comments on this document yet."}
-        </p>
-      )}
-    </section>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Local AI group
-// ---------------------------------------------------------------------------
-//
-// Live-test 2026-04-25 — this section was previously called "Session" and
-// stacked three rows (Local AI status, Tool calling toggle, Recording).
-// Tool calling and Recording were dropped (toggle wasn't useful from the
-// status tray; recording is conveyed by the top-row MicButton). The
-// section was renamed to "Local AI" and the two remaining concepts
-// (status dot + active model) now sit on a 2-row layout:
-//
-//   row 1: <Cpu icon> "Local AI"          <status-dot right-aligned>
-//   row 2: "Model"                        <select with downloaded models>
-//
-// `SessionGroup` is kept as the export name to avoid touching the
-// `StatusTrayGroup = "session"` deep-link key used by the StatusBar's
-// dot-click navigation. The `aria-label` on the section is now "Local
-// AI" so assistive tech announces the new framing.
-
-// ---------------------------------------------------------------------------
-// Actions group (bugs #3-#5) — open-actions count + click to open
-// ActionsDialog. Mirrors the `ActionsIndicator` button in the
-// full-variant StatusBar but presents it as a click-to-reveal row
-// inside the StatusTray popover, consistent with the other groups.
-// When `openCount === 0` the row stays visible with a muted "No open
-// actions" state for consistency with the rest of the tray.
-// ---------------------------------------------------------------------------
-
-function ActionsGroup({ onOpenActions }: { onOpenActions?: () => void }) {
-  const openCount = useActionStore((s) => s.getOpenCount());
-  const handleClick = () => {
-    if (onOpenActions) onOpenActions();
-  };
-  // Visual style matches HelpGroup's "Keyboard shortcuts" button — a
-  // muted-foreground row with the chord on the right. Bugs #3 / live
-  // finding 8 (looks like a button, not a submenu item).
-  return (
-    <section className="space-y-2" aria-label="Actions">
-      <div className="flex items-center gap-2">
-        <CheckSquare className="h-3.5 w-3.5 shrink-0" strokeWidth={1.5} />
-        <span className="text-xs font-medium">Actions</span>
-      </div>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <button
-            type="button"
-            onClick={handleClick}
-            disabled={!onOpenActions}
-            className={cn(
-              "w-full flex items-center gap-2 text-xs text-muted-foreground hover:text-foreground transition-colors",
-              "rounded-sm px-2 py-1 hover:bg-muted/50",
-              "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
-              "disabled:cursor-not-allowed disabled:opacity-60",
-            )}
-          >
-            <CheckSquare className="h-3 w-3 shrink-0" strokeWidth={1.5} />
-            <span className="flex-1 text-left">
-              {openCount === 0
-                ? "No open actions"
-                : `${openCount} open ${openCount === 1 ? "action" : "actions"}`}
-            </span>
-            <span className="text-[10px] text-muted-foreground/60 tabular-nums">
-              {"⌘!"}
-            </span>
-          </button>
-        </TooltipTrigger>
-        <TooltipContent side="top" className="text-xs max-w-[220px]">
-          Open the actions dashboard
-        </TooltipContent>
-      </Tooltip>
-    </section>
-  );
-}
-
-function SessionGroup() {
-  const serverStatus = useLocalAIStore((s) => s.serverStatus);
-  const activeModelId = useLocalAIStore((s) => s.activeModelId);
-  const setActiveModel = useLocalAIStore((s) => s.setActiveModel);
-  const models = useLocalAIStore((s) => s.models);
-  const connections = useConnectionsStore((s) => s.connections);
-  const reducedMotion = useReducedMotion();
-
-  const hasConnection = connections.some(
-    (c) => c.provider === "local_ai" && c.authMethod === "local_bundled",
-  );
-  if (!hasConnection) return null;
-
-  // Server-state-driven dot + label come from the shared helper so this dot
-  // and the quiet status strip's Local AI dot can never drift (issue #415).
-  const dot = localAiDotClass(serverStatus, reducedMotion);
-  const statusLabel = localAiStatusLabel(serverStatus);
-
-  const downloadedModels = models.filter((m) => m.downloaded);
-
-  return (
-    <section className="space-y-2" aria-label="Local AI">
-      {/* Title row — icon + label + right-aligned status dot. */}
-      <div className="flex items-center gap-2">
-        <Cpu className="h-3.5 w-3.5 shrink-0" strokeWidth={1.5} />
-        <span className="text-xs font-medium">Local AI</span>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <span
-              className={cn("ml-auto h-1.5 w-1.5 rounded-full shrink-0", dot)}
-              data-testid="local-ai-status-dot"
-              data-server-status={serverStatus}
-              role="status"
-              aria-label={`Local AI ${statusLabel}`}
-            />
-          </TooltipTrigger>
-          <TooltipContent side="top" className="text-xs max-w-[220px]">
-            {statusLabel}
-          </TooltipContent>
-        </Tooltip>
-      </div>
-
-      {/* Model picker — populated with downloaded models only. Picking a
-          model writes to local-ai-store; useLocalAI auto-restarts the
-          server when activeModelId changes.
-
-          Live-test 2026-04-25 — dense styling: h-6 trigger (24 px),
-          tighter px-2 padding, size-3 chevron, no border (the row sits
-          inside a popover that already has its own surface). The
-          underlying shadcn trigger always renders min-w-fit, so we cap
-          the width at 160 px and rely on the SelectValue's truncation
-          to keep long model names from blowing out the row. */}
-      {/* Live-test 2026-04-25 — `px-2` indent so the row's label and
-          picker align with the `px-2` button content in the Comments /
-          Help groups. Keeps the second-row left edge consistent across
-          the whole popover. */}
-      <div className="flex items-center justify-between gap-2 px-2 min-h-0">
-        <label
-          htmlFor="status-tray-local-ai-model"
-          className="text-xs text-muted-foreground"
-        >
-          Model
-        </label>
-        <Select
-          value={activeModelId ?? undefined}
-          onValueChange={setActiveModel}
-          disabled={downloadedModels.length === 0}
-        >
-          <SelectTrigger
-            id="status-tray-local-ai-model"
-            className={cn(
-              // Live-test 2026-04-25 — tightened further: 20 px tall,
-              // 11 px text, 6 px horizontal padding, 10 px chevron.
-              // The trigger is inside the popover (already a surface),
-              // so no border is needed; a faint muted background marks
-              // the affordance.
-              "h-5 w-[160px] max-w-[160px] text-[11px] leading-none",
-              "px-1.5 py-0 gap-1 border-0 bg-muted/40 hover:bg-muted/70",
-              "[&>svg]:size-2.5",
-              "[&_[data-slot=select-value]]:truncate [&_[data-slot=select-value]]:min-w-0",
-            )}
-            aria-label="Active local AI model"
-          >
-            <SelectValue
-              placeholder={
-                downloadedModels.length === 0
-                  ? "No models downloaded"
-                  : "Pick a model"
-              }
-            />
-          </SelectTrigger>
-          <SelectContent>
-            {downloadedModels.map((m) => (
-              <SelectItem key={m.id} value={m.id} className="text-xs">
-                {m.name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
-    </section>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Help group
-// ---------------------------------------------------------------------------
-
-function HelpGroup({
-  onShortcutsOpen,
-}: {
-  onShortcutsOpen?: () => void;
-}) {
-  return (
-    <section className="space-y-2" aria-label="Help">
-      <div className="flex items-center gap-2">
-        <HelpCircle className="h-3.5 w-3.5 shrink-0" strokeWidth={1.5} />
-        <span className="text-xs font-medium">Help</span>
-      </div>
-      {onShortcutsOpen && (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              onClick={onShortcutsOpen}
-              className={cn(
-                "w-full flex items-center gap-2 text-xs text-muted-foreground hover:text-foreground transition-colors",
-                "rounded-sm px-2 py-1 hover:bg-muted/50",
-                "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
-              )}
-            >
-              <CommandIcon className="h-3 w-3 shrink-0" strokeWidth={1.5} />
-              <span className="flex-1 text-left">Keyboard shortcuts</span>
-              <span className="text-[10px] text-muted-foreground/60 tabular-nums">
-                {"\u23187"}
-              </span>
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="top" className="text-xs max-w-[220px]">
-            Show all keyboard shortcuts
-          </TooltipContent>
-        </Tooltip>
-      )}
-    </section>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Top-level tray
-// ---------------------------------------------------------------------------
-
-/**
- * StatusTray — popover mounted above the quiet `StatusBar` strip.
- *
- * Holds four groups: Completions (provider picker), Comments (count + open
- * list), Session (local AI, tool calling, recording), Help (shortcuts +
- * word count). All state reads come from existing Zustand stores so the
- * popover is additive — no new persistence, no new Tauri calls.
- */
 export function StatusTray({
   open,
   onOpenChange,
@@ -712,10 +70,7 @@ export function StatusTray({
     onShortcutsOpen?.();
   }, [onOpenChange, onShortcutsOpen]);
 
-  // Bugs #3 — clicking the Actions row should close the tray AND
-  // open the dashboard. Wrapper is undefined when no parent handler
-  // is provided so ActionsGroup can disable the button (avoids
-  // surfacing a no-op affordance).
+  // Close the tray before opening the dashboard so the two don't overlap.
   const handleOpenActions = React.useMemo(
     () =>
       onOpenActions
@@ -727,16 +82,11 @@ export function StatusTray({
     [onOpenChange, onOpenActions],
   );
 
-  // Per-group refs used to deep-link into a section when a task #54 dot is
-  // clicked. Each group wrapper holds a `tabIndex={-1}` so `.focus()` works
-  // without trapping Tab order; scrollIntoView keeps the section anchored
-  // in the 300px popover when the tray is tall enough to overflow.
   const completionsRef = React.useRef<HTMLDivElement | null>(null);
   const commentsRef = React.useRef<HTMLDivElement | null>(null);
   const sessionRef = React.useRef<HTMLDivElement | null>(null);
   const helpRef = React.useRef<HTMLDivElement | null>(null);
 
-  /** Resolve the group ref by id. Safe to call before mount — returns null. */
   const resolveGroup = React.useCallback(
     (group?: StatusTrayGroup): HTMLDivElement | null => {
       if (!group) return null;
@@ -749,12 +99,9 @@ export function StatusTray({
     [],
   );
 
-  // `onOpenAutoFocus` runs after Radix has mounted the popover content.
-  // ALWAYS prevent Radix's default autofocus: it lands on the first focusable
-  // descendant — the recording `MicButton` — whose focus-triggered Radix
-  // tooltip then auto-opens on every popover open (the tooltip looks "stuck").
-  // Focus stays on the trigger; Tab still reaches the controls. When a dot has
-  // pre-selected a group, steer focus + scroll to that group root instead.
+  // Prevent Radix's default autofocus (it lands on the first focusable child
+  // and triggers its tooltip). When a dot pre-selected a group, steer focus
+  // and scroll to that group root instead.
   const handleOpenAutoFocus = React.useCallback(
     (e: Event) => {
       e.preventDefault();
@@ -780,27 +127,14 @@ export function StatusTray({
         sideOffset={6}
         className="w-[300px] p-0"
         onOpenAutoFocus={handleOpenAutoFocus}
-        // The anchor is the whole status strip; clicking the strip is what
-        // opens us. When no `initialExpandedGroup` is set, Radix's default
-        // autofocus runs (first focusable control). When a dot requested a
-        // group, `handleOpenAutoFocus` preventDefaults Radix and steers
-        // focus + scroll to that group root instead.
       >
         {/*
-          TooltipProvider is REQUIRED here because PopoverContent portal-
-          mounts to document.body — any TooltipProvider higher in the React
-          tree doesn't reach into this portal. MicButton and other children
-          use <Tooltip> which throws "Tooltip must be used within
-          TooltipProvider" without this wrapper (see
-          feedback_code_review_mandatory_gate in auto-memory).
+          TooltipProvider is required here because PopoverContent portal-
+          mounts to document.body — any provider higher in the React tree
+          doesn't reach into this portal.
         */}
         <TooltipProvider delayDuration={300}>
-          {/*
-           * Live-test 2026-04-26 — inset inter-section separators (12px
-           * from each edge) instead of edge-to-edge `divide-y`. The first
-           * section keeps a flush top edge — the popover's own border
-           * carries that boundary already.
-           */}
+          {/* Inset separators (12 px from each edge) between sections. */}
           <div className="[&>*+*]:relative [&>*+*]:before:pointer-events-none [&>*+*]:before:absolute [&>*+*]:before:left-3 [&>*+*]:before:right-3 [&>*+*]:before:top-0 [&>*+*]:before:h-px [&>*+*]:before:bg-border">
             {(editor || onToggleViewMode) && (
               <div className="p-3">
@@ -824,10 +158,6 @@ export function StatusTray({
                 onCloseTray={() => onOpenChange(false)}
               />
             </div>
-            {/* Bugs #3 — Actions group sits between Comments and
-                Session ("things to act on" cluster). Click closes the
-                tray + opens the ActionsDialog via the threaded
-                `onOpenActions` prop (Editor → StatusBar → here). */}
             <div tabIndex={-1} className="p-3 focus:outline-none">
               <ActionsGroup onOpenActions={handleOpenActions} />
             </div>

--- a/src/components/editor/__tests__/StatusTraySplit.test.ts
+++ b/src/components/editor/__tests__/StatusTraySplit.test.ts
@@ -1,0 +1,57 @@
+// Structural split gate for issue #439
+// All tests RED before the split, GREEN after.
+// Uses fs.readFileSync to avoid any React/Tauri bootstrap overhead.
+
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import { describe, expect, it } from "vitest";
+
+const componentDir = resolve(__dirname, "..");
+
+describe("StatusTray structural split (#439)", () => {
+  it("EditorToolsGroup.tsx exists and exports EditorToolsGroup", () => {
+    const src = readFileSync(resolve(componentDir, "EditorToolsGroup.tsx"), "utf8");
+    expect(src).toContain("export function EditorToolsGroup");
+  });
+
+  it("CompletionsGroup.tsx exists and exports CompletionsGroup", () => {
+    const src = readFileSync(resolve(componentDir, "CompletionsGroup.tsx"), "utf8");
+    expect(src).toContain("export function CompletionsGroup");
+  });
+
+  it("CommentsGroup.tsx exists and exports CommentsGroup", () => {
+    const src = readFileSync(resolve(componentDir, "CommentsGroup.tsx"), "utf8");
+    expect(src).toContain("export function CommentsGroup");
+  });
+
+  it("ActionsGroup.tsx exists and exports ActionsGroup", () => {
+    const src = readFileSync(resolve(componentDir, "ActionsGroup.tsx"), "utf8");
+    expect(src).toContain("export function ActionsGroup");
+  });
+
+  it("SessionGroup.tsx exists and exports SessionGroup", () => {
+    const src = readFileSync(resolve(componentDir, "SessionGroup.tsx"), "utf8");
+    expect(src).toContain("export function SessionGroup");
+  });
+
+  it("HelpGroup.tsx exists and exports HelpGroup", () => {
+    const src = readFileSync(resolve(componentDir, "HelpGroup.tsx"), "utf8");
+    expect(src).toContain("export function HelpGroup");
+  });
+
+  it("StatusTray.tsx is at most 200 lines after the split", () => {
+    const src = readFileSync(resolve(componentDir, "StatusTray.tsx"), "utf8");
+    const lines = src.split("\n").length;
+    expect(lines).toBeLessThanOrEqual(200);
+  });
+
+  it("StatusTray.tsx still exports StatusTray for backward compatibility", () => {
+    const src = readFileSync(resolve(componentDir, "StatusTray.tsx"), "utf8");
+    expect(src).toContain("export function StatusTray");
+  });
+
+  it("StatusTray.tsx still exports StatusTrayGroup type for backward compatibility", () => {
+    const src = readFileSync(resolve(componentDir, "StatusTray.tsx"), "utf8");
+    expect(src).toMatch(/export type StatusTrayGroup|export\s+\{[^}]*StatusTrayGroup/);
+  });
+});


### PR DESCRIPTION
Resolves #439

## What

Splits the 845-line `StatusTray.tsx` into one file per component, then reduces the orchestrator to ~195 lines that compose them.

### Files created

| File | Component | Lines |
|---|---|---|
| `EditorToolsGroup.tsx` | MicButton + source-mode toggle | ~65 |
| `CompletionsGroup.tsx` | Completion provider picker (+ co-located `InlineCompletionIcon` SVG) | ~95 |
| `CommentsGroup.tsx` | Comment count + nested popover list | ~90 |
| `ActionsGroup.tsx` | Open-actions count + click-to-open | ~55 |
| `SessionGroup.tsx` | Local AI status dot + model picker | ~90 |
| `HelpGroup.tsx` | Keyboard shortcuts row | ~40 |
| `StatusTray.tsx` | Orchestrator only | ~195 |

### Files modified

- `StatusTray.tsx` — replaced with orchestrator that imports the six group files; exports `StatusTray`, `StatusTrayProps`, and `StatusTrayGroup` unchanged for full backward compatibility.

### Test added

`StatusTraySplit.test.ts` — 9 structural tests (no jsdom/Tauri required):
- Each group file exists and exports its named function (6 tests — were RED before the split)
- `StatusTray.tsx` ≤ 200 lines (was RED at 846 before split)
- Backward-compat exports still present (2 tests — were already green)

## What was NOT changed

- Zero behaviour changes: all props, Radix markup, Zustand selectors, and CSS classes are identical.
- No new persistence, no new Tauri commands, no new state.
- All 5395 existing unit tests pass; typecheck clean.

## Dead-code audit findings

Per the precedent set in PR #438 (which found and removed a dead `variant='full'` prop before splitting `StatusBar.tsx`), this split was preceded by a full reachability audit:

**No dead props found.** All six group components are live; `StatusTray` has no `variant` or `mode` props.

**Latent bug surfaced (not fixed in this PR — pure chore scope):**
`StatusTrayGroup` includes `"actions"` as a valid type value, but `resolveGroup()` in the orchestrator has no case for it — deep-linking to the Actions group via `initialExpandedGroup="actions"` silently no-ops (returns `null`). This is dormant because the only call site (`StatusBar.tsx:openTrayForGroup`) only ever passes `"session"`. Documented in the `StatusTrayGroup` JSDoc comment on line 22–25 of the new `StatusTray.tsx`. A follow-up issue should wire the `actionsRef` and the `resolveGroup` case.

Co-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>