### PR TITLE
chore: release v0.46.0-alpha.21

### DIFF
--- a/docs/history/146-release-v0.46.0-alpha.21.md
+++ b/docs/history/146-release-v0.46.0-alpha.21.md
@@ -1,0 +1,22 @@
+# Release v0.46.0-alpha.21
+
+**Date:** 2026-06-09
+**Previous version:** 0.46.0-alpha.20
+**Channel:** Alpha
+
+Auto-cut by `aw-alpha-cut`. Sections below are auto-classified from merged PRs; refine the prose before promoting to stable.
+
+## Changes
+
+### Fixes
+- fix(transcription): auto-detect spoken language instead of forcing English (#437)
+
+### Improvements
+- refactor(status-bar): remove dead full variant, sync Local AI dot, add background-activity ring (#438)
+
+## Under the hood
+
+Auto-generated from merged PRs + commits since `v0.46.0-alpha.20`. Alpha builds list commit-level detail for technical users.
+
+- refactor(status-bar): remove dead full variant, sync Local AI dot, add activity ring (#438)
+- fix(transcription): auto-detect spoken language instead of forcing English (#437)

--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -149,3 +149,4 @@ Chronological log of major implementation milestones and changes.
 | 143 | [Release v0.46.0-alpha.18](143-release-v0.46.0-alpha.18.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
 | 144 | [Release v0.46.0-alpha.19](144-release-v0.46.0-alpha.19.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
 | 145 | [Release v0.46.0-alpha.20](145-release-v0.46.0-alpha.20.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
+| 146 | [Release v0.46.0-alpha.21](146-release-v0.46.0-alpha.21.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "notesage",
   "private": true,
-  "version": "0.46.0-alpha.20",
+  "version": "0.46.0-alpha.21",
   "license": "MIT",
   "author": "Peter Blenessy",
   "type": "module",

--- a/public/changelog-alpha.json
+++ b/public/changelog-alpha.json
@@ -1,6 +1,23 @@
 {
   "releases": [
     {
+      "version": "0.46.0-alpha.21",
+      "date": "2026-06-09",
+      "previousVersion": "0.46.0-alpha.20",
+      "sections": {
+        "fixes": [
+          "fix(transcription): auto-detect spoken language instead of forcing English (#437)"
+        ],
+        "improvements": [
+          "refactor(status-bar): remove dead full variant, sync Local AI dot, add background-activity ring (#438)"
+        ]
+      },
+      "underTheHood": [
+        "refactor(status-bar): remove dead full variant, sync Local AI dot, add activity ring (#438)",
+        "fix(transcription): auto-detect spoken language instead of forcing English (#437)"
+      ]
+    },
+    {
       "version": "0.46.0-alpha.20",
       "date": "2026-06-08",
       "previousVersion": "0.46.0-alpha.19",


### PR DESCRIPTION
Auto-cut by `aw-alpha-cut`. The history file at `docs/history/146-release-v0.46.0-alpha.21.md` lists the merged PRs.

## PRs included

- #437
- #438

Auto-merge enabled. Once the 4 required status checks pass, this merges to main, and the `tag-after-merge` job in `aw-alpha-cut.yml` tags + pushes `v0.46.0-alpha.21`. `release.yml` then builds and publishes.
