### PR TITLE
fix(acp): conversation/session/branch state integrity

### DIFF
--- a/src/components/chat/AcpSessionControls.tsx
+++ b/src/components/chat/AcpSessionControls.tsx
@@ -36,6 +36,7 @@ import {
   acpAgent,
 } from '@/lib/ai/acp-agent-state';
 import { useConnectionsStore } from '@/stores/connections-store';
+import { useChatStore } from '@/stores/chat-store';
 import type { AcpSessionConfigOption } from '@/lib/ai/acp-utils';
 import type { Connection } from '@/lib/ai/connections';
 
@@ -102,6 +103,11 @@ export const AcpModePicker = memo(function AcpModePicker({ connection }: { conne
   // This lets the footer populate instantly on agent switch, without waiting
   // for session/new to complete.
   const sessionInfo = useSyncExternalStore(subscribeSessionInfo, getSessionInfo);
+  // Conversation-scoped remembered mode — drives the label during the brief window
+  // after a respawn before `useAcpLifecycle` re-applies it to the live session.
+  const conversationModeId = useChatStore((s) =>
+    s.conversations.find((c) => c.id === s.activeConversationId)?.agentModeId
+  );
   const availableModes = connection.acpCapabilities?.availableModes ?? [];
   const [conflictMode, setConflictMode] = useState<{ id: string; name: string } | null>(null);
   const [open, setOpen] = useState(false);
@@ -114,6 +120,9 @@ export const AcpModePicker = memo(function AcpModePicker({ connection }: { conne
     }
     try {
       updateCurrentMode(modeId);
+      // Persist the pick on the conversation so it survives agent respawns (a sandbox
+      // scope change spawns a fresh session that otherwise resets to the agent default).
+      useChatStore.getState().setConversationMode(modeId);
       await tauriApi.acpSessionSetMode(acpAgent.instanceId, acpAgent.chatSessionId, modeId);
     } catch (err) {
       log.error('ai', `Failed to set mode: ${String(err)}`);
@@ -162,6 +171,7 @@ export const AcpModePicker = memo(function AcpModePicker({ connection }: { conne
   // ensureAcpAgent → clearSessionInfo, so (1) won't bleed across agents.
   const currentModeId =
     sessionInfo.modes?.currentModeId
+    ?? conversationModeId
     ?? connection.acpDefaults?.modeId
     ?? commonModes[0]?.agentModeId
     ?? null;

--- a/src/components/chat/AcpSessionControls.tsx
+++ b/src/components/chat/AcpSessionControls.tsx
@@ -31,6 +31,7 @@ import {
   subscribeSessionInfo,
   getCommonModes,
   getCommonMode,
+  resolveConfiguredModeId,
   updateCurrentMode,
   updateConfigOptionValue,
   acpAgent,
@@ -171,8 +172,7 @@ export const AcpModePicker = memo(function AcpModePicker({ connection }: { conne
   // ensureAcpAgent → clearSessionInfo, so (1) won't bleed across agents.
   const currentModeId =
     sessionInfo.modes?.currentModeId
-    ?? conversationModeId
-    ?? connection.acpDefaults?.modeId
+    ?? resolveConfiguredModeId(conversationModeId, connection)
     ?? commonModes[0]?.agentModeId
     ?? null;
   const currentCommon = currentModeId ? getCommonMode(currentModeId) : null;

--- a/src/components/chat/ChatHistoryView.tsx
+++ b/src/components/chat/ChatHistoryView.tsx
@@ -10,7 +10,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { toast } from 'sonner';
 import { tauriApi } from '@/lib/tauri';
-import { getThread, getLeaves } from '@/lib/chat-tree';
+import { getThread, getThreadResilient, getLeaves } from '@/lib/chat-tree';
 import type { ChatMessage } from '@/lib/ai/types';
 import { acpAgent } from '@/lib/ai/acp-agent-state';
 import { hasSessionCapability } from '@/lib/ai/acp-utils';
@@ -140,10 +140,9 @@ export const ChatHistoryView = memo(function ChatHistoryView({
     const title = conv.title || 'conversation';
     const slug = title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/-+$/, '').slice(0, 40);
 
-    // Export only the active thread
-    const thread = conv.activeLeafId
-      ? getThread(conv.messages, conv.activeLeafId)
-      : conv.messages;
+    // Export only the active thread (resilient: an orphaned activeLeafId must
+    // not truncate the export to a single message).
+    const thread = getThreadResilient(conv.messages, conv.activeLeafId).thread;
 
     const lines = [`# ${title}`, ''];
     lines.push(...formatMessagesAsMarkdown(thread));
@@ -159,10 +158,8 @@ export const ChatHistoryView = memo(function ChatHistoryView({
     const lines = [`# ${title}`, ''];
 
     if (leaves.length <= 1) {
-      // Single thread or no messages — export linearly
-      const thread = conv.activeLeafId
-        ? getThread(conv.messages, conv.activeLeafId)
-        : conv.messages;
+      // Single thread or no messages — export linearly (resilient).
+      const thread = getThreadResilient(conv.messages, conv.activeLeafId).thread;
       lines.push(...formatMessagesAsMarkdown(thread));
     } else {
       // Multiple branches — export each with a header

--- a/src/components/cmd/__tests__/CommandBarContext.test.tsx
+++ b/src/components/cmd/__tests__/CommandBarContext.test.tsx
@@ -33,6 +33,7 @@ const toggleProjectPathMock = vi.fn<(path: string) => void>();
 const setSelectedProjectPathsMock = vi.fn<(paths: string[]) => void>();
 const updateConnectionMock = vi.fn<(id: string, patch: Partial<Connection>) => void>();
 const createConversationMock = vi.fn<() => string>(() => 'conv-new');
+const setConversationModeMock = vi.fn<(modeId: string) => void>();
 
 // ---------------------------------------------------------------------------
 // ACP agent / session mocks (driving `AcpModePicker` via #26)
@@ -142,6 +143,9 @@ vi.mock('@/stores/chat-store', () => {
     toggleProjectPath: (path: string) => toggleProjectPathMock(path),
     setSelectedProjectPaths: (paths: string[]) => setSelectedProjectPathsMock(paths),
     createConversation: () => createConversationMock(),
+    // AcpModePicker persists the picked mode per-conversation so it survives
+    // agent respawns (fix/acp-mode-persists-across-respawn).
+    setConversationMode: (modeId: string) => setConversationModeMock(modeId),
   };
   return {
     useChatStore: Object.assign(

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -26,7 +26,7 @@ import { useEditorTabSwitch } from "@/hooks/useEditorTabSwitch";
 import type { EditorView as CMEditorView } from "@codemirror/view";
 import { useCommentStore } from "@/stores/comment-store";
 import { useChatStore } from "@/stores/chat-store";
-import { getThread } from "@/lib/chat-tree";
+import { getThreadResilient } from "@/lib/chat-tree";
 import {
   setPendingCommentRange as setPendingRangeDecoration,
   setSuggestion,
@@ -926,7 +926,7 @@ export function Editor({ onNewNote, onNewProject, onOpenFolder, onOpenProject, o
             const conv = chatStore.conversations.find((c) => c.id === freshComment.linkedConversationId);
             if (conv) {
               chatStore.setActiveConversation(conv.id);
-              const threadMessages = getThread(conv.messages, conv.activeLeafId) || conv.messages;
+              const threadMessages = getThreadResilient(conv.messages, conv.activeLeafId).thread;
               await sendChatMessage(text, threadMessages);
               emitCmdBarEvent({ type: 'focus' });
               return;

--- a/src/hooks/__tests__/useAcpLifecycle-history-block.test.ts
+++ b/src/hooks/__tests__/useAcpLifecycle-history-block.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+//
+// Regression test for the crash-retry "agent can't continue" symptom
+// (fix/acp-conversation-state-integrity).
+//
+// When a NEW ACP session starts mid-conversation (first message of a fresh
+// session, or a crash-retry that fell back to a fresh session), the prior
+// conversation must be replayed as a <conversation-history> preamble — otherwise
+// the agent gets zero context and the conversation appears broken.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import '@/test/tauri-mock';
+
+vi.mock('@/lib/logger', () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+vi.mock('@/lib/tauri', () => ({ tauriApi: { getHomeDir: vi.fn().mockResolvedValue('/Users/test') } }));
+vi.mock('@/hooks/useAcpSessionListeners', () => ({
+  setupAcpChatListeners: vi.fn(),
+  buildAcpChatCleanup: vi.fn(),
+}));
+
+import { buildAcpHistoryBlock } from '@/hooks/useAcpLifecycle';
+import { useChatStore } from '@/stores/chat-store';
+
+const store = useChatStore;
+
+describe('buildAcpHistoryBlock', () => {
+  beforeEach(() => {
+    store.setState({ conversations: [], activeConversationId: null });
+  });
+
+  function seedConversation() {
+    store.getState().createConversation({ projectPaths: [] });
+    store.getState().addMessage({ role: 'user', content: 'first question', timestamp: 100 });
+    store.getState().addMessage({ role: 'assistant', content: 'first answer', timestamp: 101 });
+    // The pair currently being (re)sent:
+    store.getState().addMessage({ role: 'user', content: 'second question', timestamp: 200 });
+    store.getState().addMessage({ role: 'assistant', content: '', timestamp: 201 });
+  }
+
+  it('replays prior messages and excludes the current pair', () => {
+    seedConversation();
+
+    const block = buildAcpHistoryBlock([201, 200]); // exclude current assistant + user
+
+    expect(block).toContain('<conversation-history>');
+    expect(block).toContain('User: first question');
+    expect(block).toContain('Assistant: first answer');
+    // The current pair must NOT appear in the replayed history.
+    expect(block).not.toContain('second question');
+  });
+
+  it('returns an empty string when there is no prior history', () => {
+    store.getState().createConversation({ projectPaths: [] });
+    store.getState().addMessage({ role: 'user', content: 'only question', timestamp: 200 });
+    store.getState().addMessage({ role: 'assistant', content: '', timestamp: 201 });
+
+    expect(buildAcpHistoryBlock([201, 200])).toBe('');
+  });
+
+  it('marks interrupted messages in the replayed history', () => {
+    store.getState().createConversation({ projectPaths: [] });
+    store.getState().addMessage({ role: 'user', content: 'q', timestamp: 100 });
+    store.getState().addMessage({ role: 'assistant', content: 'partial', timestamp: 101, interrupted: true });
+    store.getState().addMessage({ role: 'user', content: 'retry q', timestamp: 200 });
+    store.getState().addMessage({ role: 'assistant', content: '', timestamp: 201 });
+
+    const block = buildAcpHistoryBlock([201, 200]);
+    expect(block).toContain('Assistant [interrupted]: partial');
+  });
+});

--- a/src/hooks/__tests__/useAcpLifecycle-mode-reapply.test.ts
+++ b/src/hooks/__tests__/useAcpLifecycle-mode-reapply.test.ts
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+//
+// Regression test for the "Agent mode silently reverts to Read Only" bug.
+//
+// A sandbox-scope change respawns the ACP agent and creates a fresh session that
+// resets to the agent's own default mode (Claude Code → 'default' = Read Only).
+// `reapplySessionMode` must re-assert the conversation's remembered mode after every
+// such session creation, so the user's "Agent" pick survives the respawn.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import '@/test/tauri-mock';
+
+// Mock logger + tauriApi BEFORE importing the hook. We keep the REAL
+// acp-agent-state so updateCurrentMode/setSessionModes/getSessionInfo actually mutate.
+vi.mock('@/lib/logger', () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const { acpSessionSetMode } = vi.hoisted(() => ({
+  acpSessionSetMode: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('@/lib/tauri', () => ({
+  tauriApi: {
+    getHomeDir: vi.fn().mockResolvedValue('/Users/test'),
+    acpSessionSetMode,
+    acpSessionSetConfigOption: vi.fn().mockResolvedValue(undefined),
+    acpSessionSetModel: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+// Keep the session-listener wiring out of the import graph — not under test here.
+vi.mock('@/hooks/useAcpSessionListeners', () => ({
+  setupAcpChatListeners: vi.fn(),
+  buildAcpChatCleanup: vi.fn(),
+}));
+
+import { reapplySessionMode } from '@/hooks/useAcpLifecycle';
+import { setSessionModes, getSessionInfo, clearSessionInfo } from '@/lib/ai/acp-agent-state';
+import { useChatStore } from '@/stores/chat-store';
+import type { Connection } from '@/lib/ai/connections';
+import type { AcpSessionResult } from '@/lib/ai/acp-utils';
+
+const CLAUDE_MODES = [
+  { id: 'default', name: 'Default' },
+  { id: 'acceptEdits', name: 'Accept Edits' },
+  { id: 'plan', name: 'Plan' },
+  { id: 'bypassPermissions', name: 'Bypass Permissions' },
+];
+
+/** A fresh session as returned by a respawn — agent default 'default' (Read Only). */
+function freshSession(currentModeId = 'default'): AcpSessionResult {
+  return {
+    session_id: 'sess-new',
+    current_model: null,
+    available_models: [],
+    modes: { currentModeId, availableModes: CLAUDE_MODES },
+    config_options: null,
+  } as AcpSessionResult;
+}
+
+function makeConnection(overrides: Partial<Connection> = {}): Connection {
+  return {
+    id: 'conn-test',
+    provider: 'anthropic',
+    label: 'Test Agent',
+    capabilities: ['interactive'],
+    credentials: { type: 'agent_managed', agentBinary: 'claude-agent-acp' },
+    ...overrides,
+  } as Connection;
+}
+
+function newActiveConversation(): string {
+  const id = useChatStore.getState().createConversation();
+  return id;
+}
+
+describe('reapplySessionMode', () => {
+  beforeEach(() => {
+    acpSessionSetMode.mockClear();
+    clearSessionInfo();
+    // Reset the chat store to a clean slate between tests.
+    useChatStore.setState({ conversations: [], activeConversationId: null });
+  });
+
+  it('re-applies the conversation-remembered mode after a respawn resets to default', () => {
+    newActiveConversation();
+    useChatStore.getState().setConversationMode('acceptEdits'); // user picked "Agent"
+
+    // Simulate the respawn: a fresh session whose mode is the agent default.
+    const session = freshSession('default');
+    setSessionModes(session.modes); // mirrors the setSessionModes() call at the creation site
+
+    reapplySessionMode('inst-1', session, makeConnection(), false);
+
+    // The remembered pick is pushed to the live session AND optimistically reflected.
+    expect(acpSessionSetMode).toHaveBeenCalledWith('inst-1', 'sess-new', 'acceptEdits');
+    expect(getSessionInfo().modes?.currentModeId).toBe('acceptEdits');
+  });
+
+  it('falls back to the connection default for a fresh session with no remembered mode', () => {
+    newActiveConversation(); // no setConversationMode → no remembered pick
+    const session = freshSession('default');
+    setSessionModes(session.modes);
+
+    reapplySessionMode('inst-1', session, makeConnection({ acpDefaults: { modeId: 'plan' } }), false);
+
+    expect(acpSessionSetMode).toHaveBeenCalledWith('inst-1', 'sess-new', 'plan');
+    expect(getSessionInfo().modes?.currentModeId).toBe('plan');
+  });
+
+  it('does NOT impose the connection default on a restored session', () => {
+    newActiveConversation(); // no remembered pick
+    const session = freshSession('default');
+    setSessionModes(session.modes);
+
+    // restored = true → the loaded session already carries the agent's mode.
+    reapplySessionMode('inst-1', session, makeConnection({ acpDefaults: { modeId: 'plan' } }), true);
+
+    expect(acpSessionSetMode).not.toHaveBeenCalled();
+    expect(getSessionInfo().modes?.currentModeId).toBe('default');
+  });
+
+  it('still re-applies an explicit conversation pick even on a restored session', () => {
+    newActiveConversation();
+    useChatStore.getState().setConversationMode('acceptEdits');
+    const session = freshSession('default');
+    setSessionModes(session.modes);
+
+    reapplySessionMode('inst-1', session, makeConnection(), true);
+
+    expect(acpSessionSetMode).toHaveBeenCalledWith('inst-1', 'sess-new', 'acceptEdits');
+  });
+
+  it('is a no-op when the session already carries the remembered mode', () => {
+    newActiveConversation();
+    useChatStore.getState().setConversationMode('acceptEdits');
+    const session = freshSession('acceptEdits'); // agent already in Agent mode
+    setSessionModes(session.modes);
+
+    reapplySessionMode('inst-1', session, makeConnection(), false);
+
+    expect(acpSessionSetMode).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/__tests__/useChatSwitchPrompts.test.ts
+++ b/src/hooks/__tests__/useChatSwitchPrompts.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+//
+// Regression test for the spurious "Project changed to…" prompt on conversation
+// switch (fix/acp-conversation-state-integrity).
+//
+// Switching from conversation A (scope P_A) to B (scope P_B) must NOT be treated
+// as an in-conversation project change — it's a silent restore of B's own scope.
+// The prompt should fire ONLY when the scope mutates within a single conversation.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+vi.mock('@/lib/logger', () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+// The provider/agent-switch effect is out of scope here — stub its stores so it
+// never fires (interactive connection resolves to undefined, empty metadata).
+vi.mock('@/stores/connections-store', () => ({
+  useConnectionsStore: Object.assign(
+    vi.fn((sel: (s: { connections: unknown[] }) => unknown) => sel({ connections: [] })),
+    { getState: () => ({ connections: [] }) },
+  ),
+}));
+vi.mock('@/stores/routing-store', () => ({
+  useRoutingStore: Object.assign(
+    vi.fn((sel: (s: { getConnectionForUseCase: () => undefined }) => unknown) =>
+      sel({ getConnectionForUseCase: () => undefined }),
+    ),
+    { getState: () => ({ getConnectionForUseCase: () => undefined }) },
+  ),
+}));
+vi.mock('@/stores/project-metadata-store', () => ({
+  useProjectMetadataStore: Object.assign(
+    vi.fn((sel: (s: { metadataMap: Record<string, unknown> }) => unknown) =>
+      sel({ metadataMap: {} }),
+    ),
+    { getState: () => ({ metadataMap: {} }) },
+  ),
+}));
+
+import { useChatSwitchPrompts } from '@/hooks/useChatSwitchPrompts';
+import { useChatStore } from '@/stores/chat-store';
+
+const store = useChatStore;
+const pendingFor = (id: string) =>
+  store.getState().conversations.find((c) => c.id === id)?.pendingProjectSwitch ?? null;
+
+describe('useChatSwitchPrompts — conversation-scoped project switch', () => {
+  beforeEach(() => {
+    store.setState({ conversations: [], activeConversationId: null });
+  });
+
+  it('does NOT prompt when switching between conversations with different scopes', () => {
+    renderHook(() => useChatSwitchPrompts());
+
+    let aId = '';
+    let bId = '';
+    act(() => {
+      aId = store.getState().createConversation({ projectPaths: ['/X'] });
+      store.getState().addMessage({ role: 'user', content: 'hi', timestamp: 1 });
+    });
+    act(() => {
+      bId = store.getState().createConversation({ projectPaths: ['/Y'] });
+      store.getState().addMessage({ role: 'user', content: 'yo', timestamp: 2 });
+    });
+
+    // Switch A → B → A. Each is a restore of that conversation's own scope.
+    act(() => store.getState().setActiveConversation(aId));
+    act(() => store.getState().setActiveConversation(bId));
+    act(() => store.getState().setActiveConversation(aId));
+
+    expect(pendingFor(aId)).toBeNull();
+    expect(pendingFor(bId)).toBeNull();
+  });
+
+  it('DOES prompt when the scope changes within a single conversation', () => {
+    renderHook(() => useChatSwitchPrompts());
+
+    let aId = '';
+    act(() => {
+      aId = store.getState().createConversation({ projectPaths: ['/X'] });
+      store.getState().addMessage({ role: 'user', content: 'hi', timestamp: 1 });
+    });
+
+    // Same conversation, user adds a project → real change → prompt fires.
+    act(() => store.getState().toggleProjectPath('/Y'));
+
+    const pending = pendingFor(aId);
+    expect(pending).not.toBeNull();
+    expect(new Set(pending!.newPaths)).toEqual(new Set(['/X', '/Y']));
+    expect(new Set(pending!.previousPaths)).toEqual(new Set(['/X']));
+  });
+});

--- a/src/hooks/useAcpLifecycle.ts
+++ b/src/hooks/useAcpLifecycle.ts
@@ -22,6 +22,38 @@ import { setupAcpChatListeners, buildAcpChatCleanup } from '@/hooks/useAcpSessio
 import { useAgentStatusStore } from '@/stores/agent-status-store';
 
 /**
+ * Re-apply the conversation's remembered ACP permission mode (or, for a fresh
+ * session, the connection default) to a newly created or restored session.
+ *
+ * A sandbox-scope change respawns the agent and creates a fresh session that
+ * resets to the agent's own default mode (e.g. Claude Code → 'default' = Read
+ * Only). Without this, the footer's mode silently reverts after the user picked
+ * "Agent". The pick is persisted per-conversation (`chat-store.agentModeId`) and
+ * re-asserted here so it survives every respawn. Must be called immediately after
+ * `setSessionModes(session.modes)` at each session-creation site.
+ *
+ * @param restored True when `session` came from session/load|resume (it already
+ *   carries the agent's remembered mode, so we don't impose the connection
+ *   default — but an explicit per-conversation pick still wins).
+ */
+export function reapplySessionMode(
+  instanceId: string,
+  session: AcpSessionResult,
+  connection: Connection | null,
+  restored: boolean,
+): void {
+  if (!session.modes || !session.session_id) return;
+  const state = useChatStore.getState();
+  const convMode = state.conversations.find((c) => c.id === state.activeConversationId)?.agentModeId;
+  const targetMode = convMode ?? (restored ? undefined : connection?.acpDefaults?.modeId);
+  if (!targetMode || targetMode === session.modes.currentModeId) return;
+  updateCurrentMode(targetMode);
+  tauriApi.acpSessionSetMode(instanceId, session.session_id, targetMode).catch((err) => {
+    log.debug('ai', `ACP re-apply mode failed: ${String(err)}`);
+  });
+}
+
+/**
  * Resolve the ACP session ID to use for the next prompt on the active conversation.
  *
  * Prefers a branch-specific session (attached after `session/fork` on a leaf-branch)
@@ -414,16 +446,16 @@ export function useAcpLifecycle({ effectiveConnection, acpSystemMessage, buildAc
         setSessionConfigOptions(session.config_options ?? null);
         backfillAcpCapabilities(effectiveConnection?.id, session);
 
-        // Apply user's configured defaults only for fresh sessions. A restoration hit
-        // returns the agent's existing mode/config — don't overwrite it.
+        // Re-apply the conversation's remembered mode (or, for fresh sessions, the
+        // connection default). Listeners aren't active yet for the eager session, so
+        // the optimistic local update inside the helper is what the picker reads.
         const restored = session.session_id === storedSessionId;
+        reapplySessionMode(instanceId, session, effectiveConnection, restored);
+
+        // Apply remaining configured defaults only for fresh sessions. A restoration hit
+        // returns the agent's existing config — don't overwrite it.
         if (!restored) {
           const defaults = effectiveConnection.acpDefaults;
-          if (defaults?.modeId && session.modes && session.session_id) {
-            // Optimistically update local state (listeners aren't active yet for eager session)
-            updateCurrentMode(defaults.modeId);
-            tauriApi.acpSessionSetMode(instanceId, session.session_id, defaults.modeId).catch(() => {});
-          }
           if (defaults?.thinkingEffort && session.session_id) {
             updateConfigOptionValue('reasoning_effort', defaults.thinkingEffort);
             tauriApi.acpSessionSetConfigOption(instanceId, session.session_id, 'reasoning_effort', defaults.thinkingEffort).catch(() => {});
@@ -714,6 +746,9 @@ export function useAcpLifecycle({ effectiveConnection, acpSystemMessage, buildAc
           setSessionModes(session.modes ?? null);
           setSessionConfigOptions(session.config_options ?? null);
           backfillAcpCapabilities(effectiveConnection?.id, session);
+          // Fresh session (respawn on scope change / new conversation / new segment)
+          // resets to the agent default — re-assert the conversation's remembered mode.
+          reapplySessionMode(instanceId, session, effectiveConnection ?? null, false);
 
           // Set model via ACP-native mechanism (replaces CLI arg injection)
           if (effectiveConnection?.config?.model && session.session_id) {
@@ -987,6 +1022,8 @@ export function useAcpLifecycle({ effectiveConnection, acpSystemMessage, buildAc
         setSessionModes(session.modes ?? null);
         setSessionConfigOptions(session.config_options ?? null);
         backfillAcpCapabilities(effectiveConnection?.id, session);
+        // Fresh session on reconnect — re-assert the conversation's remembered mode.
+        reapplySessionMode(instanceId, session, effectiveConnection ?? null, false);
 
         // Set model via ACP-native mechanism
         if (effectiveConnection?.config?.model && session.session_id) {

--- a/src/hooks/useAcpLifecycle.ts
+++ b/src/hooks/useAcpLifecycle.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { useChatStore, selectProjectPaths, selectPendingProjectSwitch, getSessionIdForLeaf, sliceThreadBySegment } from '@/stores/chat-store';
-import { getThread } from '@/lib/chat-tree';
+import { getThreadResilient } from '@/lib/chat-tree';
 import { usePermissionStore } from '@/stores/permission-store';
 import type { ChatMessage, ImageAttachment } from '@/lib/ai/types';
 import type { Connection } from '@/lib/ai/connections';
@@ -783,9 +783,11 @@ export function useAcpLifecycle({ effectiveConnection, acpSystemMessage, buildAc
             const conv = useChatStore.getState().conversations
               .find(c => c.id === useChatStore.getState().activeConversationId);
             const segment = useChatStore.getState().getActiveSegment();
-            const baseThread: ChatMessage[] = conv?.activeLeafId
-              ? getThread(conv.messages, conv.activeLeafId)
-              : (conv?.messages ?? []);
+            // Resilient walk so a corrupted/orphaned activeLeafId can't collapse
+            // the agent's history to just the last message ("agent can't continue").
+            const baseThread: ChatMessage[] = conv
+              ? getThreadResilient(conv.messages, conv.activeLeafId).thread
+              : [];
             const allMessages = sliceThreadBySegment(baseThread, segment, conv?.messages ?? []);
             const priorMessages = allMessages.filter(
               (m) => m.timestamp !== assistantMessageId && m.timestamp !== userTimestamp

--- a/src/hooks/useAcpLifecycle.ts
+++ b/src/hooks/useAcpLifecycle.ts
@@ -17,7 +17,7 @@ import { useSettingsStore } from '@/stores/settings-store';
 import type { AcpSessionResult, AcpSessionUpdatePayload, AcpPermissionRequestPayload } from '@/lib/ai/acp-utils';
 import { restoreOrCreateAcpSession } from '@/lib/ai/acp-session-restore';
 import { buildAttachmentActivities, getChatSandboxScope, hasLoadSessionCapability } from '@/lib/ai/acp-utils';
-import { acpAgent, stopAcpAgent, ensureAcpAgent, updateAcpAgentInstanceId, setSessionModes, setSessionConfigOptions, updateCurrentMode, updateConfigOptionValue, setAvailableCommands, backfillAcpCapabilities } from '@/lib/ai/acp-agent-state';
+import { acpAgent, stopAcpAgent, ensureAcpAgent, updateAcpAgentInstanceId, setSessionModes, setSessionConfigOptions, updateCurrentMode, updateConfigOptionValue, setAvailableCommands, backfillAcpCapabilities, resolveConfiguredModeId } from '@/lib/ai/acp-agent-state';
 import { setupAcpChatListeners, buildAcpChatCleanup } from '@/hooks/useAcpSessionListeners';
 import { useAgentStatusStore } from '@/stores/agent-status-store';
 
@@ -45,7 +45,10 @@ export function reapplySessionMode(
   if (!session.modes || !session.session_id) return;
   const state = useChatStore.getState();
   const convMode = state.conversations.find((c) => c.id === state.activeConversationId)?.agentModeId;
-  const targetMode = convMode ?? (restored ? undefined : connection?.acpDefaults?.modeId);
+  // On restore, only an explicit per-conversation pick wins (don't impose the
+  // connection default over the agent's restored mode); on a fresh session, fall
+  // back to the connection default via the shared precedence resolver.
+  const targetMode = restored ? convMode : resolveConfiguredModeId(convMode, connection);
   if (!targetMode || targetMode === session.modes.currentModeId) return;
   updateCurrentMode(targetMode);
   tauriApi.acpSessionSetMode(instanceId, session.session_id, targetMode).catch((err) => {
@@ -463,6 +466,9 @@ export function useAcpLifecycle({ effectiveConnection, acpSystemMessage, buildAc
             }
           } else if (update.sessionUpdate === 'current_mode_update' && typeof update.currentModeId === 'string') {
             updateCurrentMode(update.currentModeId);
+            // Persist agent-initiated mode changes too, so a later restore re-applies
+            // the latest actual mode rather than a stale user pick.
+            useChatStore.getState().setConversationMode(update.currentModeId);
           } else if (update.sessionUpdate === 'config_option_update') {
             const configId = update.optionId ?? update.option_id;
             const value = update.selectedValueId ?? update.selected_value_id ?? update.value;
@@ -528,6 +534,8 @@ export function useAcpLifecycle({ effectiveConnection, acpSystemMessage, buildAc
   const lastPromptRef = useRef<{
     content: string;
     assistantMessageId: number;
+    /** Timestamp of the user message in the (re)sent pair — excluded from replayed history. */
+    userTimestamp: number;
     attachedFilePaths?: string[];
     sandboxPaths?: string[];
     attachments?: ImageAttachment[];
@@ -718,6 +726,7 @@ export function useAcpLifecycle({ effectiveConnection, acpSystemMessage, buildAc
       lastPromptRef.current = {
         content,
         assistantMessageId,
+        userTimestamp,
         attachedFilePaths: opts?.attachedFilePaths,
         sandboxPaths: opts?.sandboxPaths,
         attachments: opts?.attachments,
@@ -1060,11 +1069,10 @@ export function useAcpLifecycle({ effectiveConnection, acpSystemMessage, buildAc
         : acpSystemMessage;
       // On a fresh-session fallback, replay prior conversation history so the
       // agent keeps context (otherwise a crash-retry "breaks" the conversation).
-      // The retried pair is the assistant message + its user message; the user
-      // message timestamp is assistantMessageId - 1 (assistantMessageId =
-      // userTimestamp + 1 by construction in acpSendChatMessage).
+      // Exclude the retried pair (assistant message + its user message) by their
+      // actual timestamps captured at send time.
       const promptContent = isNewSession
-        ? `${effectiveSystemMessage}${buildAcpHistoryBlock([prompt.assistantMessageId, prompt.assistantMessageId - 1])}\n\n${prompt.content}`
+        ? `${effectiveSystemMessage}${buildAcpHistoryBlock([prompt.assistantMessageId, prompt.userTimestamp])}\n\n${prompt.content}`
         : prompt.content;
 
       try {

--- a/src/hooks/useAcpLifecycle.ts
+++ b/src/hooks/useAcpLifecycle.ts
@@ -54,6 +54,40 @@ export function reapplySessionMode(
 }
 
 /**
+ * Build the `<conversation-history>` preamble injected when a NEW ACP session
+ * starts mid-conversation — the first message of a fresh session, OR a
+ * crash-retry that fell back to a fresh session (session/load unsupported or
+ * failed). Without it, the new session gives the agent zero prior context and
+ * the conversation appears "broken" / the agent can't continue.
+ *
+ * Reads the active conversation's RESILIENT thread (so an orphaned activeLeafId
+ * can't collapse it to a single message), slices it to the active segment for
+ * provider context isolation, and excludes the message pair currently being
+ * (re)sent (passed as `excludeTimestamps`).
+ */
+export function buildAcpHistoryBlock(excludeTimestamps: number[]): string {
+  const store = useChatStore.getState();
+  const conv = store.conversations.find((c) => c.id === store.activeConversationId);
+  const segment = store.getActiveSegment();
+  const baseThread: ChatMessage[] = conv
+    ? getThreadResilient(conv.messages, conv.activeLeafId).thread
+    : [];
+  const allMessages = sliceThreadBySegment(baseThread, segment, conv?.messages ?? []);
+  const exclude = new Set(excludeTimestamps);
+  const priorMessages = allMessages.filter(
+    (m) => (m.timestamp === undefined || !exclude.has(m.timestamp)) && m.role !== 'system-status' && m.content,
+  );
+  if (priorMessages.length === 0) return '';
+  const lines = priorMessages.map((m) => {
+    const prefix = m.role === 'user' ? 'User' : 'Assistant';
+    const truncated = m.content.length > 2000 ? m.content.slice(0, 2000) + '\n... (truncated)' : m.content;
+    const suffix = m.interrupted ? ' [interrupted]' : '';
+    return `${prefix}${suffix}: ${truncated}`;
+  });
+  return `\n\n<conversation-history>\nThe following is the prior conversation in this session. The user may ask you to continue from where you left off.\n\n${lines.join('\n\n')}\n</conversation-history>`;
+}
+
+/**
  * Resolve the ACP session ID to use for the next prompt on the active conversation.
  *
  * Prefers a branch-specific session (attached after `session/fork` on a leaf-branch)
@@ -777,34 +811,9 @@ export function useAcpLifecycle({ effectiveConnection, acpSystemMessage, buildAc
           if (isNewSession) {
             // Build conversation history for context restoration after interruption.
             // Respect provider context isolation — when user chose "Start fresh",
-            // only include messages from the segment boundary onward. Uses the
-            // active-leaf thread (not raw `messages`) so branching stays correct
-            // (task #28 — segment boundary as message id).
-            const conv = useChatStore.getState().conversations
-              .find(c => c.id === useChatStore.getState().activeConversationId);
-            const segment = useChatStore.getState().getActiveSegment();
-            // Resilient walk so a corrupted/orphaned activeLeafId can't collapse
-            // the agent's history to just the last message ("agent can't continue").
-            const baseThread: ChatMessage[] = conv
-              ? getThreadResilient(conv.messages, conv.activeLeafId).thread
-              : [];
-            const allMessages = sliceThreadBySegment(baseThread, segment, conv?.messages ?? []);
-            const priorMessages = allMessages.filter(
-              (m) => m.timestamp !== assistantMessageId && m.timestamp !== userTimestamp
-                && m.role !== 'system-status' && m.content
-            );
-            let historyBlock = '';
-            if (priorMessages.length > 0) {
-              const lines = priorMessages.map((m) => {
-                const prefix = m.role === 'user' ? 'User' : 'Assistant';
-                const truncated = m.content.length > 2000
-                  ? m.content.slice(0, 2000) + '\n... (truncated)'
-                  : m.content;
-                const suffix = m.interrupted ? ' [interrupted]' : '';
-                return `${prefix}${suffix}: ${truncated}`;
-              });
-              historyBlock = `\n\n<conversation-history>\nThe following is the prior conversation in this session. The user may ask you to continue from where you left off.\n\n${lines.join('\n\n')}\n</conversation-history>`;
-            }
+            // only include messages from the segment boundary onward. Excludes the
+            // pair currently being sent (this user message + its assistant placeholder).
+            const historyBlock = buildAcpHistoryBlock([assistantMessageId, userTimestamp]);
             promptContent = `${effectiveSystemMessage}${historyBlock}\n\n${content}`;
           } else {
             promptContent = content;
@@ -1049,8 +1058,13 @@ export function useAcpLifecycle({ effectiveConnection, acpSystemMessage, buildAc
       const effectiveSystemMessage = buildAcpSystemMessage
         ? buildAcpSystemMessage(prompt.attachedFilePaths)
         : acpSystemMessage;
+      // On a fresh-session fallback, replay prior conversation history so the
+      // agent keeps context (otherwise a crash-retry "breaks" the conversation).
+      // The retried pair is the assistant message + its user message; the user
+      // message timestamp is assistantMessageId - 1 (assistantMessageId =
+      // userTimestamp + 1 by construction in acpSendChatMessage).
       const promptContent = isNewSession
-        ? `${effectiveSystemMessage}\n\n${prompt.content}`
+        ? `${effectiveSystemMessage}${buildAcpHistoryBlock([prompt.assistantMessageId, prompt.assistantMessageId - 1])}\n\n${prompt.content}`
         : prompt.content;
 
       try {

--- a/src/hooks/useAcpSessionListeners.ts
+++ b/src/hooks/useAcpSessionListeners.ts
@@ -263,7 +263,11 @@ export async function setupAcpChatListeners(deps: ChatListenerDeps): Promise<Acp
       }
     } else if (update.sessionUpdate === 'current_mode_update' && (update.currentModeId || update.current_mode_id)) {
       // Agent-initiated mode change (camelCase from ACP schema)
-      updateCurrentMode(String(update.currentModeId ?? update.current_mode_id));
+      const nextModeId = String(update.currentModeId ?? update.current_mode_id);
+      updateCurrentMode(nextModeId);
+      // Persist so a later restore re-applies the latest actual mode (keeps the
+      // conversation's agentModeId in sync with agent self-changes).
+      useChatStore.getState().setConversationMode(nextModeId);
     } else if (update.sessionUpdate === 'config_option_update' && (update.configId || update.config_id)) {
       // Agent-initiated config option change (camelCase from ACP schema)
       const configId = String(update.configId ?? update.config_id);

--- a/src/hooks/useChatSwitchPrompts.ts
+++ b/src/hooks/useChatSwitchPrompts.ts
@@ -6,6 +6,7 @@ import {
   selectPendingProjectSwitch,
   selectPendingAgentSwitch,
 } from '@/stores/chat-store';
+import { log } from '@/lib/logger';
 import { useConnectionsStore } from '@/stores/connections-store';
 import { useRoutingStore } from '@/stores/routing-store';
 import { useProjectMetadataStore } from '@/stores/project-metadata-store';
@@ -33,6 +34,16 @@ import { useProjectMetadataStore } from '@/stores/project-metadata-store';
  *   - Empty message history (nothing to isolate)
  *   - First-render rehydration (prev was empty/undefined)
  *   - A pending prompt already in flight (don't stack)
+ *   - A conversation switch. The detection is keyed to
+ *     `activeConversationId`: each ref stores the conversation it was
+ *     captured in, and when the active conversation changes we treat the
+ *     new scope/connection as a SILENT RESTORE — never a "change". Without
+ *     this, switching from conversation A (scope P_A) to B (scope P_B)
+ *     diffs P_A vs P_B and falsely fires ProjectSwitchCard / AgentSwitchCard,
+ *     even though the user only opened B (which always had P_B). That
+ *     spurious switch also spawns a redundant segment + fresh agent
+ *     session, severing restored context. The prompt must fire ONLY when
+ *     the scope/connection mutates WITHIN a single conversation.
  *
  * The hook lives in `useChatSwitchPrompts` so the chat surface
  * (`FloatingCommandBar`) can mount it once and get the data-isolation
@@ -40,6 +51,7 @@ import { useProjectMetadataStore } from '@/stores/project-metadata-store';
  */
 export function useChatSwitchPrompts(): void {
   const messages = useChatStore(selectMessages);
+  const activeConversationId = useChatStore((s) => s.activeConversationId);
   const selectedProjectPaths = useChatStore(selectProjectPaths);
   const pendingProjectSwitch = useChatStore(selectPendingProjectSwitch);
   const pendingAgentSwitch = useChatStore(selectPendingAgentSwitch);
@@ -82,50 +94,67 @@ export function useChatSwitchPrompts(): void {
   const effectiveConnection =
     lockedConnection ?? projectOverrideConnection ?? interactiveConnection;
 
-  // Project selection change.
-  const prevProjectPathsRef = useRef<string[]>(selectedProjectPaths);
+  // Project selection change. The ref carries the conversation the paths
+  // were captured in; a conversation switch resets it silently (no prompt).
+  const prevProjectPathsRef = useRef<{ convId: string | null; paths: string[] }>({
+    convId: activeConversationId,
+    paths: selectedProjectPaths,
+  });
   useEffect(() => {
     const prev = prevProjectPathsRef.current;
     const curr = selectedProjectPaths;
-    prevProjectPathsRef.current = curr;
+    const currConvId = activeConversationId;
+    prevProjectPathsRef.current = { convId: currConvId, paths: curr };
 
+    // Conversation switch (or restore) — adopt the new scope silently.
+    if (prev.convId !== currConvId) return;
     if (messages.length === 0) return;
-    if (prev.length === 0) return;
-    const prevSet = new Set(prev);
+    if (prev.paths.length === 0) return;
+    const prevSet = new Set(prev.paths);
     const currSet = new Set(curr);
     if (prevSet.size === currSet.size && [...prevSet].every((p) => currSet.has(p)))
       return;
     if (pendingProjectSwitch) return;
 
-    setPendingProjectSwitch(curr, prev);
+    log.info(
+      'ai',
+      `[switch-prompt] in-conversation project change conv=${currConvId} [${prev.paths.join('|')}] → [${curr.join('|')}]`,
+    );
+    setPendingProjectSwitch(curr, prev.paths);
   }, [
+    activeConversationId,
     selectedProjectPaths,
     messages.length,
     pendingProjectSwitch,
     setPendingProjectSwitch,
   ]);
 
-  // Provider connection change.
-  const prevConnectionRef = useRef<string | undefined>(
-    effectiveConnection?.id,
-  );
+  // Provider connection change. Same conversation-scoping as projects.
+  const prevConnectionRef = useRef<{ convId: string | null; id: string | undefined }>({
+    convId: activeConversationId,
+    id: effectiveConnection?.id,
+  });
   useEffect(() => {
     const prev = prevConnectionRef.current;
     const curr = effectiveConnection?.id;
-    prevConnectionRef.current = curr;
+    const currConvId = activeConversationId;
+    prevConnectionRef.current = { convId: currConvId, id: curr };
 
+    // Conversation switch (or restore) — adopt the new connection silently.
+    if (prev.convId !== currConvId) return;
     if (messages.length === 0) return;
-    if (prev === curr) return;
-    if (!prev || !curr) return;
+    if (prev.id === curr) return;
+    if (!prev.id || !curr) return;
     if (pendingAgentSwitch) return;
 
-    const prevConn = allConnections.find((c) => c.id === prev);
+    const prevConn = allConnections.find((c) => c.id === prev.id);
     const currConn = allConnections.find((c) => c.id === curr);
     setPendingAgentSwitch(
       currConn?.label ?? 'Unknown provider',
       prevConn?.label ?? 'Unknown provider',
     );
   }, [
+    activeConversationId,
     effectiveConnection?.id,
     messages.length,
     pendingAgentSwitch,

--- a/src/lib/__tests__/chat-tree.test.ts
+++ b/src/lib/__tests__/chat-tree.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getThread, getChildren, getBranches, getLeaves, getDescendants } from '@/lib/chat-tree';
+import { getThread, getThreadResilient, getChildren, getBranches, getLeaves, getDescendants } from '@/lib/chat-tree';
 import type { ChatMessage } from '@/lib/ai/types';
 
 function msg(id: string, parentId: string | null, role: 'user' | 'assistant' = 'user', ts?: number): ChatMessage {
@@ -212,6 +212,77 @@ describe('chat-tree', () => {
       ];
       const desc = getDescendants(messages, '2');
       expect(desc).toEqual(new Set(['2', '3', '4', '5']));
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // getThreadResilient — orphaned-leaf recovery (history never disappears)
+  // -----------------------------------------------------------------------
+  describe('getThreadResilient', () => {
+    const linear: ChatMessage[] = [
+      msg('1', null, 'user', 1),
+      msg('2', '1', 'assistant', 2),
+      msg('3', '2', 'user', 3),
+      msg('4', '3', 'assistant', 4),
+    ];
+
+    it('returns the clean thread and broken=false for a healthy chain', () => {
+      const { thread, broken } = getThreadResilient(linear, '4');
+      expect(thread.map((m) => m.id)).toEqual(['1', '2', '3', '4']);
+      expect(broken).toBe(false);
+    });
+
+    it('is broken=false for a healthy branch (normal branching unaffected)', () => {
+      const branched: ChatMessage[] = [
+        msg('1', null, 'user', 1),
+        msg('2', '1', 'assistant', 2),
+        msg('3a', '2', 'user', 3),
+        msg('3b', '2', 'user', 4),
+      ];
+      const { thread, broken } = getThreadResilient(branched, '3b');
+      expect(thread.map((m) => m.id)).toEqual(['1', '2', '3b']);
+      expect(broken).toBe(false);
+    });
+
+    it('recovers full history when the leaf parent chain is orphaned', () => {
+      // '4' points at parent '3', but '3' was removed → plain getThread would
+      // return just ['4']; resilient falls back to all messages chronologically.
+      const orphaned: ChatMessage[] = [
+        msg('1', null, 'user', 1),
+        msg('2', '1', 'assistant', 2),
+        // '3' deleted
+        msg('4', '3', 'assistant', 4),
+      ];
+      expect(getThread(orphaned, '4').map((m) => m.id)).toEqual(['4']); // the bug
+      const { thread, broken } = getThreadResilient(orphaned, '4');
+      expect(broken).toBe(true);
+      expect(thread.map((m) => m.id)).toEqual(['1', '2', '4']); // history recovered
+    });
+
+    it('recovers when the leaf itself is missing', () => {
+      const { thread, broken } = getThreadResilient(linear, 'nonexistent');
+      expect(broken).toBe(true);
+      expect(thread.map((m) => m.id)).toEqual(['1', '2', '3', '4']);
+    });
+
+    it('recovers from a parentId cycle without infinite looping', () => {
+      const cyclic: ChatMessage[] = [
+        msg('a', 'b', 'user', 1),
+        msg('b', 'a', 'assistant', 2),
+      ];
+      const { thread, broken } = getThreadResilient(cyclic, 'a');
+      expect(broken).toBe(true);
+      expect(thread.map((m) => m.id).sort()).toEqual(['a', 'b']);
+    });
+
+    it('returns all messages chronologically when no leafId is given', () => {
+      const { thread, broken } = getThreadResilient(linear, null);
+      expect(broken).toBe(false);
+      expect(thread.map((m) => m.id)).toEqual(['1', '2', '3', '4']);
+    });
+
+    it('returns empty for an empty conversation', () => {
+      expect(getThreadResilient([], '4')).toEqual({ thread: [], broken: false });
     });
   });
 });

--- a/src/lib/__tests__/chat-tree.test.ts
+++ b/src/lib/__tests__/chat-tree.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getThread, getThreadResilient, getChildren, getBranches, getLeaves, getDescendants } from '@/lib/chat-tree';
+import { getThread, getThreadResilient, sortByTimestamp, getChildren, getBranches, getLeaves, getDescendants } from '@/lib/chat-tree';
 import type { ChatMessage } from '@/lib/ai/types';
 
 function msg(id: string, parentId: string | null, role: 'user' | 'assistant' = 'user', ts?: number): ChatMessage {
@@ -283,6 +283,20 @@ describe('chat-tree', () => {
 
     it('returns empty for an empty conversation', () => {
       expect(getThreadResilient([], '4')).toEqual({ thread: [], broken: false });
+    });
+  });
+
+  describe('sortByTimestamp', () => {
+    it('sorts ascending by timestamp and does not mutate the input', () => {
+      const input = [msg('c', null, 'user', 3), msg('a', null, 'user', 1), msg('b', null, 'user', 2)];
+      const sorted = sortByTimestamp(input);
+      expect(sorted.map((m) => m.id)).toEqual(['a', 'b', 'c']);
+      expect(input.map((m) => m.id)).toEqual(['c', 'a', 'b']); // original untouched
+    });
+
+    it('treats undefined timestamps as 0', () => {
+      const input = [msg('b', null, 'user', 2), { id: 'a', parentId: null, role: 'user' as const, content: 'x' }];
+      expect(sortByTimestamp(input).map((m) => m.id)).toEqual(['a', 'b']);
     });
   });
 });

--- a/src/lib/ai/__tests__/acp-agent-state.test.ts
+++ b/src/lib/ai/__tests__/acp-agent-state.test.ts
@@ -349,3 +349,23 @@ describe('ensureAcpAgent', () => {
     expect(mod.acpAgent!.instanceId).toBe('new-id');
   });
 });
+
+describe('resolveConfiguredModeId', () => {
+  it('prefers the per-conversation pick over the connection default', async () => {
+    const mod = await import('../acp-agent-state');
+    const conn = makeConnection({ acpDefaults: { modeId: 'default' } });
+    expect(mod.resolveConfiguredModeId('acceptEdits', conn)).toBe('acceptEdits');
+  });
+
+  it('falls back to the connection default when there is no conversation pick', async () => {
+    const mod = await import('../acp-agent-state');
+    const conn = makeConnection({ acpDefaults: { modeId: 'plan' } });
+    expect(mod.resolveConfiguredModeId(undefined, conn)).toBe('plan');
+  });
+
+  it('returns undefined when neither is set', async () => {
+    const mod = await import('../acp-agent-state');
+    expect(mod.resolveConfiguredModeId(undefined, makeConnection())).toBeUndefined();
+    expect(mod.resolveConfiguredModeId(undefined, null)).toBeUndefined();
+  });
+});

--- a/src/lib/ai/acp-agent-state.ts
+++ b/src/lib/ai/acp-agent-state.ts
@@ -96,6 +96,20 @@ export function getCommonModes(availableModes: { id: string; name: string; descr
   return result;
 }
 
+/**
+ * The configured mode for a conversation: the per-conversation pick if set,
+ * otherwise the connection's default mode. Single source of the
+ * `conversationModeId → connection.acpDefaults.modeId` precedence so the footer
+ * picker and `reapplySessionMode` can't drift. Returns undefined when neither is
+ * set (caller falls back to a display default or the agent's own default).
+ */
+export function resolveConfiguredModeId(
+  conversationModeId: string | undefined,
+  connection: Connection | null,
+): string | undefined {
+  return conversationModeId ?? connection?.acpDefaults?.modeId;
+}
+
 // ---------------------------------------------------------------------------
 // Agent state (module-level singleton — survives re-renders)
 // ---------------------------------------------------------------------------

--- a/src/lib/chat-tree.ts
+++ b/src/lib/chat-tree.ts
@@ -30,6 +30,65 @@ export function getThread(messages: ChatMessage[], leafId: string | null | undef
 }
 
 /**
+ * Resilient variant of {@link getThread}. Walks from the leaf to a root via
+ * `parentId`, but detects a CORRUPTED chain — a `parentId` that references a
+ * message not present in the list, or a cycle — and, rather than silently
+ * returning a truncated (often single-message) thread, falls back to the full
+ * message list in chronological order so history is never hidden.
+ *
+ * This is the safety net for the "history disappears, only the last message is
+ * visible" failure: an orphaned `activeLeafId` makes the plain `getThread` stop
+ * at the first missing ancestor. A genuine linear/branched conversation always
+ * terminates at a real root (`parentId == null`) and reports `broken: false`,
+ * so normal branching is unaffected.
+ *
+ * @returns `{ thread, broken }` — `broken` is true only on real corruption, so
+ *   callers can log a diagnostic without firing on healthy conversations.
+ */
+export function getThreadResilient(
+  messages: ChatMessage[],
+  leafId: string | null | undefined,
+): { thread: ChatMessage[]; broken: boolean } {
+  if (messages.length === 0) return { thread: [], broken: false };
+  const chronological = () => [...messages].sort((a, b) => (a.timestamp ?? 0) - (b.timestamp ?? 0));
+  // No leaf pointer — legacy/empty conversations show everything.
+  if (!leafId) return { thread: chronological(), broken: false };
+
+  const byId = new Map<string, ChatMessage>();
+  for (const msg of messages) {
+    if (msg.id) byId.set(msg.id, msg);
+  }
+
+  const leaf = byId.get(leafId);
+  if (!leaf) return { thread: chronological(), broken: true };
+
+  const thread: ChatMessage[] = [];
+  const seen = new Set<string>();
+  let current: ChatMessage | undefined = leaf;
+  let broken = false;
+  while (current) {
+    if (current.id && seen.has(current.id)) {
+      broken = true; // cycle
+      break;
+    }
+    if (current.id) seen.add(current.id);
+    thread.push(current);
+    const pid = current.parentId;
+    if (pid === null || pid === undefined) break; // reached a genuine root
+    const parent = byId.get(pid);
+    if (!parent) {
+      broken = true; // parent referenced but missing → orphaned chain
+      break;
+    }
+    current = parent;
+  }
+
+  if (broken) return { thread: chronological(), broken: true };
+  thread.reverse();
+  return { thread, broken: false };
+}
+
+/**
  * Get the direct children of a message (messages whose parentId matches the given id).
  */
 export function getChildren(messages: ChatMessage[], parentId: string | null): ChatMessage[] {

--- a/src/lib/chat-tree.ts
+++ b/src/lib/chat-tree.ts
@@ -1,5 +1,10 @@
 import type { ChatMessage } from '@/lib/ai/types';
 
+/** Return a copy of `messages` sorted ascending by timestamp (undefined → 0). */
+export function sortByTimestamp(messages: ChatMessage[]): ChatMessage[] {
+  return [...messages].sort((a, b) => (a.timestamp ?? 0) - (b.timestamp ?? 0));
+}
+
 /**
  * Walk from a leaf message to the root via parentId, return messages in
  * chronological order (root first). This is the linear thread that AI hooks
@@ -50,7 +55,7 @@ export function getThreadResilient(
   leafId: string | null | undefined,
 ): { thread: ChatMessage[]; broken: boolean } {
   if (messages.length === 0) return { thread: [], broken: false };
-  const chronological = () => [...messages].sort((a, b) => (a.timestamp ?? 0) - (b.timestamp ?? 0));
+  const chronological = () => sortByTimestamp(messages);
   // No leaf pointer — legacy/empty conversations show everything.
   if (!leafId) return { thread: chronological(), broken: false };
 
@@ -131,8 +136,7 @@ export function getBranches(messages: ChatMessage[], messageId: string): ChatMes
       }
     }
     // Sort by timestamp for chronological order
-    branch.sort((a, b) => (a.timestamp ?? 0) - (b.timestamp ?? 0));
-    return branch;
+    return sortByTimestamp(branch);
   });
 }
 

--- a/src/stores/chat-store.ts
+++ b/src/stores/chat-store.ts
@@ -61,6 +61,13 @@ export interface Conversation {
   /** ACP session ID for session restoration via session/load */
   acpSessionId?: string;
   /**
+   * User-selected ACP session permission mode (e.g. 'acceptEdits' = Agent) for this
+   * conversation. Persisted so it survives agent respawns (scope changes spawn a fresh
+   * session that resets to the agent's default mode). Falls back to the connection's
+   * `acpDefaults.modeId` when unset. See `useAcpLifecycle` mode re-application.
+   */
+  agentModeId?: string;
+  /**
    * Per-branch ACP session IDs, keyed by the new branch's first message ID (assigned when
    * the first message after branching is added). Populated only when `session/fork` was
    * used on a leaf-branch. Historical branches and pre-migration conversations continue
@@ -200,6 +207,8 @@ interface ChatStore {
   getActiveSegment: () => ConversationSegment | undefined;
   /** Update the session ID on the active segment */
   setSegmentSessionId: (sessionId: string) => void;
+  /** Persist the user-selected ACP permission mode on the active conversation. */
+  setConversationMode: (modeId: string) => void;
 
   /** Remove project paths that no longer exist from all conversations. */
   pruneStaleProjectPaths: (validPaths: Set<string>) => void;
@@ -827,6 +836,9 @@ export const useChatStore = create<ChatStore>()(
             i === c.activeSegmentIndex ? { ...s, sessionId } : s
           ),
         }))),
+
+      setConversationMode: (modeId) =>
+        set((state) => updateActiveConv(state, (c) => ({ ...c, agentModeId: modeId }))),
 
       pruneStaleProjectPaths: (validPaths) =>
         set((state) => {

--- a/src/stores/chat-store.ts
+++ b/src/stores/chat-store.ts
@@ -2,7 +2,8 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import type { ChatMessage, Citation, AgentActivity, ToolCall, ToolCallActivity, SystemStatusType, Segment } from '@/lib/ai/types';
 import { createTauriStorage } from '@/lib/tauri-storage';
-import { getThread, getDescendants, getChildren, getLeaves } from '@/lib/chat-tree';
+import { getThread, getThreadResilient, getDescendants, getChildren, getLeaves } from '@/lib/chat-tree';
+import { log } from '@/lib/logger';
 // Note: the thread-slicing helper `sliceThreadBySegment` is declared below and
 // exported for use by hooks/components that apply segment-based context isolation.
 import { autoTitle, pruneConversations, pruneStaleProjectPaths as pruneStaleProjectPathsUtil } from '@/lib/conversationOps';
@@ -1001,6 +1002,9 @@ const EMPTY_SEGMENTS: ConversationSegment[] = [];
  * IMPORTANT: Must return a stable reference when the result hasn't changed,
  * otherwise Zustand triggers infinite re-renders (new array !== old array).
  */
+/** Conversations already warned about an orphaned thread — dedupes the log. */
+const warnedOrphanThreads = new Set<string>();
+
 export const selectMessages = (() => {
   // Per-conversation thread memoization. A single shared slot (the previous
   // design) corrupts the moment two subscribers render different conversations
@@ -1025,7 +1029,20 @@ export const selectMessages = (() => {
       const entry = cache.get(conv.id);
       if (entry && entry.key === key) return entry.thread;
 
-      const thread = getThread(conv.messages, conv.activeLeafId);
+      // Resilient walk: an orphaned activeLeafId (parent chain references a
+      // missing message) would make a plain getThread return just the leaf,
+      // hiding all history. getThreadResilient falls back to the full thread
+      // on corruption so history is never lost.
+      const { thread, broken } = getThreadResilient(conv.messages, conv.activeLeafId);
+      if (broken && !warnedOrphanThreads.has(conv.id)) {
+        warnedOrphanThreads.add(conv.id);
+        log.warn(
+          'ai',
+          `[chat] orphaned activeLeafId=${conv.activeLeafId} in conv=${conv.id} (${conv.messages.length} msgs) — recovered full history`,
+        );
+      } else if (!broken) {
+        warnedOrphanThreads.delete(conv.id);
+      }
       const result = thread.length > 0 ? thread : conv.messages;
       cache.set(conv.id, { key, thread: result });
       if (cache.size > MAX_ENTRIES) {

--- a/src/stores/chat-store.ts
+++ b/src/stores/chat-store.ts
@@ -221,6 +221,8 @@ interface ChatStore {
 
 const MAX_CONVERSATIONS = 50;
 const MAX_MESSAGES_PER_CONVERSATION = 500;
+/** Conversations already warned about an orphaned thread — dedupes the log. Cleared on delete. */
+const warnedOrphanThreads = new Set<string>();
 
 /**
  * Monotonically increasing timestamp for conversation updates.
@@ -304,6 +306,7 @@ export const useChatStore = create<ChatStore>()(
       },
 
       deleteConversation: (id) => {
+        warnedOrphanThreads.delete(id); // don't retain diagnostic state for a gone conversation
         set((state) => {
           const remaining = state.conversations.filter((c) => c.id !== id);
           let nextActive = state.activeConversationId;
@@ -1002,9 +1005,6 @@ const EMPTY_SEGMENTS: ConversationSegment[] = [];
  * IMPORTANT: Must return a stable reference when the result hasn't changed,
  * otherwise Zustand triggers infinite re-renders (new array !== old array).
  */
-/** Conversations already warned about an orphaned thread — dedupes the log. */
-const warnedOrphanThreads = new Set<string>();
-
 export const selectMessages = (() => {
   // Per-conversation thread memoization. A single shared slot (the previous
   // design) corrupts the moment two subscribers render different conversations


### PR DESCRIPTION
Fixes a family of related ACP conversation-state bugs surfaced during live use. All share one theme: per-conversation session/mode/branch state was not durable or not consistently reconstructed, so routine actions silently corrupted it.

## Symptoms fixed

1. **Agent mode reverts to "Read Only".** The chat-footer permission mode lived only in transient session state and was reset to the agent default on every new ACP session. A sandbox-scope change (first send into a project, or adding/removing a project) respawns the agent → fresh session → mode silently reverted. Now persisted per-conversation (`agentModeId`) and re-asserted after every session (re)creation via a shared `reapplySessionMode` at all 3 creation sites.

2. **Spurious "Project changed to…" prompt on conversation switch.** `useChatSwitchPrompts` diffed project paths / connection against a ref that persisted across conversation switches, so opening a different conversation (whose saved scope differs from the previous one) was misread as an in-conversation change — firing `ProjectSwitchCard`, appending a redundant `ContextDivider` segment, and severing the restored session ("Session: Pending"). Detection is now scoped to `activeConversationId`: a switch/restore is silent; the prompt fires only on an *in-conversation* scope/provider change.

3. **Resend/retry after a crash: history disappears, agent can't continue.** An orphaned `activeLeafId` (parent chain referencing a missing message) made `getThread` return only the leaf, and `selectMessages` only fell back to all-messages when the thread was *empty* — so it rendered just the last message, and the ACP send fed the agent that same single message. New `getThreadResilient` detects a corrupted chain (or cycle) and recovers the full history; wired into chat display, ACP send, conversation export, and delegation. Plus: the crash-retry fresh-session fallback now replays `<conversation-history>` (it previously sent zero context).

## Review follow-ups (last commit)
- Resilience routed through the remaining history surfaces (export, delegation); structural branch walks intentionally kept strict.
- Retry history exclusion uses a stored `userTimestamp` instead of `assistantMessageId - 1` arithmetic.
- `agentModeId` made single-source-of-truth: agent-initiated `current_mode_update` changes are persisted too.
- Mode precedence de-duplicated behind `resolveConfiguredModeId` (picker + reapply can't drift).
- `warnedOrphanThreads` cleared on conversation delete; `sortByTimestamp` extracted/shared.

## Tests / gates
- New regression tests: per-conversation mode re-apply across respawn, conversation-scoped switch detection, orphaned-thread recovery, crash-retry history replay, `sortByTimestamp`, `resolveConfiguredModeId`.
- `pnpm typecheck` green; full unit suite green (5420 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)