### PR TITLE
chore: release v0.46.0-alpha.22

### DIFF
--- a/docs/history/147-release-v0.46.0-alpha.22.md
+++ b/docs/history/147-release-v0.46.0-alpha.22.md
@@ -1,0 +1,24 @@
+# Release v0.46.0-alpha.22
+
+**Date:** 2026-06-10
+**Previous version:** 0.46.0-alpha.21
+**Channel:** Alpha
+
+Auto-cut by `aw-alpha-cut`. Sections below are auto-classified from merged PRs; refine the prose before promoting to stable.
+
+## Changes
+
+### Fixes
+- fix(ci): alpha-cut gates on any merged PR, no-ops cleanly when idle (#442)
+- fix(acp): conversation/session/branch state integrity (#445)
+
+## Under the hood
+
+Auto-generated from merged PRs + commits since `v0.46.0-alpha.21`. Alpha builds list commit-level detail for technical users.
+
+- chore(editor): split StatusTray.tsx into one-component-per-file (#440)
+- security: harden skill/MCP execution, link-preview beacons, CSP, asset scope (#444)
+- fix(acp): conversation/session/branch state integrity (#445)
+- security: harden skill/MCP execution, link-preview beacons, CSP, asset scope (#444)
+- fix(ci): alpha-cut gates on any merged PR, no-ops cleanly when idle (#442)
+- chore(editor): split StatusTray.tsx into one-component-per-file (#439) (#440)

--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -150,3 +150,4 @@ Chronological log of major implementation milestones and changes.
 | 144 | [Release v0.46.0-alpha.19](144-release-v0.46.0-alpha.19.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
 | 145 | [Release v0.46.0-alpha.20](145-release-v0.46.0-alpha.20.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
 | 146 | [Release v0.46.0-alpha.21](146-release-v0.46.0-alpha.21.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
+| 147 | [Release v0.46.0-alpha.22](147-release-v0.46.0-alpha.22.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "notesage",
   "private": true,
-  "version": "0.46.0-alpha.21",
+  "version": "0.46.0-alpha.22",
   "license": "MIT",
   "author": "Peter Blenessy",
   "type": "module",

--- a/public/changelog-alpha.json
+++ b/public/changelog-alpha.json
@@ -1,6 +1,25 @@
 {
   "releases": [
     {
+      "version": "0.46.0-alpha.22",
+      "date": "2026-06-10",
+      "previousVersion": "0.46.0-alpha.21",
+      "sections": {
+        "fixes": [
+          "fix(ci): alpha-cut gates on any merged PR, no-ops cleanly when idle (#442)",
+          "fix(acp): conversation/session/branch state integrity (#445)"
+        ]
+      },
+      "underTheHood": [
+        "chore(editor): split StatusTray.tsx into one-component-per-file (#440)",
+        "security: harden skill/MCP execution, link-preview beacons, CSP, asset scope (#444)",
+        "fix(acp): conversation/session/branch state integrity (#445)",
+        "security: harden skill/MCP execution, link-preview beacons, CSP, asset scope (#444)",
+        "fix(ci): alpha-cut gates on any merged PR, no-ops cleanly when idle (#442)",
+        "chore(editor): split StatusTray.tsx into one-component-per-file (#439) (#440)"
+      ]
+    },
+    {
       "version": "0.46.0-alpha.21",
       "date": "2026-06-09",
       "previousVersion": "0.46.0-alpha.20",


### PR DESCRIPTION
Auto-cut by `aw-alpha-cut`. The history file at `docs/history/147-release-v0.46.0-alpha.22.md` lists the merged PRs.

## PRs included

- #440
- #442
- #444
- #445

Auto-merge enabled. Once the 4 required status checks pass, this merges to main, and the `tag-after-merge` job in `aw-alpha-cut.yml` tags + pushes `v0.46.0-alpha.22`. `release.yml` then builds and publishes.
