### PR TITLE
chore: release v0.46.0-alpha.23

### DIFF
--- a/docs/history/148-release-v0.46.0-alpha.23.md
+++ b/docs/history/148-release-v0.46.0-alpha.23.md
@@ -1,0 +1,19 @@
+# Release v0.46.0-alpha.23
+
+**Date:** 2026-06-10
+**Previous version:** 0.46.0-alpha.22
+**Channel:** Alpha
+
+Auto-cut by `aw-alpha-cut`. Sections below are auto-classified from merged PRs; refine the prose before promoting to stable.
+
+## Changes
+
+### Fixes
+- fix(html-viewer): render iframe paths from blob: URL so document styles survive the CSP (#447)
+
+## Under the hood
+
+Auto-generated from merged PRs + commits since `v0.46.0-alpha.22`. Alpha builds list commit-level detail for technical users.
+
+- security: harden skill/MCP execution, link-preview beacons, CSP, asset scope (#444)
+- fix(html-viewer): render iframe paths from blob: URL so document styles survive the CSP (#447)

--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -151,3 +151,4 @@ Chronological log of major implementation milestones and changes.
 | 145 | [Release v0.46.0-alpha.20](145-release-v0.46.0-alpha.20.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
 | 146 | [Release v0.46.0-alpha.21](146-release-v0.46.0-alpha.21.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
 | 147 | [Release v0.46.0-alpha.22](147-release-v0.46.0-alpha.22.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
+| 148 | [Release v0.46.0-alpha.23](148-release-v0.46.0-alpha.23.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "notesage",
   "private": true,
-  "version": "0.46.0-alpha.22",
+  "version": "0.46.0-alpha.23",
   "license": "MIT",
   "author": "Peter Blenessy",
   "type": "module",

--- a/public/changelog-alpha.json
+++ b/public/changelog-alpha.json
@@ -1,6 +1,20 @@
 {
   "releases": [
     {
+      "version": "0.46.0-alpha.23",
+      "date": "2026-06-10",
+      "previousVersion": "0.46.0-alpha.22",
+      "sections": {
+        "fixes": [
+          "fix(html-viewer): render iframe paths from blob: URL so document styles survive the CSP (#447)"
+        ]
+      },
+      "underTheHood": [
+        "security: harden skill/MCP execution, link-preview beacons, CSP, asset scope (#444)",
+        "fix(html-viewer): render iframe paths from blob: URL so document styles survive the CSP (#447)"
+      ]
+    },
+    {
       "version": "0.46.0-alpha.22",
       "date": "2026-06-10",
       "previousVersion": "0.46.0-alpha.21",


### PR DESCRIPTION
Auto-cut by `aw-alpha-cut`. The history file at `docs/history/148-release-v0.46.0-alpha.23.md` lists the merged PRs.

## PRs included

- #444
- #447

Auto-merge enabled. Once the 4 required status checks pass, this merges to main, and the `tag-after-merge` job in `aw-alpha-cut.yml` tags + pushes `v0.46.0-alpha.23`. `release.yml` then builds and publishes.
