### PR TITLE
fix(html-viewer): restore find-in-document in the sandboxed iframe modes

### DIFF
--- a/e2e-real/tests/html-viewer-csp.test.ts
+++ b/e2e-real/tests/html-viewer-csp.test.ts
@@ -169,4 +169,47 @@ describe('HTML viewer renders document styles under the app CSP', () => {
         expect(pixel.b).toBeGreaterThan(pixel.r);
         console.log(`[csp-test] frame centre pixel: rgb(${pixel.r}, ${pixel.g}, ${pixel.b}) — styles applied`);
     });
+
+    it('searches inside the sandboxed iframe via postMessage (find-in-document)', async () => {
+        const filePath = `${TEST_PROJECT_PATH}/${HTML_FILE}`;
+        const content = await tauriInvoke<string>('read_file', { path: filePath });
+        await browser.execute(
+            (fp: string, name: string, html: string) => {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                const w = window as any;
+                w.__E2E_EDITOR_STORE__?.getState().openTab(fp, name, html, null, 'other');
+            },
+            filePath,
+            HTML_FILE,
+            content,
+        );
+        const iframe = await browser.$('iframe');
+        await iframe.waitForExist({ timeout: 10000 });
+        await browser.waitUntil(
+            async () => ((await iframe.getAttribute('src')) ?? '').startsWith('blob:'),
+            { timeout: 10000, timeoutMsg: 'iframe never received a blob: src' },
+        );
+
+        // Open the find bar (Cmd+F path) and search for a word that appears once
+        // in the fixture body ("navy"). The host can't reach into the sandboxed
+        // frame — the match count below only updates if the injected in-frame
+        // script received the query over postMessage, searched, and posted back.
+        await browser.execute(() => window.dispatchEvent(new Event('notesage:find-open')));
+        const input = await browser.$('input[aria-label="Find in document"]');
+        await input.waitForExist({ timeout: 10000 });
+        await input.setValue('navy');
+
+        await browser.waitUntil(
+            async () => {
+                const count = await browser.execute(() => {
+                    const spans = Array.from(document.querySelectorAll('span'));
+                    const el = spans.find((s) => /^\d+\/\d+$/.test((s.textContent || '').trim()));
+                    return el ? (el.textContent || '').trim() : null;
+                });
+                return count === '1/1';
+            },
+            { timeout: 10000, timeoutMsg: 'find bar never showed the in-frame match count (1/1)' },
+        );
+        console.log('[csp-test] in-frame search reported 1/1 for "navy"');
+    });
 });

--- a/src/components/editor/viewers/HtmlViewer.tsx
+++ b/src/components/editor/viewers/HtmlViewer.tsx
@@ -4,6 +4,7 @@ import { cn } from "@/lib/utils";
 import DOMPurify from "dompurify";
 import { invoke } from "@tauri-apps/api/core";
 import { highlightDomMatches, clearDomHighlights } from "@/lib/dom-search";
+import { injectFindScript, HTML_FIND_NS, type HtmlFindResult } from "./html-find-frame";
 import { CodeEditor } from "./CodeEditor";
 import { ViewerToolbarPill } from "./ViewerToolbarPill";
 import { useSettingsStore } from "@/stores/settings-store";
@@ -150,13 +151,21 @@ export function HtmlViewer({
   const [searchQuery, setSearchQuery] = useState("");
   const [searchMatches, setSearchMatches] = useState<HTMLElement[]>([]);
   const [searchCurrentIndex, setSearchCurrentIndex] = useState(-1);
+  // Match count for the iframe paths (div mode uses searchMatches.length instead).
+  const [frameMatchCount, setFrameMatchCount] = useState(0);
   const [zoom, setZoom] = useState(1.0);
   const [unsafeMode, setUnsafeMode] = useState(false);
   const [showConfirmDialog, setShowConfirmDialog] = useState(false);
 
   const renderRef = useRef<HTMLDivElement>(null);
+  const iframeRef = useRef<HTMLIFrameElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const searchMatchesRef = useRef<HTMLElement[]>([]);
+
+  // Search runs inside the sandboxed iframe (via postMessage) in the
+  // allow-scripts / unsafe-preview paths; in the default sanitised-div path it
+  // runs over the host DOM.
+  const isIframeMode = allowScripts || unsafeMode;
   const searchInputRef = useRef<HTMLInputElement>(null);
 
   // Whether the content is empty or whitespace-only (triggers placeholder)
@@ -250,10 +259,31 @@ export function HtmlViewer({
       setIframeUrl(null);
       return;
     }
-    const url = URL.createObjectURL(new Blob([iframeContent], { type: "text/html" }));
+    // Inject the in-frame find script so Cmd+F / the search bar can search the
+    // rendered (sandboxed, cross-origin) document via postMessage.
+    const html = injectFindScript(iframeContent);
+    const url = URL.createObjectURL(new Blob([html], { type: "text/html" }));
     setIframeUrl(url);
     return () => URL.revokeObjectURL(url);
   }, [iframeContent]);
+
+  // Receive match count / current index from the in-frame search script.
+  useEffect(() => {
+    const onMessage = (e: MessageEvent) => {
+      if (e.source !== iframeRef.current?.contentWindow) return;
+      const d = e.data as HtmlFindResult | undefined;
+      if (!d || d.ns !== HTML_FIND_NS) return;
+      setFrameMatchCount(d.count);
+      setSearchCurrentIndex(d.current);
+    };
+    window.addEventListener("message", onMessage);
+    return () => window.removeEventListener("message", onMessage);
+  }, []);
+
+  /** Send a command to the in-frame find script. */
+  const postFind = useCallback((action: "search" | "next" | "prev" | "clear", query?: string) => {
+    iframeRef.current?.contentWindow?.postMessage({ ns: HTML_FIND_NS, action, query }, "*");
+  }, []);
 
   // Reset search state when switching modes, content changes, or iframe mode toggles.
   useEffect(() => {
@@ -262,7 +292,8 @@ export function HtmlViewer({
     setSearchMatches([]);
     searchMatchesRef.current = [];
     setSearchCurrentIndex(-1);
-  }, [sourceMode, content, unsafeMode]);
+    setFrameMatchCount(0);
+  }, [sourceMode, content, unsafeMode, allowScripts]);
 
   // Unsafe mode is session-only — reset when the user switches to a different tab
   useEffect(() => {
@@ -275,18 +306,18 @@ export function HtmlViewer({
     setZoom(1.0);
   }, [tabId]);
 
-  // Listen for Cmd+F / notesage:find-open — only active in sanitised-div mode;
-  // disabled in iframe modes (allowScripts or unsafeMode) where find operates
-  // inside the sandboxed frame, not the host DOM.
+  // Listen for Cmd+F / notesage:find-open. Active in the rendered view (both the
+  // sanitised-div path and the sandboxed-iframe paths, which search in-frame via
+  // postMessage). Disabled only in source mode (CodeMirror owns find there).
   useEffect(() => {
-    if (sourceMode || allowScripts || unsafeMode) return;
+    if (sourceMode) return;
     const handleFindOpen = () => {
       setFindBarOpen(true);
       requestAnimationFrame(() => searchInputRef.current?.focus());
     };
     window.addEventListener("notesage:find-open", handleFindOpen);
     return () => window.removeEventListener("notesage:find-open", handleFindOpen);
-  }, [sourceMode, allowScripts, unsafeMode]);
+  }, [sourceMode]);
 
   // Register as the active zoom controller while rendered. ⌘+ / ⌘- / ⌘0
   // scale the rendered tree via CSS `zoom` (#188).
@@ -307,6 +338,13 @@ export function HtmlViewer({
 
   const handleSearch = useCallback(
     (query: string) => {
+      // Iframe paths: search runs inside the sandboxed frame via postMessage.
+      if (isIframeMode) {
+        postFind("search", query);
+        if (!query) setSearchCurrentIndex(-1);
+        return;
+      }
+      // Default sanitised-div path: search the host DOM.
       const container = getSearchContainer();
       if (!container) return;
       clearDomHighlights(container);
@@ -329,7 +367,7 @@ export function HtmlViewer({
         setSearchCurrentIndex(-1);
       }
     },
-    [getSearchContainer],
+    [isIframeMode, postFind, getSearchContainer],
   );
 
   const scrollToMatch = useCallback((index: number, marks: HTMLElement[]) => {
@@ -339,6 +377,10 @@ export function HtmlViewer({
   }, []);
 
   const handleNext = useCallback(() => {
+    if (isIframeMode) {
+      postFind("next");
+      return;
+    }
     const marks = searchMatchesRef.current;
     if (marks.length === 0) return;
     setSearchCurrentIndex((prev) => {
@@ -346,9 +388,13 @@ export function HtmlViewer({
       scrollToMatch(next, marks);
       return next;
     });
-  }, [scrollToMatch]);
+  }, [isIframeMode, postFind, scrollToMatch]);
 
   const handlePrevious = useCallback(() => {
+    if (isIframeMode) {
+      postFind("prev");
+      return;
+    }
     const marks = searchMatchesRef.current;
     if (marks.length === 0) return;
     setSearchCurrentIndex((prev) => {
@@ -356,17 +402,22 @@ export function HtmlViewer({
       scrollToMatch(prevIdx, marks);
       return prevIdx;
     });
-  }, [scrollToMatch]);
+  }, [isIframeMode, postFind, scrollToMatch]);
 
   const handleClose = useCallback(() => {
     setFindBarOpen(false);
     setSearchQuery("");
-    const container = getSearchContainer();
-    if (container) clearDomHighlights(container);
+    if (isIframeMode) {
+      postFind("clear");
+    } else {
+      const container = getSearchContainer();
+      if (container) clearDomHighlights(container);
+    }
     setSearchMatches([]);
     searchMatchesRef.current = [];
     setSearchCurrentIndex(-1);
-  }, [getSearchContainer]);
+    setFrameMatchCount(0);
+  }, [isIframeMode, postFind, getSearchContainer]);
 
   if (sourceMode) {
     return (
@@ -452,9 +503,9 @@ export function HtmlViewer({
                 // eslint-disable-next-line jsx-a11y/no-autofocus
                 autoFocus
               />
-              {searchMatches.length > 0 && (
+              {(isIframeMode ? frameMatchCount : searchMatches.length) > 0 && (
                 <span className="text-[10px] text-muted-foreground tabular-nums shrink-0">
-                  {searchCurrentIndex + 1}/{searchMatches.length}
+                  {searchCurrentIndex + 1}/{isIframeMode ? frameMatchCount : searchMatches.length}
                 </span>
               )}
               <button type="button" onClick={handlePrevious} className={cn(PILL_BTN, "text-muted-foreground px-1")} aria-label="Previous match">
@@ -498,7 +549,6 @@ export function HtmlViewer({
               <button
                 type="button"
                 onClick={() => {
-                  if (allowScripts || unsafeMode) return;
                   setFindBarOpen(true);
                   requestAnimationFrame(() => searchInputRef.current?.focus());
                 }}
@@ -535,6 +585,7 @@ export function HtmlViewer({
         >
           {unsafeMode ? (
             <iframe
+              ref={iframeRef}
               src={iframeUrl ?? undefined}
               sandbox="allow-scripts"
               className="w-full h-full border-0"
@@ -550,6 +601,7 @@ export function HtmlViewer({
             </div>
           ) : allowScripts && unsafeHtml !== null ? (
             <iframe
+              ref={iframeRef}
               sandbox="allow-scripts"
               src={iframeUrl ?? undefined}
               title={`Rendered HTML (scripts enabled): ${fileName}`}

--- a/src/components/editor/viewers/__tests__/HtmlViewer.test.tsx
+++ b/src/components/editor/viewers/__tests__/HtmlViewer.test.tsx
@@ -984,8 +984,10 @@ describe("HtmlViewer — Bugs 2 & 3: blockExternal strips poster/formaction/ping
   });
 });
 
-// Bug 4 — Find (Cmd+F) must not open in iframe render modes
-describe("HtmlViewer — Bug 4: Find does not open in iframe render modes", () => {
+// Find (Cmd+F) opens in the iframe render modes and drives in-frame search via
+// postMessage. (Was disabled by #377 when search couldn't reach the sandboxed
+// cross-origin frame; restored once the viewer injects an in-frame find script.)
+describe("HtmlViewer — Find opens in iframe render modes (in-frame search)", () => {
   const filePath = "/path/to/page.html";
   const fileName = "page.html";
 
@@ -996,40 +998,36 @@ describe("HtmlViewer — Bug 4: Find does not open in iframe render modes", () =
     } as Parameters<typeof useSettingsStore.setState>[0]);
   });
 
-  it("notesage:find-open event does NOT open the find bar when allowScripts iframe is active", async () => {
+  it("notesage:find-open opens the find bar when allowScripts iframe is active", async () => {
     useSettingsStore.setState({ htmlViewerAllowScripts: true } as Parameters<typeof useSettingsStore.setState>[0]);
     render(
       <HtmlViewer
         content="<html><body><p>page</p></body></html>"
         fileName={fileName}
         filePath={filePath}
-        tabId="tab-bug4-find-scripts"
+        tabId="tab-find-scripts"
         isDirty={false}
         updateTabContent={vi.fn()}
         saveFileWithContent={vi.fn()}
       />
     );
     await waitFor(() => {
-      // Wait for allowScripts iframe to be rendered
       expect(document.querySelector("iframe")).not.toBeNull();
     });
-    // Dispatch the find-open event (Cmd+F)
     act(() => {
       window.dispatchEvent(new Event("notesage:find-open"));
     });
-    // Find bar must NOT open — no search input should appear
-    expect(screen.queryByRole("textbox", { name: /find in document/i })).toBeNull();
-    expect(screen.queryByPlaceholderText(/find/i)).toBeNull();
+    expect(screen.getByPlaceholderText(/find/i)).toBeTruthy();
   });
 
-  it("Find toolbar button does NOT open the find bar when allowScripts iframe is active", async () => {
+  it("Find toolbar button opens the find bar when allowScripts iframe is active", async () => {
     useSettingsStore.setState({ htmlViewerAllowScripts: true } as Parameters<typeof useSettingsStore.setState>[0]);
     render(
       <HtmlViewer
         content="<html><body><p>page</p></body></html>"
         fileName={fileName}
         filePath={filePath}
-        tabId="tab-bug4-find-btn-scripts"
+        tabId="tab-find-btn-scripts"
         isDirty={false}
         updateTabContent={vi.fn()}
         saveFileWithContent={vi.fn()}
@@ -1038,39 +1036,30 @@ describe("HtmlViewer — Bug 4: Find does not open in iframe render modes", () =
     await waitFor(() => {
       expect(document.querySelector("iframe")).not.toBeNull();
     });
-    // Click the Find button in the toolbar
-    const findBtn = screen.queryByRole("button", { name: /^find$/i });
-    if (findBtn) {
-      fireEvent.click(findBtn);
-      // Find bar must NOT open in iframe mode
-      expect(screen.queryByPlaceholderText(/find/i)).toBeNull();
-    }
-    // If the button is not rendered in iframe mode, that's also acceptable (guard moved the button)
+    fireEvent.click(screen.getByRole("button", { name: /^find$/i }));
+    expect(screen.getByPlaceholderText(/find/i)).toBeTruthy();
   });
 
-  it("notesage:find-open event does NOT open the find bar when unsafe-preview iframe is active", () => {
+  it("notesage:find-open opens the find bar when unsafe-preview iframe is active", () => {
     render(
       <HtmlViewer
         content="<html><body><p>page</p></body></html>"
         fileName={fileName}
         filePath={filePath}
-        tabId="tab-bug4-find-unsafe"
+        tabId="tab-find-unsafe"
         isDirty={false}
         updateTabContent={vi.fn()}
         saveFileWithContent={vi.fn()}
       />
     );
-    // Activate unsafe mode
     fireEvent.click(screen.getByRole("button", { name: /unsafe preview/i }));
     fireEvent.click(screen.getByRole("button", { name: /accept|enable|confirm/i }));
     expect(document.querySelector("iframe")).not.toBeNull();
 
-    // Dispatch the find-open event
     act(() => {
       window.dispatchEvent(new Event("notesage:find-open"));
     });
-    // Find bar must NOT open
-    expect(screen.queryByPlaceholderText(/find/i)).toBeNull();
+    expect(screen.getByPlaceholderText(/find/i)).toBeTruthy();
   });
 });
 
@@ -1142,11 +1131,11 @@ describe("EditorViewerContainer — Bug 5: htmlSourceMode resets to false on tab
 
 // Bug 6 — Search state (counter, DOM nodes) must reset on unsafeMode toggle.
 // The find bar UI and the unsafe-preview toggle are mutually exclusive in the
-// toolbar: find bar replaces the normal toolbar buttons. To verify the reset-on-
-// unsafeMode dep, we close the find bar first, activate unsafe mode, then confirm
-// that the find-open event is blocked (Bug 4 guard) and no stale input appears.
+// toolbar: find bar replaces the normal toolbar buttons. We close the find bar
+// first, activate unsafe mode, then confirm find re-opens (now works in-frame)
+// with fresh state (no stale match counter).
 describe("HtmlViewer — Bug 6: search state resets on unsafeMode toggle", () => {
-  it("find bar stays closed and find-open event blocked after unsafeMode activates", () => {
+  it("find resets on unsafeMode toggle and re-opens (in-frame) afterwards", () => {
     const filePath = "/path/to/page.html";
     const fileName = "page.html";
     render(
@@ -1176,12 +1165,13 @@ describe("HtmlViewer — Bug 6: search state resets on unsafeMode toggle", () =>
     fireEvent.click(screen.getByRole("button", { name: /accept|enable|confirm/i }));
     expect(document.querySelector("iframe")).not.toBeNull();
 
-    // In unsafe mode, find-open event must not reopen the find bar
-    // (Bug 4 guard + Bug 6 reset effect both apply)
+    // In unsafe (iframe) mode, find-open now re-opens the bar — search runs
+    // in-frame via postMessage — with fresh state (no stale match counter).
     act(() => {
       window.dispatchEvent(new Event("notesage:find-open"));
     });
-    expect(screen.queryByPlaceholderText(/find/i)).toBeNull();
+    expect(screen.getByPlaceholderText(/find/i)).toBeTruthy();
+    expect(screen.queryByText(/\d+\/\d+/)).toBeNull();
   });
 });
 

--- a/src/components/editor/viewers/__tests__/html-find-frame.test.ts
+++ b/src/components/editor/viewers/__tests__/html-find-frame.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { injectFindScript, HTML_FIND_NS } from "../html-find-frame";
+
+describe("injectFindScript", () => {
+  it("injects the find script just before </body>", () => {
+    const html = "<!DOCTYPE html><html><head></head><body><p>hi</p></body></html>";
+    const out = injectFindScript(html);
+    expect(out).toContain("<script>");
+    // Script must land inside the body, before the closing tag.
+    const scriptIdx = out.indexOf("<script>");
+    const bodyCloseIdx = out.toLowerCase().lastIndexOf("</body>");
+    expect(scriptIdx).toBeGreaterThan(-1);
+    expect(scriptIdx).toBeLessThan(bodyCloseIdx);
+    // The script references the shared message namespace.
+    expect(out).toContain(HTML_FIND_NS);
+    // Original content is preserved.
+    expect(out).toContain("<p>hi</p>");
+  });
+
+  it("appends the script when there is no </body>", () => {
+    const html = "<div>fragment</div>";
+    const out = injectFindScript(html);
+    expect(out.startsWith("<div>fragment</div>")).toBe(true);
+    expect(out).toContain("<script>");
+    expect(out).toContain(HTML_FIND_NS);
+  });
+
+  it("is case-insensitive about the closing body tag", () => {
+    const html = "<body><p>x</p></BODY>";
+    const out = injectFindScript(html);
+    const scriptIdx = out.indexOf("<script>");
+    const bodyCloseIdx = out.toLowerCase().lastIndexOf("</body>");
+    expect(scriptIdx).toBeLessThan(bodyCloseIdx);
+  });
+});

--- a/src/components/editor/viewers/html-find-frame.ts
+++ b/src/components/editor/viewers/html-find-frame.ts
@@ -1,0 +1,145 @@
+/**
+ * In-frame find-in-document for the HtmlViewer's sandboxed iframe paths.
+ *
+ * The viewer renders document HTML in a `sandbox="allow-scripts"` iframe with
+ * NO `allow-same-origin` (opaque origin) — so the host cannot reach into
+ * `iframe.contentDocument` to search/highlight (this is what broke find when the
+ * viewer was hardened from a same-origin iframe). Instead we inject a small,
+ * self-contained search script into the document and drive it over `postMessage`.
+ * The frame highlights matches and reports the count + current index back.
+ *
+ * Security: the injected script only walks the document's own text nodes and
+ * wraps matches in <mark>; it accepts a fixed, tiny command vocabulary and never
+ * evals. It runs inside the existing sandbox, so it gains no new privileges.
+ */
+
+/** Namespace tag on every host↔frame message so unrelated messages are ignored. */
+export const HTML_FIND_NS = 'ns-html-find';
+
+/** Host → frame command. */
+export interface HtmlFindCommand {
+    ns: typeof HTML_FIND_NS;
+    action: 'search' | 'next' | 'prev' | 'clear';
+    query?: string;
+}
+
+/** Frame → host result. */
+export interface HtmlFindResult {
+    ns: typeof HTML_FIND_NS;
+    /** Total match count. */
+    count: number;
+    /** Active match index (0-based), or -1 when there are no matches. */
+    current: number;
+}
+
+// The frame-side script, as a string injected into the document. Plain JS (runs
+// in the iframe, not through the app's TS build). Kept dependency-free and small.
+const FRAME_SCRIPT = `(function () {
+  var NS = ${JSON.stringify(HTML_FIND_NS)};
+  var MARK = 'nshl-find';
+  var ACTIVE = 'nshl-find-active';
+  var marks = [];
+  var current = -1;
+
+  var style = document.createElement('style');
+  style.textContent =
+    'mark.' + MARK + '{background:#fde68a;color:inherit;border-radius:2px;}' +
+    'mark.' + ACTIVE + '{background:#f59e0b;color:#000;}';
+  (document.head || document.documentElement).appendChild(style);
+
+  function post() {
+    parent.postMessage({ ns: NS, count: marks.length, current: current }, '*');
+  }
+
+  function clear() {
+    var existing = document.querySelectorAll('mark.' + MARK);
+    for (var i = 0; i < existing.length; i++) {
+      var m = existing[i];
+      if (m.parentNode) m.parentNode.replaceChild(document.createTextNode(m.textContent || ''), m);
+    }
+    if (document.body) document.body.normalize();
+    marks = [];
+    current = -1;
+  }
+
+  function paint() {
+    for (var i = 0; i < marks.length; i++) marks[i].classList.remove(ACTIVE);
+    if (current >= 0 && marks[current]) {
+      marks[current].classList.add(ACTIVE);
+      if (marks[current].scrollIntoView) {
+        marks[current].scrollIntoView({ block: 'center', inline: 'nearest' });
+      }
+    }
+  }
+
+  function search(query) {
+    clear();
+    if (!query || !document.body) { post(); return; }
+    var q = String(query).toLowerCase();
+    var walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, {
+      acceptNode: function (node) {
+        if (!node.nodeValue || node.nodeValue.toLowerCase().indexOf(q) === -1) return NodeFilter.FILTER_REJECT;
+        var p = node.parentElement;
+        if (!p) return NodeFilter.FILTER_REJECT;
+        var tag = p.tagName;
+        if (tag === 'SCRIPT' || tag === 'STYLE' || tag === 'NOSCRIPT') return NodeFilter.FILTER_REJECT;
+        return NodeFilter.FILTER_ACCEPT;
+      }
+    });
+    var targets = [];
+    var n;
+    while ((n = walker.nextNode())) targets.push(n);
+    for (var t = 0; t < targets.length; t++) {
+      var node = targets[t];
+      var text = node.nodeValue;
+      var lower = text.toLowerCase();
+      var frag = document.createDocumentFragment();
+      var pos = 0;
+      var idx;
+      while ((idx = lower.indexOf(q, pos)) !== -1) {
+        if (idx > pos) frag.appendChild(document.createTextNode(text.slice(pos, idx)));
+        var mk = document.createElement('mark');
+        mk.className = MARK;
+        mk.textContent = text.slice(idx, idx + q.length);
+        frag.appendChild(mk);
+        pos = idx + q.length;
+      }
+      if (pos < text.length) frag.appendChild(document.createTextNode(text.slice(pos)));
+      if (node.parentNode) node.parentNode.replaceChild(frag, node);
+    }
+    marks = Array.prototype.slice.call(document.querySelectorAll('mark.' + MARK));
+    current = marks.length ? 0 : -1;
+    paint();
+    post();
+  }
+
+  function step(delta) {
+    if (!marks.length) { post(); return; }
+    current = (current + delta + marks.length) % marks.length;
+    paint();
+    post();
+  }
+
+  window.addEventListener('message', function (e) {
+    var d = e.data;
+    if (!d || d.ns !== NS) return;
+    if (d.action === 'search') search(d.query);
+    else if (d.action === 'next') step(1);
+    else if (d.action === 'prev') step(-1);
+    else if (d.action === 'clear') clear();
+  });
+})();`;
+
+/**
+ * Inject the find script just before `</body>` (or append it) so it runs inside
+ * the rendered document. Idempotent-safe: a fresh blob is built per render, so
+ * the script is only ever present once.
+ */
+export function injectFindScript(html: string): string {
+    const tag = `<script>${FRAME_SCRIPT}</script>`;
+    const idx = html.toLowerCase().lastIndexOf('</body>');
+    if (idx !== -1) {
+        return html.slice(0, idx) + tag + html.slice(idx);
+    }
+    return html + tag;
+}


### PR DESCRIPTION
## Problem (a real regression)
Search stopped working in the HTML viewer's styled view. Root cause traced through git history:
- The viewer was originally a **same-origin iframe**; find read into `iframe.contentDocument.body` — so search worked in the rendered view.
- The rendered view was later hardened to a `sandbox="allow-scripts"` iframe with **no `allow-same-origin`** (opaque origin). The host lost `contentDocument` access; the search target was repointed to the sanitised `<div>` (default mode only), and **#377** then disabled Cmd+F + the find button in the allow-scripts / unsafe-preview modes.
- Net: find silently did nothing in the styled view — the mode you need for any document with `<head>` styles (and the one the recent blob/CSP fix made usable).

## Fix
Re-establish search **inside** the now-isolated frame without re-weakening the sandbox:
- A small, dependency-free **find script is injected into the rendered document** (`html-find-frame.ts`).
- The host drives it over **`postMessage`** (`search` / `next` / `prev` / `clear`) and receives `{ count, current }` back to update the existing find bar.
- Default sanitised-div mode keeps its host-DOM search. Cmd+F and the find button are re-enabled in the iframe modes.

The injected script only walks the document's own text nodes and wraps matches in `<mark>` — no new privileges, runs within the existing sandbox.

## Verification — real E2E (WKWebView)
Extends `e2e-real/tests/html-viewer-csp.test.ts`: opens the styled fixture with `htmlViewerAllowScripts` on, opens find, types **"navy"**, and asserts the host find bar shows **`1/1`** — only possible if the frame received the query across the sandbox, searched, and posted the count back. Verified locally against the real Tauri WKWebView; CI's Real-E2E job is the gate.

## Tests
- New `html-find-frame.test.ts` (injector). The old #377 tests that asserted find *stays disabled* in iframe modes are flipped to assert it now opens + searches. Full unit suite green (5423).

🤖 Generated with [Claude Code](https://claude.com/claude-code)