### PR TITLE
chore: release v0.46.0-alpha.25

### DIFF
--- a/docs/history/150-release-v0.46.0-alpha.25.md
+++ b/docs/history/150-release-v0.46.0-alpha.25.md
@@ -1,0 +1,20 @@
+# Release v0.46.0-alpha.25
+
+**Date:** 2026-06-11
+**Previous version:** 0.46.0-alpha.24
+**Channel:** Alpha
+
+Auto-cut by `aw-alpha-cut`. Sections below are auto-classified from merged PRs; refine the prose before promoting to stable.
+
+## Changes
+
+### Features
+- feat(quiet): optional title bar, resizable sidebar, and sidebar polish (#452)
+
+## Under the hood
+
+Auto-generated from merged PRs + commits since `v0.46.0-alpha.24`. Alpha builds list commit-level detail for technical users.
+
+- test(e2e-real): enable the title bar for the dirty-dot spec + update docs
+- feat(quiet-sidebar): empty-Pinned hide, sticky header, list-all children, nested indent guides, active-doc highlight, resize handle
+- feat(quiet-layout): hide-able title bar + flush/transparent top, resizable sidebar width

--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -153,3 +153,4 @@ Chronological log of major implementation milestones and changes.
 | 147 | [Release v0.46.0-alpha.22](147-release-v0.46.0-alpha.22.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
 | 148 | [Release v0.46.0-alpha.23](148-release-v0.46.0-alpha.23.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
 | 149 | [Release v0.46.0-alpha.24](149-release-v0.46.0-alpha.24.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
+| 150 | [Release v0.46.0-alpha.25](150-release-v0.46.0-alpha.25.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "notesage",
   "private": true,
-  "version": "0.46.0-alpha.24",
+  "version": "0.46.0-alpha.25",
   "license": "MIT",
   "author": "Peter Blenessy",
   "type": "module",

--- a/public/changelog-alpha.json
+++ b/public/changelog-alpha.json
@@ -1,6 +1,21 @@
 {
   "releases": [
     {
+      "version": "0.46.0-alpha.25",
+      "date": "2026-06-11",
+      "previousVersion": "0.46.0-alpha.24",
+      "sections": {
+        "features": [
+          "feat(quiet): optional title bar, resizable sidebar, and sidebar polish (#452)"
+        ]
+      },
+      "underTheHood": [
+        "test(e2e-real): enable the title bar for the dirty-dot spec + update docs",
+        "feat(quiet-sidebar): empty-Pinned hide, sticky header, list-all children, nested indent guides, active-doc highlight, resize handle",
+        "feat(quiet-layout): hide-able title bar + flush/transparent top, resizable sidebar width"
+      ]
+    },
+    {
       "version": "0.46.0-alpha.24",
       "date": "2026-06-10",
       "previousVersion": "0.46.0-alpha.23",


### PR DESCRIPTION
Auto-cut by `aw-alpha-cut`. The history file at `docs/history/150-release-v0.46.0-alpha.25.md` lists the merged PRs.

## PRs included

- #452

Auto-merge enabled. Once the 4 required status checks pass, this merges to main, and the `tag-after-merge` job in `aw-alpha-cut.yml` tags + pushes `v0.46.0-alpha.25`. `release.yml` then builds and publishes.
