### PR TITLE
fix(html-viewer): re-apply find query on iframe load (fixes find-in-frame flake)

### DIFF
--- a/e2e-real/tests/html-viewer-csp.test.ts
+++ b/e2e-real/tests/html-viewer-csp.test.ts
@@ -198,6 +198,12 @@ describe('HTML viewer renders document styles under the app CSP', () => {
         // in the fixture body ("navy"). The host can't reach into the sandboxed
         // frame — the match count below only updates if the injected in-frame
         // script received the query over postMessage, searched, and posted back.
+        //
+        // Robustness: the query may be typed before the sandboxed document has
+        // finished loading its injected find script, in which case the first
+        // `search` postMessage is dropped. HtmlViewer re-sends the active query on
+        // the iframe `load` event (handleIframeLoad), so the count is guaranteed
+        // to arrive once the document is ready — no race, no flake.
         await browser.execute(() => window.dispatchEvent(new Event('notesage:find-open')));
         const input = await browser.$('input[aria-label="Find in document"]');
         await input.waitForExist({ timeout: 10000 });
@@ -212,7 +218,7 @@ describe('HTML viewer renders document styles under the app CSP', () => {
                 });
                 return count === '1/1';
             },
-            { timeout: 10000, timeoutMsg: 'find bar never showed the in-frame match count (1/1)' },
+            { timeout: 15000, timeoutMsg: 'find bar never showed the in-frame match count (1/1)' },
         );
         console.log('[csp-test] in-frame search reported 1/1 for "navy"');
     });

--- a/src/components/editor/viewers/HtmlViewer.tsx
+++ b/src/components/editor/viewers/HtmlViewer.tsx
@@ -175,6 +175,13 @@ export function HtmlViewer({
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const searchMatchesRef = useRef<HTMLElement[]>([]);
+  // Latest find state, mirrored to refs so the iframe `onLoad` handler (a stable
+  // callback) can read them without re-subscribing — used to re-apply the active
+  // search once the sandboxed document is ready (see handleIframeLoad).
+  const searchQueryRef = useRef(searchQuery);
+  searchQueryRef.current = searchQuery;
+  const findBarOpenRef = useRef(findBarOpen);
+  findBarOpenRef.current = findBarOpen;
 
   // Search runs inside the sandboxed iframe (via postMessage) in the
   // allow-scripts / unsafe-preview paths; in the default sanitised-div path it
@@ -355,6 +362,19 @@ export function HtmlViewer({
   const postFind = useCallback((action: "search" | "next" | "prev" | "clear", query?: string) => {
     iframeRef.current?.contentWindow?.postMessage({ ns: HTML_FIND_NS, action, query }, "*");
   }, []);
+
+  // Re-apply the active find query once the sandboxed iframe document (and its
+  // injected find script) has finished loading. This closes a race: a `search`
+  // postMessage sent while the document was still loading is dropped silently
+  // (the script's message listener isn't registered yet), so the match count
+  // never appears and find looks broken. The `load` event fires only after the
+  // in-body `<script>` has executed and registered its listener, so re-sending
+  // here is guaranteed to land. No-op when find isn't open.
+  const handleIframeLoad = useCallback(() => {
+    if (findBarOpenRef.current && searchQueryRef.current) {
+      postFind("search", searchQueryRef.current);
+    }
+  }, [postFind]);
 
   // Reset search state when switching modes, content changes, or iframe mode
   // toggles. This is an instant teardown (no exit animation) — the surface the
@@ -686,6 +706,7 @@ export function HtmlViewer({
               ref={iframeRef}
               src={iframeUrl ?? undefined}
               sandbox="allow-scripts"
+              onLoad={handleIframeLoad}
               className="w-full h-full border-0"
               title={`Unsafe preview: ${fileName}`}
             />
@@ -702,6 +723,7 @@ export function HtmlViewer({
               ref={iframeRef}
               sandbox="allow-scripts"
               src={iframeUrl ?? undefined}
+              onLoad={handleIframeLoad}
               title={`Rendered HTML (scripts enabled): ${fileName}`}
               aria-label={`Rendered HTML: ${fileName}`}
               className="w-full h-full border-0"

--- a/src/components/editor/viewers/__tests__/HtmlViewer.test.tsx
+++ b/src/components/editor/viewers/__tests__/HtmlViewer.test.tsx
@@ -18,7 +18,7 @@ import { PlainTextViewer } from "../PlainTextViewer";
 import { EditorViewerContainer } from "../../EditorViewerContainer";
 import { useSettingsStore } from "@/stores/settings-store";
 import { setMockInvokeHandler } from "@/test/tauri-mock";
-import { HTML_KEY_NS } from "../html-find-frame";
+import { HTML_KEY_NS, HTML_FIND_NS } from "../html-find-frame";
 
 // Mock CodeEditor to avoid full CodeMirror setup in jsdom
 vi.mock("../CodeEditor", () => ({
@@ -1484,5 +1484,89 @@ describe("HtmlViewer — find bar open/close morph animation", () => {
     await waitFor(() =>
       expect(screen.queryByPlaceholderText(/find/i)).toBeNull()
     );
+  });
+});
+
+describe("HtmlViewer — re-applies the find query on iframe load (flake fix)", () => {
+  const filePath = "/path/to/page.html";
+  const fileName = "page.html";
+
+  afterEach(() => {
+    useSettingsStore.setState({
+      htmlViewerAllowScripts: false,
+    } as Parameters<typeof useSettingsStore.setState>[0]);
+  });
+
+  it("re-posts the active search to the frame when the iframe fires load", async () => {
+    useSettingsStore.setState({
+      htmlViewerAllowScripts: true,
+    } as Parameters<typeof useSettingsStore.setState>[0]);
+    render(
+      <HtmlViewer
+        content="<html><body><p>find the navy word</p></body></html>"
+        fileName={fileName}
+        filePath={filePath}
+        tabId="tab-find-reload"
+        isDirty={false}
+        updateTabContent={vi.fn()}
+        saveFileWithContent={vi.fn()}
+      />
+    );
+    let iframe: HTMLIFrameElement | null = null;
+    await waitFor(() => {
+      iframe = document.querySelector("iframe");
+      expect(iframe).not.toBeNull();
+      expect(iframe!.getAttribute("src")).toMatch(/^htmlpreview:\/\//);
+    });
+
+    // Open find + type a query (an active search now exists).
+    act(() => {
+      window.dispatchEvent(new Event("notesage:find-open"));
+    });
+    const input = screen.getByPlaceholderText(/find/i);
+    fireEvent.change(input, { target: { value: "navy" } });
+
+    // Spy on the frame's postMessage and clear any sends from typing, then fire
+    // the iframe load event — the active query must be re-sent so a search that
+    // raced the document load isn't lost.
+    const post = vi.spyOn(iframe!.contentWindow!, "postMessage");
+    fireEvent.load(iframe!);
+
+    expect(post).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ns: HTML_FIND_NS,
+        action: "search",
+        query: "navy",
+      }),
+      "*"
+    );
+    post.mockRestore();
+  });
+
+  it("does NOT post a search on iframe load when find is closed", async () => {
+    useSettingsStore.setState({
+      htmlViewerAllowScripts: true,
+    } as Parameters<typeof useSettingsStore.setState>[0]);
+    render(
+      <HtmlViewer
+        content="<html><body><p>page</p></body></html>"
+        fileName={fileName}
+        filePath={filePath}
+        tabId="tab-find-reload-closed"
+        isDirty={false}
+        updateTabContent={vi.fn()}
+        saveFileWithContent={vi.fn()}
+      />
+    );
+    let iframe: HTMLIFrameElement | null = null;
+    await waitFor(() => {
+      iframe = document.querySelector("iframe");
+      expect(iframe).not.toBeNull();
+      expect(iframe!.getAttribute("src")).toMatch(/^htmlpreview:\/\//);
+    });
+    const post = vi.spyOn(iframe!.contentWindow!, "postMessage");
+    fireEvent.load(iframe!);
+    expect(post).not.toHaveBeenCalled();
+    post.mockRestore();
   });
 });


### PR DESCRIPTION
## The flake (and why it blocked the alpha)
The sandboxed HTML-viewer iframe runs find-in-document over `postMessage`: the host posts a `search` command, the injected in-frame script searches and posts the match count back. **If the user typed a query before the sandboxed document finished loading its injected script, the `search` message was sent to a document whose listener wasn't registered yet — silently dropped.** The match count never appeared.

In the real WKWebView this surfaced as an intermittent E2E failure (`find bar never showed the in-frame match count (1/1)`). It passed on every PR run but occasionally went red on the post-merge `main` run, which tripped `aw-alpha-cut`'s "don't ship an alpha off a red `main`" safety gate — blocking the alpha cut.

## The fix (root cause, not a retry)
Re-send the active find query on the iframe **`load`** event. `load` fires only after the in-body `<script>` has executed and registered its message listener, so the re-sent search is guaranteed to land. No-op when find is closed.

- `HtmlViewer`: `handleIframeLoad` + `onLoad` on both sandboxed iframes; `searchQuery` / `findBarOpen` mirrored to refs so the stable callback reads current state.
- This also fixes a real UX bug: typing in find before the page rendered used to silently do nothing.

## Tests
- **Unit:** iframe `load` re-posts the active search; no post when find is closed.
- **Real-E2E:** documented the guarantee + bumped the count-wait to 15 s for CI-load headroom.
- `pnpm test` (5439) ✓, `pnpm typecheck` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)