### PR TITLE
chore: release v0.46.0-alpha.26

### DIFF
--- a/docs/history/151-release-v0.46.0-alpha.26.md
+++ b/docs/history/151-release-v0.46.0-alpha.26.md
@@ -1,0 +1,23 @@
+# Release v0.46.0-alpha.26
+
+**Date:** 2026-06-11
+**Previous version:** 0.46.0-alpha.25
+**Channel:** Alpha
+
+Auto-cut by `aw-alpha-cut`. Sections below are auto-classified from merged PRs; refine the prose before promoting to stable.
+
+## Changes
+
+### Fixes
+- fix(html-viewer): render under production CSP, keep shortcuts in the sandboxed iframe, animate find bar (#451)
+- fix(html-viewer): re-apply find query on iframe load (fixes find-in-frame flake) (#454)
+
+## Under the hood
+
+Auto-generated from merged PRs + commits since `v0.46.0-alpha.25`. Alpha builds list commit-level detail for technical users.
+
+- security: harden skill/MCP execution, link-preview beacons, CSP, asset scope (#444)
+- fix(html-viewer): re-apply the find query on iframe load (fixes find-in-frame flake)
+- feat(html-viewer): animate the find-bar morph open and closed
+- fix(html-viewer): keep app keyboard shortcuts working when the sandboxed iframe has focus
+- fix(html-viewer): serve sandboxed iframe from htmlpreview:// so it renders under the production CSP

--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -154,3 +154,4 @@ Chronological log of major implementation milestones and changes.
 | 148 | [Release v0.46.0-alpha.23](148-release-v0.46.0-alpha.23.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
 | 149 | [Release v0.46.0-alpha.24](149-release-v0.46.0-alpha.24.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
 | 150 | [Release v0.46.0-alpha.25](150-release-v0.46.0-alpha.25.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
+| 151 | [Release v0.46.0-alpha.26](151-release-v0.46.0-alpha.26.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "notesage",
   "private": true,
-  "version": "0.46.0-alpha.25",
+  "version": "0.46.0-alpha.26",
   "license": "MIT",
   "author": "Peter Blenessy",
   "type": "module",

--- a/public/changelog-alpha.json
+++ b/public/changelog-alpha.json
@@ -1,6 +1,24 @@
 {
   "releases": [
     {
+      "version": "0.46.0-alpha.26",
+      "date": "2026-06-11",
+      "previousVersion": "0.46.0-alpha.25",
+      "sections": {
+        "fixes": [
+          "fix(html-viewer): render under production CSP, keep shortcuts in the sandboxed iframe, animate find bar (#451)",
+          "fix(html-viewer): re-apply find query on iframe load (fixes find-in-frame flake) (#454)"
+        ]
+      },
+      "underTheHood": [
+        "security: harden skill/MCP execution, link-preview beacons, CSP, asset scope (#444)",
+        "fix(html-viewer): re-apply the find query on iframe load (fixes find-in-frame flake)",
+        "feat(html-viewer): animate the find-bar morph open and closed",
+        "fix(html-viewer): keep app keyboard shortcuts working when the sandboxed iframe has focus",
+        "fix(html-viewer): serve sandboxed iframe from htmlpreview:// so it renders under the production CSP"
+      ]
+    },
+    {
       "version": "0.46.0-alpha.25",
       "date": "2026-06-11",
       "previousVersion": "0.46.0-alpha.24",


### PR DESCRIPTION
Auto-cut by `aw-alpha-cut`. The history file at `docs/history/151-release-v0.46.0-alpha.26.md` lists the merged PRs.

## PRs included

- #444
- #451
- #454

Auto-merge enabled. Once the 4 required status checks pass, this merges to main, and the `tag-after-merge` job in `aw-alpha-cut.yml` tags + pushes `v0.46.0-alpha.26`. `release.yml` then builds and publishes.
