### PR TITLE
test: deflake the test suite — remove wall-clock timing asserts, make perf benchmarks advisory

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,19 +78,17 @@ jobs:
         run: pnpm test:coverage
 
       - name: Performance benchmarks
+        # ADVISORY (does not block merge/release). Wall-clock benchmarks on a
+        # shared macos-latest runner have irreducible variance — even after
+        # bumping the budget multiplier 3 → 4 → 5, the markdown-parse 50KB case
+        # still spiked to ~1.5s under contention and blocked a release on a pure
+        # timing flake (with no regression). Gating merges on shared-runner
+        # wall-clock is unreliable, so this step runs + uploads results but
+        # `continue-on-error` keeps a transient spike from failing the build.
+        # Real regression signal: local `pnpm test:perf` (multiplier 1x, strict)
+        # and the separate post-merge "Real-App Performance Tracking" job.
+        continue-on-error: true
         env:
-          # Multiplier scales the per-test base budgets to absorb runner
-          # variance. macos-latest under shared load consistently lands
-          # 3.3-3.5x the local baseline on the markdown-parse 50KB case
-          # (873-903ms observed vs 276ms local baseline = ~3.3x), so 3x
-          # leaves no headroom and tests flake even without regressions.
-          # 4x is the documented CI maximum and absorbs current runner
-          # variance without hiding ≥25% real regressions.
-          # Bumped 4 → 5 after observing repeated near-miss flakes:
-          # 1KB parse at 153.27ms vs 152ms budget (off by 1.27ms) on macOS-latest.
-          # The macos-latest runner pacing is more variable than the original
-          # baseline assumed; 5x absorbs CI noise without masking real >25%
-          # regressions.
           PERF_BUDGET_MULTIPLIER: "5"
         run: pnpm test:perf
 

--- a/src-tauri/src/commands/fonts.rs
+++ b/src-tauri/src/commands/fonts.rs
@@ -220,14 +220,15 @@ mod tests {
     }
 
     #[test]
-    fn second_call_is_cached() {
-        // First call populates the cache
+    fn second_call_returns_fonts() {
+        // First call populates the cache.
         let _ = list_system_fonts().expect("Should enumerate fonts");
-        // Second call should be near-instant (cached)
-        let start = std::time::Instant::now();
+        // Second (cache-backed) call must still return the font set. The previous
+        // wall-clock "<5ms" assertion was removed — a 5ms bound is far too tight
+        // to be reliable on shared CI runners (it flaked). Caching is a perf
+        // optimisation; correctness is what we assert here. Verifying the cache
+        // HIT deterministically would need a cache-hit counter (follow-up).
         let fonts = list_system_fonts().expect("Should enumerate fonts");
-        let elapsed = start.elapsed();
         assert!(fonts.len() > 10, "Should have many fonts");
-        assert!(elapsed.as_millis() < 5, "Cached call took {}ms — should be <5ms", elapsed.as_millis());
     }
 }

--- a/src-tauri/src/export/integration_tests.rs
+++ b/src-tauri/src/export/integration_tests.rs
@@ -2,7 +2,6 @@ use super::markdown_to_pptx::markdown_to_pptx;
 use super::markdown_to_typst::markdown_to_typst;
 use super::templates::{apply_template, PageSize, Template, TemplateOptions};
 use super::typst_world::NotesageWorld;
-use std::time::Instant;
 
 /// Run the full export pipeline: markdown → typst → template → PDF bytes.
 fn export_pipeline(
@@ -443,8 +442,7 @@ fn test_complex_document_all_node_types() {
 }
 
 #[test]
-fn test_long_document_performance() {
-    let start = Instant::now();
+fn test_long_document_export() {
     let result = export_pipeline(
         LONG_DOC,
         "Comprehensive Project Report",
@@ -453,19 +451,16 @@ fn test_long_document_performance() {
         true,
         PageSize::A4,
     );
-    let elapsed = start.elapsed();
 
     assert!(result.is_ok(), "Long doc failed: {:?}", result.err());
     let pdf = result.unwrap();
     assert_eq!(&pdf[..5], b"%PDF-");
     // Long doc should produce a substantial PDF
     assert!(pdf.len() > 10_000, "Long doc PDF too small ({} bytes)", pdf.len());
-    // Performance target: under 5 seconds (generous for CI, expect <2s locally)
-    assert!(
-        elapsed.as_secs() < 5,
-        "Long doc export took too long: {:?}",
-        elapsed
-    );
+    // NOTE: the wall-clock "under 5s" assertion was removed — it flaked on
+    // contended CI runners. This test verifies the long document EXPORTS
+    // CORRECTLY; export speed is tracked by the synthetic perf benchmarks and
+    // the post-merge Real-App Performance Tracking job, not a hard assert here.
 }
 
 #[test]
@@ -852,15 +847,14 @@ fn test_pptx_special_characters_in_title() {
 }
 
 #[test]
-fn test_pptx_performance_long_document() {
-    let start = Instant::now();
-    let _ = pptx_pipeline(LONG_DOC, "Perf Test", "report");
-    let elapsed = start.elapsed();
-    assert!(
-        elapsed.as_secs() < 3,
-        "PPTX export took too long: {:?} (budget: 3s)",
-        elapsed
-    );
+fn test_pptx_long_document_export() {
+    // Was a wall-clock "under 3s" assertion (flaky on contended CI runners).
+    // Now asserts the long document exports CORRECTLY; export speed is tracked
+    // by the perf benchmarks + Real-App Performance Tracking, not a hard assert.
+    // pptx_pipeline() internally asserts is_ok + valid ZIP magic + size, so a
+    // successful return IS the correctness check.
+    let bytes = pptx_pipeline(LONG_DOC, "Perf Test", "report");
+    assert!(bytes.len() > 1_000, "PPTX long-doc too small: {} bytes", bytes.len());
 }
 
 #[test]


### PR DESCRIPTION
## Why

Following up on the alpha-cut flake: a timing-based test spiked under CI contention and blocked a release with **no actual regression**. Rather than re-run-and-hope, this fixes the **entire class** of wall-clock timing flakes in one pass.

## What changed

### Rust — 3 wall-clock `assert!`s removed (correctness asserts kept)

| Test | Removed assert | Still verifies |
| --- | --- | --- |
| `export::integration_tests::test_long_document_performance` → `…_export` | `elapsed.as_secs() < 5` | valid `%PDF-` magic, `pdf.len() > 10_000` |
| `export::integration_tests::test_pptx_performance_long_document` → `…_export` | `elapsed.as_secs() < 3` | `pptx_pipeline` internal `is_ok` + `PK` ZIP magic + size |
| `commands::fonts::tests::second_call_is_cached` → `…returns_fonts` | `elapsed.as_millis() < 5` | `fonts.len() > 10` |

Also dropped the now-unused `use std::time::Instant`. These asserted export/cache **speed** on shared CI runners — irreducibly flaky. Each test still checks the operation produces **correct** output. Deterministically verifying a cache HIT would need a hit counter (noted as a follow-up in the test comment).

### Frontend — perf benchmarks step is now advisory

`.github/workflows/test.yml` "Performance benchmarks" → `continue-on-error: true`. Wall-clock benchmarks on a shared `macos-latest` runner have irreducible variance — even after bumping `PERF_BUDGET_MULTIPLIER` 3 → 4 → 5, the markdown-parse 50KB case still spiked to ~1.5s under contention and blocked a release on a pure timing flake. The step still runs and uploads results; it just no longer fails the build on a transient spike.

**Regression signal preserved:** local `pnpm test:perf` (multiplier 1x, strict) + the separate post-merge "Real-App Performance Tracking" job.

## Sweep — what was checked and left alone

- Remaining `Date.now()` usages in tests are mock timestamps or `vi.useFakeTimers()` (deterministic).
- `src/perf/harness.test.ts` runs in the main suite but its wall-clock asserts have 20×–1000× margins (no-op vs 1000ms budget; 50ms spin vs 1ms floor) — robust by design.
- `useRecording.test.ts` uses fake timers throughout.
- `agent_manager.rs` `elapsed.num_hours() < 1` is production rate-limiting, not a test.

## Flagged tech-debt (NOT fixed here — surfaced, not silently deferred)

- `e2e-real` specs use `browser.pause()` hard-sleeps in places — a different (real-E2E) flake surface.
- `e2e-real/tests/editor.test.ts:211` has an already-`skip`ped flaky FindBar test.

These are separate from the unit/CI timing flakes this PR targets; raising them so they aren't lost.

## Verification

- `cargo check --tests` — clean (no unused-import warning)
- 3 edited Rust tests pass (`cargo test`)
- `pnpm typecheck` — clean
- No frontend source touched (only Rust + CI yaml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)