### PR TITLE
chore: release v0.46.0-alpha.27

### DIFF
--- a/docs/history/152-release-v0.46.0-alpha.27.md
+++ b/docs/history/152-release-v0.46.0-alpha.27.md
@@ -1,0 +1,18 @@
+# Release v0.46.0-alpha.27
+
+**Date:** 2026-06-12
+**Previous version:** 0.46.0-alpha.26
+**Channel:** Alpha
+
+Auto-cut by `aw-alpha-cut`. Sections below are auto-classified from merged PRs; refine the prose before promoting to stable.
+
+## Changes
+
+_No user-visible changes._
+
+## Under the hood
+
+Auto-generated from merged PRs + commits since `v0.46.0-alpha.26`. Alpha builds list commit-level detail for technical users.
+
+- test: deflake the test suite — remove wall-clock timing asserts, make perf benchmarks advisory (#456)
+- test: deflake the test suite — remove wall-clock timing asserts, make perf benchmarks advisory (#456)

--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -155,3 +155,4 @@ Chronological log of major implementation milestones and changes.
 | 149 | [Release v0.46.0-alpha.24](149-release-v0.46.0-alpha.24.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
 | 150 | [Release v0.46.0-alpha.25](150-release-v0.46.0-alpha.25.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
 | 151 | [Release v0.46.0-alpha.26](151-release-v0.46.0-alpha.26.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |
+| 152 | [Release v0.46.0-alpha.27](152-release-v0.46.0-alpha.27.md) | Auto-cut alpha by `aw-alpha-cut`. See merged PRs for details. |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "notesage",
   "private": true,
-  "version": "0.46.0-alpha.26",
+  "version": "0.46.0-alpha.27",
   "license": "MIT",
   "author": "Peter Blenessy",
   "type": "module",

--- a/public/changelog-alpha.json
+++ b/public/changelog-alpha.json
@@ -1,6 +1,16 @@
 {
   "releases": [
     {
+      "version": "0.46.0-alpha.27",
+      "date": "2026-06-12",
+      "previousVersion": "0.46.0-alpha.26",
+      "sections": {},
+      "underTheHood": [
+        "test: deflake the test suite — remove wall-clock timing asserts, make perf benchmarks advisory (#456)",
+        "test: deflake the test suite — remove wall-clock timing asserts, make perf benchmarks advisory (#456)"
+      ]
+    },
+    {
       "version": "0.46.0-alpha.26",
       "date": "2026-06-11",
       "previousVersion": "0.46.0-alpha.25",


### PR DESCRIPTION
Auto-cut by `aw-alpha-cut`. The history file at `docs/history/152-release-v0.46.0-alpha.27.md` lists the merged PRs.

## PRs included

- #456

Auto-merge enabled. Once the 4 required status checks pass, this merges to main, and the `tag-after-merge` job in `aw-alpha-cut.yml` tags + pushes `v0.46.0-alpha.27`. `release.yml` then builds and publishes.
